### PR TITLE
feat: add inbound status for recruiter outreach

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -87,7 +87,8 @@
     "rejected": "Abgelehnt",
     "offer": "Angebot",
     "ghost": "Ghosted",
-    "draft": "Entwurf"
+    "draft": "Entwurf",
+    "inbound": "Eingehend"
   },
   "kanban": {
     "empty": "Keine Einträge"
@@ -133,7 +134,8 @@
       "rejected": "Abgelehnt",
       "offer": "Angebot",
       "ghost": "Ghosted",
-      "draft": "Entwurf"
+      "draft": "Entwurf",
+      "inbound": "Eingehend"
     },
     "footer_note": "Dies ist eine schreibgeschützte Ansicht. Nur Christian kann Änderungen vornehmen."
   }

--- a/messages/en.json
+++ b/messages/en.json
@@ -87,7 +87,8 @@
     "rejected": "Rejected",
     "offer": "Offer",
     "ghost": "Ghosted",
-    "draft": "Draft"
+    "draft": "Draft",
+    "inbound": "Inbound"
   },
   "kanban": {
     "empty": "No entries"
@@ -133,7 +134,8 @@
       "rejected": "Rejected",
       "offer": "Offer",
       "ghost": "Ghosted",
-      "draft": "Draft"
+      "draft": "Draft",
+      "inbound": "Inbound"
     },
     "footer_note": "This is a read-only view. Only Christian can make changes."
   }

--- a/types/index.ts
+++ b/types/index.ts
@@ -5,7 +5,8 @@ export type ApplicationStatus =
   | "rejected"
   | "offer"
   | "ghost"
-  | "draft";
+  | "draft"
+  | "inbound";
 
 export interface Contact {
   id: string;
@@ -43,6 +44,7 @@ export const STATUS_COLORS: Record<ApplicationStatus, string> = {
   offer: "bg-green-100 text-green-800 dark:bg-emerald-500/25 dark:text-emerald-300",
   ghost: "bg-gray-100 text-gray-600 dark:bg-gray-500/25 dark:text-gray-300",
   draft: "bg-slate-100 text-slate-600 dark:bg-slate-500/25 dark:text-slate-300",
+  inbound: "bg-teal-100 text-teal-800 dark:bg-teal-500/25 dark:text-teal-300",
 };
 
 // Row highlight colors for table
@@ -54,10 +56,12 @@ export const STATUS_ROW_COLORS: Record<ApplicationStatus, string> = {
   offer: "bg-green-50/40 dark:bg-green-950/20",
   ghost: "bg-gray-50/50 dark:bg-gray-800/30",
   draft: "",
+  inbound: "",
 };
 
 // Ordered for Kanban display
 export const STATUS_ORDER: ApplicationStatus[] = [
+  "inbound",
   "draft",
   "applied",
   "waiting",
@@ -76,4 +80,5 @@ export const STATUS_OPTIONS: { value: ApplicationStatus; label: string; color: s
   { value: "offer", label: "Angebot", color: STATUS_COLORS.offer },
   { value: "ghost", label: "Ghosted", color: STATUS_COLORS.ghost },
   { value: "draft", label: "Entwurf", color: STATUS_COLORS.draft },
+  { value: "inbound", label: "Eingehend", color: STATUS_COLORS.inbound },
 ];


### PR DESCRIPTION
## Summary
- Adds new `inbound` application status to distinguish recruiter outreach from user-initiated drafts
- `draft` remains for unsent applications; `inbound` is for incoming recruiter messages not yet responded to
- Includes teal color scheme, DE/EN translations, kanban column ordering (inbound appears first)

## Changes
- `types/index.ts`: Added `inbound` to `ApplicationStatus`, `STATUS_COLORS`, `STATUS_ROW_COLORS`, `STATUS_ORDER`, and `STATUS_OPTIONS`
- `messages/en.json`: Added "Inbound" translation
- `messages/de.json`: Added "Eingehend" translation

## Test plan
- [ ] Verify `inbound` appears as a kanban column
- [ ] Verify `inbound` appears in status filter dropdown
- [ ] Verify new applications can be created with `inbound` status
- [ ] Verify status badge renders with teal colors in light and dark mode
- [ ] Verify existing `draft` applications are unaffected

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)