### PR TITLE
feat: add archive mechanism for applications

### DIFF
--- a/app/api/applications/[id]/route.ts
+++ b/app/api/applications/[id]/route.ts
@@ -32,7 +32,7 @@ export async function PATCH(
 
   const { id } = await params;
   const body = await request.json();
-  const { company, role, status, appliedAt, lastContact, followUpAt, notes, jobDescription, source, resumeId } = body;
+  const { company, role, status, appliedAt, lastContact, followUpAt, notes, jobDescription, source, resumeId, archivedAt } = body;
 
   const application = await getDb().updateApplication(id, auth.userId, {
     ...(company !== undefined && { company: String(company).slice(0, 255) }),
@@ -56,6 +56,9 @@ export async function PATCH(
     }),
     ...(resumeId !== undefined && {
       resumeId: resumeId ? String(resumeId).slice(0, 255) : null,
+    }),
+    ...(archivedAt !== undefined && {
+      archivedAt: archivedAt ? new Date(archivedAt) : null,
     }),
   });
 

--- a/components/application-table.tsx
+++ b/components/application-table.tsx
@@ -71,9 +71,11 @@ interface ApplicationTableProps {
   applications: Application[];
   onEdit: (app: Application) => void;
   onDelete: (id: string) => void;
+  onArchive?: (id: string, archive: boolean) => void;
+  showArchived?: boolean;
 }
 
