### PR TITLE
chore: pin typescript to 5.9.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
         "tsx": "^4.21.0",
-        "typescript": "^5"
+        "typescript": "5.9.3"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "tsx": "^4.21.0",
-    "typescript": "^5"
+    "typescript": "5.9.3"
   }
 }


### PR DESCRIPTION
chore: pin typescript to 5.9.3