### PR TITLE
feat: add source field to applications

### DIFF
--- a/app/api/applications/[id]/route.ts
+++ b/app/api/applications/[id]/route.ts
@@ -40,7 +40,7 @@ export async function PATCH(
 
   const { id } = await params;
   const body = await request.json();
-  const { company, role, status, appliedAt, lastContact, followUpAt, notes, jobDescription, resumeId } = body;
+  const { company, role, status, appliedAt, lastContact, followUpAt, notes, jobDescription, source, resumeId } = body;
 
   const application = await getDb().updateApplication(id, userId, {
     ...(company !== undefined && { company: String(company).slice(0, 255) }),
@@ -58,6 +58,9 @@ export async function PATCH(
     ...(notes !== undefined && { notes: notes ? String(notes).slice(0, 10000) : null }),
     ...(jobDescription !== undefined && {
       jobDescription: jobDescription ? String(jobDescription).slice(0, 50000) : null,
+    }),
+    ...(source !== undefined && {
+      source: source ? String(source).slice(0, 100) : null,
     }),
     ...(resumeId !== undefined && {
       resumeId: resumeId ? String(resumeId).slice(0, 255) : null,

--- a/app/api/applications/route.ts
+++ b/app/api/applications/route.ts
@@ -27,7 +27,7 @@ export async function POST(request: NextRequest) {
   }
 
   const body = await request.json();
-  const { company, role, status, appliedAt, lastContact, followUpAt, notes, jobDescription } = body;
+  const { company, role, status, appliedAt, lastContact, followUpAt, notes, jobDescription, source } = body;
 
   if (!company || !role) {
     return NextResponse.json(
@@ -45,6 +45,7 @@ export async function POST(request: NextRequest) {
     followUpAt: followUpAt ? new Date(followUpAt) : null,
     notes: notes ? String(notes).slice(0, 10000) : null,
     jobDescription: jobDescription ? String(jobDescription).slice(0, 50000) : null,
+    source: source ? String(source).slice(0, 100) : null,
   });
 
   return NextResponse.json(application, { status: 201 });

--- a/components/application-modal.tsx
+++ b/components/application-modal.tsx
@@ -3,7 +3,7 @@
 import { useQueryClient, useMutation } from "@tanstack/react-query";
 import { useState, useEffect } from "react";
 import { useTranslations } from "next-intl";
-import { Application, ApplicationStatus, Contact, STATUS_COLORS, STATUS_ORDER } from "@/types";
+import { Application, ApplicationStatus, Contact, STATUS_COLORS, STATUS_ORDER, SOURCE_PRESETS } from "@/types";
 
 interface ApplicationModalProps {
   application: Application | null;
@@ -19,6 +19,7 @@ interface FormData {
   followUpAt: string;
   notes: string;
   jobDescription: string;
+  source: string;
 }
 
 interface ContactFormRow {
@@ -42,6 +43,7 @@ async function createApplication(data: FormData): Promise<Application> {
       followUpAt: data.followUpAt || null,
       notes: data.notes || null,
       jobDescription: data.jobDescription || null,
+      source: data.source || null,
     }),
   });
   if (!res.ok) throw new Error("Failed to create application");
@@ -59,6 +61,7 @@ async function updateApplication(id: string, data: FormData): Promise<Applicatio
       followUpAt: data.followUpAt || null,
       notes: data.notes || null,
       jobDescription: data.jobDescription || null,
+      source: data.source || null,
     }),
   });
   if (!res.ok) throw new Error("Failed to update application");
@@ -129,6 +132,7 @@ export function ApplicationModal({ application, onClose }: ApplicationModalProps
     followUpAt: toDateInput(application?.followUpAt),
     notes: application?.notes || "",
     jobDescription: application?.jobDescription || "",
+    source: application?.source || "",
   });
 
   const [jdOpen, setJdOpen] = useState(false);
@@ -346,6 +350,28 @@ export function ApplicationModal({ application, onClose }: ApplicationModalProps
               <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_COLORS[form.status]}`}>
                 {ts(form.status)}
               </span>
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              {t("source")}
+            </label>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                name="source"
+                value={form.source}
+                onChange={handleChange}
+                list="source-presets"
+                className="w-full border border-gray-200 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                placeholder={t("source_placeholder")}
+              />
+              <datalist id="source-presets">
+                {SOURCE_PRESETS.map((s) => (
+                  <option key={s} value={s} />
+                ))}
+              </datalist>
             </div>
           </div>
 

--- a/components/application-table.tsx
+++ b/components/application-table.tsx
@@ -109,6 +109,20 @@ export function ApplicationTable({ applications, onEdit, onDelete }: Application
       cell: (info) => <StatusBadge status={info.getValue() as ApplicationStatus} />,
       filterFn: "equals",
     }),
+    columnHelper.accessor("source", {
+      header: t("source"),
+      cell: (info) => {
+        const val = info.getValue();
+        return val ? (
+          <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-cyan-100 text-cyan-800 dark:bg-cyan-500/20 dark:text-cyan-300">
+            {val}
+          </span>
+        ) : (
+          <span className="text-gray-400 dark:text-gray-500">—</span>
+        );
+      },
+      filterFn: "equals",
+    }),
     columnHelper.accessor("appliedAt", {
       header: t("applied_at"),
       cell: (info) => (

--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -35,11 +35,12 @@ async function deleteApplication(id: string): Promise<void> {
 }
 
 function exportToCsv(applications: Application[], filename = "applications.csv") {
-  const headers = ["Company", "Role", "Status", "Applied", "Last Contact", "Follow-up", "Notes"];
+  const headers = ["Company", "Role", "Status", "Source", "Applied", "Last Contact", "Follow-up", "Notes"];
   const rows = applications.map((a) => [
     a.company,
     a.role,
     a.status,
+    a.source ?? "",
     a.appliedAt ? format(new Date(a.appliedAt), "yyyy-MM-dd") : "",
     a.lastContact ? format(new Date(a.lastContact), "yyyy-MM-dd") : "",
     a.followUpAt ? format(new Date(a.followUpAt), "yyyy-MM-dd") : "",

--- a/lib/db/firestore-adapter.ts
+++ b/lib/db/firestore-adapter.ts
@@ -45,6 +45,7 @@ function mapApp(id: string, data: FirebaseFirestore.DocumentData): ApplicationRe
     followUpAt: toDate(data.followUpAt),
     notes: data.notes ?? null,
     jobDescription: data.jobDescription ?? null,
+    source: data.source ?? null,
     resumeId: data.resumeId ?? null,
     createdAt: toDate(data.createdAt) ?? new Date(),
     updatedAt: toDate(data.updatedAt) ?? new Date(),

--- a/lib/db/prisma-adapter.ts
+++ b/lib/db/prisma-adapter.ts
@@ -26,7 +26,7 @@ function mapContact(c: { id: number; name: string; email: string | null; phone: 
   return { ...c, id: sid(c.id), applicationId: sid(c.applicationId) };
 }
 
-function mapApp(a: { id: number; userId: string; company: string; role: string; status: string; appliedAt: Date | null; lastContact: Date | null; followUpAt: Date | null; notes: string | null; jobDescription: string | null; resumeId: string | null; createdAt: Date; updatedAt: Date; contacts?: { id: number; name: string; email: string | null; phone: string | null; role: string | null; linkedIn: string | null; applicationId: number; createdAt: Date }[] }): ApplicationRecord {
+function mapApp(a: { id: number; userId: string; company: string; role: string; status: string; appliedAt: Date | null; lastContact: Date | null; followUpAt: Date | null; notes: string | null; jobDescription: string | null; source: string | null; resumeId: string | null; createdAt: Date; updatedAt: Date; contacts?: { id: number; name: string; email: string | null; phone: string | null; role: string | null; linkedIn: string | null; applicationId: number; createdAt: Date }[] }): ApplicationRecord {
   return {
     ...a,
     id: sid(a.id),

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -11,6 +11,7 @@ export interface ApplicationRecord {
   followUpAt: Date | null;
   notes: string | null;
   jobDescription: string | null;
+  source: string | null;
   resumeId: string | null;
   createdAt: Date;
   updatedAt: Date;
@@ -62,6 +63,7 @@ export interface CreateApplicationInput {
   followUpAt: Date | null;
   notes: string | null;
   jobDescription: string | null;
+  source: string | null;
 }
 
 export interface UpdateApplicationInput {
@@ -73,6 +75,7 @@ export interface UpdateApplicationInput {
   followUpAt?: Date | null;
   notes?: string | null;
   jobDescription?: string | null;
+  source?: string | null;
   resumeId?: string | null;
 }
 

--- a/messages/de.json
+++ b/messages/de.json
@@ -36,6 +36,7 @@
     "follow_up": "Follow-up",
     "notes": "Notizen",
     "contacts": "Kontakte",
+    "source": "Quelle",
     "count": "{filtered} von {total} Bewerbungen",
     "empty": "Keine Bewerbungen gefunden."
   },
@@ -78,7 +79,9 @@
     "resume_tailoring": "Erstelle...",
     "resume_open": "In Reactive Resume öffnen",
     "resume_error": "Fehler beim Erstellen des Lebenslaufs.",
-    "resume_not_configured": "Lebenslauf-Integration nicht konfiguriert."
+    "resume_not_configured": "Lebenslauf-Integration nicht konfiguriert.",
+    "source": "Quelle",
+    "source_placeholder": "z.B. LinkedIn, Indeed, Empfehlung"
   },
   "status": {
     "applied": "Beworben",

--- a/messages/en.json
+++ b/messages/en.json
@@ -36,6 +36,7 @@
     "follow_up": "Follow-up",
     "notes": "Notes",
     "contacts": "Contacts",
+    "source": "Source",
     "count": "{filtered} of {total} applications",
     "empty": "No applications found."
   },
@@ -78,7 +79,9 @@
     "resume_tailoring": "Creating...",
     "resume_open": "Open in Reactive Resume",
     "resume_error": "Failed to create resume.",
-    "resume_not_configured": "Resume integration not configured."
+    "resume_not_configured": "Resume integration not configured.",
+    "source": "Source",
+    "source_placeholder": "e.g. LinkedIn, Indeed, referral"
   },
   "status": {
     "applied": "Applied",

--- a/prisma/migrations/20260311000000_add_source_field/migration.sql
+++ b/prisma/migrations/20260311000000_add_source_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Application" ADD COLUMN "source" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,7 @@ model Application {
   notes           String?
   followUpAt      DateTime?
   jobDescription  String?
+  source          String?
   resumeId        String?   // Reactive Resume resume ID
   createdAt       DateTime  @default(now())
   updatedAt       DateTime  @updatedAt

--- a/types/index.ts
+++ b/types/index.ts
@@ -28,6 +28,7 @@ export interface Application {
   followUpAt: string | null;
   notes: string | null;
   jobDescription: string | null;
+  source: string | null;
   resumeId: string | null;
   createdAt: string;
   updatedAt: string;
@@ -66,6 +67,18 @@ export const STATUS_ORDER: ApplicationStatus[] = [
   "rejected",
   "ghost",
 ];
+
+// Preset source values for the source field
+export const SOURCE_PRESETS = [
+  "linkedin",
+  "indeed",
+  "company-site",
+  "referral",
+  "recruiter",
+  "email",
+  "ams",
+  "other",
+] as const;
 
 // Legacy: for any place that still needs a label+color pair
 export const STATUS_OPTIONS: { value: ApplicationStatus; label: string; color: string }[] = [


### PR DESCRIPTION
## Summary
- Adds optional `source` field to track application origin (LinkedIn, Indeed, referral, etc.)
- String-based for extensibility, with datalist presets in the UI
- Source visible as a pill in the table, included in CSV export, editable in create/edit modal

## Changes
- `prisma/schema.prisma`: Added `source String?` to Application model
- `prisma/migrations/`: New migration adding the column
- `lib/db/types.ts`: Added `source` to record and input types
- `lib/db/prisma-adapter.ts`, `lib/db/firestore-adapter.ts`: Updated mappers
- `app/api/applications/route.ts`, `app/api/applications/[id]/route.ts`: Accept source in create/update
- `components/application-modal.tsx`: Source input with datalist presets
- `components/application-table.tsx`: Source column with cyan pill badge
- `components/dashboard.tsx`: Source included in CSV export
- `types/index.ts`: Added `source` to Application interface + `SOURCE_PRESETS`
- `messages/{en,de}.json`: Translations for source field

## Test plan
- [ ] Create application with a source value — verify it persists
- [ ] Edit existing application to add/change source
- [ ] Verify source appears in table view
- [ ] Verify CSV export includes source column
- [ ] Verify datalist shows presets (linkedin, indeed, etc.)
- [ ] Run `npx prisma migrate dev` to apply migration

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)