-export function ApplicationTable({ applications, onEdit, onDelete }: ApplicationTableProps) {
+export function ApplicationTable({ applications, onEdit, onDelete, onArchive, showArchived }: ApplicationTableProps) {
   const t = useTranslations("table");
   const ta = useTranslations("actions");
   const ts = useTranslations("status");
@@ -166,6 +168,14 @@ export function ApplicationTable({ applications, onEdit, onDelete }: Application
           >
             {ta("edit")}
           </button>
+          {onArchive && (
+            <button
+              onClick={() => onArchive(row.original.id, !showArchived)}
+              className="flex items-center min-h-[44px] px-2 text-amber-600 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-300 text-sm font-medium transition-colors"
+            >
+              {showArchived ? ta("unarchive") : ta("archive")}
+            </button>
+          )}
           <button
             onClick={() => onDelete(row.original.id)}
             className="flex items-center min-h-[44px] px-2 text-red-500 hover:text-red-700 text-sm font-medium transition-colors"

--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -38,6 +38,15 @@ async function deleteApplication(id: string): Promise<void> {
   if (!res.ok) throw new Error("Failed to delete application");
 }
 
+async function archiveApplication(id: string, archive: boolean): Promise<void> {
+  const res = await fetch(`/api/applications/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ archivedAt: archive ? new Date().toISOString() : null }),
+  });
+  if (!res.ok) throw new Error("Failed to archive application");
+}
+
 function exportToCsv(applications: Application[], filename = "applications.csv") {
   const headers = ["Company", "Role", "Status", "Source", "Applied", "Last Contact", "Follow-up", "Notes"];
   const rows = applications.map((a) => [
@@ -79,6 +88,7 @@ export function Dashboard({ user, shareUrl }: DashboardProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingApp, setEditingApp] = useState<Application | null>(null);
   const [viewMode, setViewMode] = useState<ViewMode>("table");
+  const [showArchived, setShowArchived] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [isAdminPanelOpen, setIsAdminPanelOpen] = useState(false);
   const [isApiTokenPanelOpen, setIsApiTokenPanelOpen] = useState(false);
@@ -90,6 +100,14 @@ export function Dashboard({ user, shareUrl }: DashboardProps) {
 
   const deleteMutation = useMutation({
     mutationFn: deleteApplication,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["applications"] });
+    },
+  });
+
+  const archiveMutation = useMutation({
+    mutationFn: ({ id, archive }: { id: string; archive: boolean }) =>
+      archiveApplication(id, archive),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["applications"] });
     },
@@ -122,17 +140,26 @@ export function Dashboard({ user, shareUrl }: DashboardProps) {
     setEditingApp(null);
   }
 
+  function handleArchive(id: string, archive: boolean) {
+    archiveMutation.mutate({ id, archive });
+  }
+
+  // Filter by archive status
+  const activeApplications = applications.filter((a) => !a.archivedAt);
+  const archivedApplications = applications.filter((a) => !!a.archivedAt);
+  const visibleApplications = showArchived ? archivedApplications : activeApplications;
+
   const stats = {
-    total: applications.length,
-    active: applications.filter((a) =>
+    total: activeApplications.length,
+    active: activeApplications.filter((a) =>
       (["applied", "waiting", "interview"] as ApplicationStatus[]).includes(a.status)
     ).length,
-    offers: applications.filter((a) => a.status === "offer").length,
-    ghosted: applications.filter((a) => a.status === "ghost").length,
+    offers: activeApplications.filter((a) => a.status === "offer").length,
+    ghosted: activeApplications.filter((a) => a.status === "ghost").length,
   };
 
-  // Overdue follow-ups banner
-  const overdueFollowUps = applications.filter((a) => {
+  // Overdue follow-ups banner (only active, non-archived)
+  const overdueFollowUps = activeApplications.filter((a) => {
     if (!a.followUpAt) return false;
     const d = new Date(a.followUpAt);
     const today = new Date();
@@ -296,7 +323,7 @@ export function Dashboard({ user, shareUrl }: DashboardProps) {
         <div className="flex items-center justify-between mb-6 gap-4 flex-wrap">
           <div className="flex items-center gap-2">
             <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
-              {t("applications")} ({applications.length})
+              {showArchived ? ta("archive") : t("applications")} ({visibleApplications.length})
             </h2>
           </div>
           <div className="flex flex-wrap items-center gap-2">
@@ -326,9 +353,26 @@ export function Dashboard({ user, shareUrl }: DashboardProps) {
 
             {/* Actions — row 2 on mobile */}
             <div className="flex items-center gap-2 ml-auto">
+              {/* Archive toggle */}
+              <button
+                onClick={() => setShowArchived((v) => !v)}
+                className={`flex items-center gap-1.5 px-3 py-1.5 border rounded-lg text-sm font-medium transition-colors whitespace-nowrap ${
+                  showArchived
+                    ? "border-amber-300 dark:border-amber-600 bg-amber-50 dark:bg-amber-950/30 text-amber-700 dark:text-amber-300"
+                    : "border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+                }`}
+              >
+                {showArchived ? ta("show_active") : ta("show_archive")}
+                {archivedApplications.length > 0 && !showArchived && (
+                  <span className="ml-1 inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 rounded-full bg-gray-200 dark:bg-gray-600 text-xs font-bold text-gray-700 dark:text-gray-200">
+                    {archivedApplications.length}
+                  </span>
+                )}
+              </button>
+
               {/* CSV Export */}
               <button
-                onClick={() => exportToCsv(applications)}
+                onClick={() => exportToCsv(visibleApplications)}
                 title={ta("export_csv")}
                 className="flex items-center gap-1.5 px-3 py-1.5 border border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-300 rounded-lg text-sm font-medium hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors whitespace-nowrap"
               >
@@ -357,12 +401,14 @@ export function Dashboard({ user, shareUrl }: DashboardProps) {
           <div className="text-center py-20 text-red-500">{t("loading_error")}</div>
         ) : viewMode === "table" ? (
           <ApplicationTable
-            applications={applications}
+            applications={visibleApplications}
             onEdit={handleEdit}
             onDelete={handleDelete}
+            onArchive={handleArchive}
+            showArchived={showArchived}
           />
         ) : (
-          <KanbanView applications={applications} onEdit={handleEdit} />
+          <KanbanView applications={visibleApplications} onEdit={handleEdit} />
         )}
       </main>
 

--- a/lib/db/firestore-adapter.ts
+++ b/lib/db/firestore-adapter.ts
@@ -49,6 +49,7 @@ function mapApp(id: string, data: FirebaseFirestore.DocumentData): ApplicationRe
     jobDescription: data.jobDescription ?? null,
     source: data.source ?? null,
     resumeId: data.resumeId ?? null,
+    archivedAt: toDate(data.archivedAt) ?? null,
     createdAt: toDate(data.createdAt) ?? new Date(),
     updatedAt: toDate(data.updatedAt) ?? new Date(),
     contacts: data._contacts, // populated separately when needed

--- a/lib/db/prisma-adapter.ts
+++ b/lib/db/prisma-adapter.ts
@@ -28,7 +28,7 @@ function mapContact(c: { id: number; name: string; email: string | null; phone: 
   return { ...c, id: sid(c.id), applicationId: sid(c.applicationId) };
 }
 
-function mapApp(a: { id: number; userId: string; company: string; role: string; status: string; appliedAt: Date | null; lastContact: Date | null; followUpAt: Date | null; notes: string | null; jobDescription: string | null; source: string | null; resumeId: string | null; createdAt: Date; updatedAt: Date; contacts?: { id: number; name: string; email: string | null; phone: string | null; role: string | null; linkedIn: string | null; applicationId: number; createdAt: Date }[] }): ApplicationRecord {
+function mapApp(a: { id: number; userId: string; company: string; role: string; status: string; appliedAt: Date | null; lastContact: Date | null; followUpAt: Date | null; notes: string | null; jobDescription: string | null; source: string | null; resumeId: string | null; archivedAt: Date | null; createdAt: Date; updatedAt: Date; contacts?: { id: number; name: string; email: string | null; phone: string | null; role: string | null; linkedIn: string | null; applicationId: number; createdAt: Date }[] }): ApplicationRecord {
   return {
     ...a,
     id: sid(a.id),

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -13,6 +13,7 @@ export interface ApplicationRecord {
   jobDescription: string | null;
   source: string | null;
   resumeId: string | null;
+  archivedAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
   contacts?: ContactRecord[];
@@ -94,6 +95,7 @@ export interface UpdateApplicationInput {
   jobDescription?: string | null;
   source?: string | null;
   resumeId?: string | null;
+  archivedAt?: Date | null;
 }
 
 export interface CreateContactInput {

--- a/messages/de.json
+++ b/messages/de.json
@@ -25,7 +25,11 @@
     "cancel": "Abbrechen",
     "saving": "Speichern...",
     "search": "Suchen...",
-    "all_statuses": "Alle Status"
+    "all_statuses": "Alle Status",
+    "archive": "Archiv",
+    "unarchive": "Wiederherstellen",
+    "show_archive": "Archiv",
+    "show_active": "Aktiv"
   },
   "table": {
     "company": "Firma",

--- a/messages/en.json
+++ b/messages/en.json
@@ -25,7 +25,11 @@
     "cancel": "Cancel",
     "saving": "Saving...",
     "search": "Search...",
-    "all_statuses": "All statuses"
+    "all_statuses": "All statuses",
+    "archive": "Archive",
+    "unarchive": "Unarchive",
+    "show_archive": "Archive",
+    "show_active": "Active"
   },
   "table": {
     "company": "Company",

--- a/prisma/migrations/20260311000001_add_archived_at/migration.sql
+++ b/prisma/migrations/20260311000001_add_archived_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Application" ADD COLUMN "archivedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,7 @@ model Application {
   jobDescription  String?
   source          String?
   resumeId        String?   // Reactive Resume resume ID
+  archivedAt      DateTime?
   createdAt       DateTime  @default(now())
   updatedAt       DateTime  @updatedAt
   documents       Document[]

--- a/types/index.ts
+++ b/types/index.ts
@@ -31,6 +31,7 @@ export interface Application {
   jobDescription: string | null;
   source: string | null;
   resumeId: string | null;
+  archivedAt: string | null;
   createdAt: string;
   updatedAt: string;
   contacts?: Contact[];


### PR DESCRIPTION
## Summary
- Adds `archivedAt` timestamp field to applications for soft-archive functionality
- Archived applications are hidden from the default dashboard view and excluded from stats
- Toggle button in toolbar switches between active and archive views
- Archive/unarchive actions available per-row in the table view

## Changes
- `prisma/schema.prisma`: Added `archivedAt DateTime?` to Application model
- `prisma/migrations/`: New migration adding the column
- `lib/db/types.ts`: Added `archivedAt` to record and update input types
- `lib/db/prisma-adapter.ts`, `lib/db/firestore-adapter.ts`: Updated mappers
- `app/api/applications/[id]/route.ts`: Accept `archivedAt` in PATCH
- `components/dashboard.tsx`: Archive toggle, filtered views, stats exclude archived
- `components/application-table.tsx`: Archive/unarchive action buttons per row
- `types/index.ts`: Added `archivedAt` to Application interface
- `messages/{en,de}.json`: Translations for archive actions

## Test plan
- [ ] Archive an application — verify it disappears from active view
- [ ] Toggle to archive view — verify archived apps are shown
- [ ] Unarchive from archive view — verify it returns to active
- [ ] Verify dashboard stats exclude archived items
- [ ] Verify overdue follow-up banner excludes archived items
- [ ] Run `npx prisma migrate dev` to apply migration

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)