### PR TITLE
Simplify status lanes from 8 to 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,8 @@ Uses Workload Identity Federation — no service account keys needed.
 
 | Status | Meaning |
 |--------|---------|
-| `draft` | Not yet sent |
+| `inbound` | Incoming opportunity |
 | `applied` | Submitted |
-| `waiting` | Awaiting response |
 | `interview` | Interview scheduled/done |
 | `offer` | Offer received |
 | `rejected` | Rejected |
-| `ghost` | No response |

--- a/app/share/page.tsx
+++ b/app/share/page.tsx
@@ -5,14 +5,6 @@ import { format } from "date-fns";
 import type { Locale } from "date-fns";
 import { de, enUS } from "date-fns/locale";
 
-interface Document {
-  id: string;
-  originalName: string;
-  mimeType: string;
-  size: number;
-  uploadedAt: Date;
-}
-
 // ── Translations ──────────────────────────────────────────────────────────────
 
 type Lang = "de" | "en";
@@ -40,23 +32,16 @@ const TRANSLATIONS = {
       empty: "Noch keine Bewerbungen eingetragen.",
     },
     status: {
+      inbound: "Eingehend",
       applied: "Beworben",
-      waiting: "Wartend",
       interview: "Interview",
-      rejected: "Abgelehnt",
       offer: "Angebot",
-      ghost: "Ghosted",
-      draft: "Entwurf",
+      rejected: "Abgelehnt",
     },
     footer: (count: number, date: string) =>
       `${count} Bewerbungen gesamt · Zuletzt aktualisiert: ${date} Uhr`,
     readOnlyNote:
       "Diese Seite ist schreibgeschützt. Nur der Eigentümer kann Änderungen vornehmen.",
-    docs: {
-      heading: "Dokumente",
-      empty: "Keine Dokumente vorhanden.",
-      download: "Herunterladen",
-    },
   },
   en: {
     title: (name: string | null) => name ? `Job Applications of ${name}` : "Job Applications",
@@ -80,23 +65,16 @@ const TRANSLATIONS = {
       empty: "No applications yet.",
     },
     status: {
+      inbound: "Inbound",
       applied: "Applied",
-      waiting: "Waiting",
       interview: "Interview",
-      rejected: "Rejected",
       offer: "Offer",
-      ghost: "Ghosted",
-      draft: "Draft",
+      rejected: "Rejected",
     },
     footer: (count: number, date: string) =>
       `${count} applications total · Last updated: ${date}`,
     readOnlyNote:
       "This is a read-only view. Only the owner can make changes.",
-    docs: {
-      heading: "Documents",
-      empty: "No documents available.",
-      download: "Download",
-    },
   },
 } satisfies Record<Lang, unknown>;
 
@@ -104,18 +82,6 @@ const TRANSLATIONS = {
 
 function resolveLang(raw: string | undefined): Lang {
   return raw === "en" ? "en" : "de";
-}
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
-}
-
-function fileIcon(mimeType: string): string {
-  if (mimeType === "application/pdf") return "📄";
-  if (mimeType.startsWith("image/")) return "🖼️";
-  return "📎";
 }
 
 function formatDate(dateVal: Date | string | null, locale: Locale): string {
@@ -206,7 +172,8 @@ export default async function SharePage({ searchParams }: SharePageProps) {
   const dateLocale = lang === "de" ? de : enUS;
 
   const db = getDb();
-  const applications = await db.listApplications(null);
+  const allApplications = await db.listApplications(null);
+  const applications = allApplications.filter((a) => !a.archivedAt);
 
   // Get owner name dynamically from first application's user, or fall back to generic
   const ownerUser = applications[0]?.userId
@@ -214,19 +181,11 @@ export default async function SharePage({ searchParams }: SharePageProps) {
     : null;
   const ownerName = ownerUser?.name ?? null;
 
-  const allDocuments = await db.listDocuments(null);
-  const documents: Document[] = allDocuments.map((d) => ({
-    id: d.id,
-    originalName: d.originalName,
-    mimeType: d.mimeType,
-    size: d.size,
-    uploadedAt: d.uploadedAt,
-  }));
 
   const stats = {
     total: applications.length,
     active: applications.filter((a) =>
-      ["applied", "waiting", "interview"].includes(a.status)
+      ["applied", "interview"].includes(a.status)
     ).length,
     offers: applications.filter((a) => a.status === "offer").length,
     rejected: applications.filter((a) => a.status === "rejected").length,
@@ -348,46 +307,6 @@ export default async function SharePage({ searchParams }: SharePageProps) {
               format(new Date(), "dd.MM.yyyy HH:mm", { locale: dateLocale })
             )}
           </div>
-        </div>
-
-        {/* Documents */}
-        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden mt-8">
-          <div className="px-6 py-4 border-b border-gray-100 dark:border-gray-700">
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
-              {t.docs.heading} ({documents.length})
-            </h2>
-          </div>
-          {documents.length === 0 ? (
-            <div className="text-center py-12 text-gray-400 dark:text-gray-500">
-              <div className="text-3xl mb-2">📭</div>
-              <p>{t.docs.empty}</p>
-            </div>
-          ) : (
-            <ul className="divide-y divide-gray-50 dark:divide-gray-700/50">
-              {documents.map((doc) => (
-                <li
-                  key={doc.id}
-                  className="flex items-center gap-4 px-6 py-4 hover:bg-gray-50/60 dark:hover:bg-gray-700/50 transition-colors"
-                >
-                  <span className="text-2xl flex-shrink-0">{fileIcon(doc.mimeType)}</span>
-                  <div className="flex-1 min-w-0">
-                    <p className="font-medium text-gray-900 dark:text-white truncate">{doc.originalName}</p>
-                    <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">
-                      {formatBytes(doc.size)} ·{" "}
-                      {format(new Date(doc.uploadedAt), "dd.MM.yyyy HH:mm", { locale: dateLocale })}
-                    </p>
-                  </div>
-                  <a
-                    href={`/api/documents/${doc.id}/file?token=${token}`}
-                    download={doc.originalName}
-                    className="flex-shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium transition-colors"
-                  >
-                    ⬇ {t.docs.download}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          )}
         </div>
 
         <p className="text-center text-xs text-gray-400 dark:text-gray-500 mt-6">

--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -152,10 +152,10 @@ export function Dashboard({ user, shareUrl }: DashboardProps) {
   const stats = {
     total: activeApplications.length,
     active: activeApplications.filter((a) =>
-      (["applied", "waiting", "interview"] as ApplicationStatus[]).includes(a.status)
+      (["applied", "interview"] as ApplicationStatus[]).includes(a.status)
     ).length,
     offers: activeApplications.filter((a) => a.status === "offer").length,
-    ghosted: activeApplications.filter((a) => a.status === "ghost").length,
+    rejected: activeApplications.filter((a) => a.status === "rejected").length,
   };
 
   // Overdue follow-ups banner (only active, non-archived)
@@ -304,7 +304,7 @@ export function Dashboard({ user, shareUrl }: DashboardProps) {
           <StatCard label={ts("total")} value={stats.total} color="blue" />
           <StatCard label={ts("active")} value={stats.active} color="yellow" />
           <StatCard label={ts("offers")} value={stats.offers} color="green" />
-          <StatCard label={ts("ghosted")} value={stats.ghosted} color="gray" />
+          <StatCard label={ts("rejected")} value={stats.rejected} color="gray" />
         </div>
 
         {isApiTokenPanelOpen && (

--- a/messages/de.json
+++ b/messages/de.json
@@ -12,7 +12,7 @@
     "total": "Gesamt",
     "active": "Aktiv",
     "offers": "Angebote",
-    "ghosted": "Ghosted"
+    "rejected": "Abgelehnt"
   },
   "actions": {
     "new_application": "Neue Bewerbung",
@@ -88,14 +88,11 @@
     "source_placeholder": "z.B. LinkedIn, Indeed, Empfehlung"
   },
   "status": {
+    "inbound": "Eingehend",
     "applied": "Beworben",
-    "waiting": "Wartend",
     "interview": "Interview",
-    "rejected": "Abgelehnt",
     "offer": "Angebot",
-    "ghost": "Ghosted",
-    "draft": "Entwurf",
-    "inbound": "Eingehend"
+    "rejected": "Abgelehnt"
   },
   "kanban": {
     "empty": "Keine Einträge"
@@ -135,14 +132,11 @@
       "empty": "Noch keine Bewerbungen eingetragen."
     },
     "status": {
+      "inbound": "Eingehend",
       "applied": "Beworben",
-      "waiting": "Wartend",
       "interview": "Interview",
-      "rejected": "Abgelehnt",
       "offer": "Angebot",
-      "ghost": "Ghosted",
-      "draft": "Entwurf",
-      "inbound": "Eingehend"
+      "rejected": "Abgelehnt"
     },
     "footer_note": "Dies ist eine schreibgeschützte Ansicht. Nur Christian kann Änderungen vornehmen."
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -12,7 +12,7 @@
     "total": "Total",
     "active": "Active",
     "offers": "Offers",
-    "ghosted": "Ghosted"
+    "rejected": "Rejected"
   },
   "actions": {
     "new_application": "New Application",
@@ -88,14 +88,11 @@
     "source_placeholder": "e.g. LinkedIn, Indeed, referral"
   },
   "status": {
+    "inbound": "Inbound",
     "applied": "Applied",
-    "waiting": "Waiting",
     "interview": "Interview",
-    "rejected": "Rejected",
     "offer": "Offer",
-    "ghost": "Ghosted",
-    "draft": "Draft",
-    "inbound": "Inbound"
+    "rejected": "Rejected"
   },
   "kanban": {
     "empty": "No entries"
@@ -135,14 +132,11 @@
       "empty": "No applications yet."
     },
     "status": {
+      "inbound": "Inbound",
       "applied": "Applied",
-      "waiting": "Waiting",
       "interview": "Interview",
-      "rejected": "Rejected",
       "offer": "Offer",
-      "ghost": "Ghosted",
-      "draft": "Draft",
-      "inbound": "Inbound"
+      "rejected": "Rejected"
     },
     "footer_note": "This is a read-only view. Only Christian can make changes."
   },

--- a/next.config.ts
+++ b/next.config.ts
@@ -38,6 +38,15 @@ const nextConfig: NextConfig = {
       { protocol: "https", hostname: "lh3.googleusercontent.com" },
     ],
   },
+  async redirects() {
+    return [
+      {
+        source: "/llms.txt",
+        destination: "/llm.txt",
+        permanent: true,
+      },
+    ];
+  },
   async headers() {
     return [
       {

--- a/prisma/migrations/20260311100000_simplify_status_lanes/migration.sql
+++ b/prisma/migrations/20260311100000_simplify_status_lanes/migration.sql
@@ -1,0 +1,3 @@
+-- Consolidate removed status lanes into remaining ones
+UPDATE "Application" SET status = 'applied' WHERE status IN ('waiting', 'draft');
+UPDATE "Application" SET status = 'rejected' WHERE status = 'ghost';

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -17,7 +17,7 @@ async function main() {
     {
       company: "Amazon Ring",
       role: "SDE",
-      status: "waiting",
+      status: "applied",
       appliedAt: new Date("2026-02-10"),
       lastContact: null,
       notes: "Matt Brown (Recruiter); HackerRank offen",
@@ -25,7 +25,7 @@ async function main() {
     {
       company: "Zurich/NTT",
       role: "Fullstack SE Alpha I",
-      status: "ghost",
+      status: "rejected",
       appliedAt: new Date("2026-02-25"),
       lastContact: null,
       notes: "Franco Mahl; 240€/Tag; kein Feedback",
@@ -33,7 +33,7 @@ async function main() {
     {
       company: "Aircall",
       role: "Senior Engineer",
-      status: "ghost",
+      status: "rejected",
       appliedAt: new Date("2026-02-26"),
       lastContact: null,
       notes: "Guillaume Moulin; kein Feedback",
@@ -41,7 +41,7 @@ async function main() {
     {
       company: "Deloitte",
       role: "Backend Engineer",
-      status: "waiting",
+      status: "applied",
       appliedAt: null,
       lastContact: null,
       notes: "Carolina Rico Quinn; CV vorbereitet",
@@ -49,7 +49,7 @@ async function main() {
     {
       company: "KNAPP AG",
       role: "Java Senior",
-      status: "draft",
+      status: "inbound",
       appliedAt: null,
       lastContact: null,
       notes: "Noch nicht abgeschickt",
@@ -57,7 +57,7 @@ async function main() {
     {
       company: "Ringier AG",
       role: "Platform Engineer",
-      status: "draft",
+      status: "inbound",
       appliedAt: null,
       lastContact: null,
       notes: "Noch nicht abgeschickt",

--- a/public/llm.txt
+++ b/public/llm.txt
@@ -76,7 +76,7 @@ Multi-tenant: each user only sees their own data. Admin users (isAdmin flag) byp
 ---
 
 ## Application status values
-`draft` | `applied` | `waiting` | `interview` | `offer` | `rejected` | `ghost`
+`inbound` | `applied` | `interview` | `offer` | `rejected`
 
 ## Example: create application via API token
 ```

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -28,7 +28,7 @@
     "schemas": {
       "ApplicationStatus": {
         "type": "string",
-        "enum": ["draft", "applied", "waiting", "interview", "offer", "rejected", "ghost"],
+        "enum": ["inbound", "applied", "interview", "offer", "rejected"],
         "description": "Current stage of the job application lifecycle."
       },
       "ContactRef": {

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,12 +1,9 @@
 export type ApplicationStatus =
+  | "inbound"
   | "applied"
-  | "waiting"
   | "interview"
-  | "rejected"
   | "offer"
-  | "ghost"
-  | "draft"
-  | "inbound";
+  | "rejected";
 
 export interface Contact {
   id: string;
@@ -39,38 +36,29 @@ export interface Application {
 
 // Color mapping per status — labels come from i18n translations
 export const STATUS_COLORS: Record<ApplicationStatus, string> = {
-  applied: "bg-blue-100 text-blue-800 dark:bg-blue-500/25 dark:text-blue-300",
-  waiting: "bg-yellow-100 text-yellow-800 dark:bg-amber-500/25 dark:text-amber-300",
-  interview: "bg-purple-100 text-purple-800 dark:bg-purple-500/25 dark:text-purple-300",
-  rejected: "bg-red-100 text-red-800 dark:bg-red-500/25 dark:text-red-300",
-  offer: "bg-green-100 text-green-800 dark:bg-emerald-500/25 dark:text-emerald-300",
-  ghost: "bg-gray-100 text-gray-600 dark:bg-gray-500/25 dark:text-gray-300",
-  draft: "bg-slate-100 text-slate-600 dark:bg-slate-500/25 dark:text-slate-300",
   inbound: "bg-teal-100 text-teal-800 dark:bg-teal-500/25 dark:text-teal-300",
+  applied: "bg-blue-100 text-blue-800 dark:bg-blue-500/25 dark:text-blue-300",
+  interview: "bg-purple-100 text-purple-800 dark:bg-purple-500/25 dark:text-purple-300",
+  offer: "bg-green-100 text-green-800 dark:bg-emerald-500/25 dark:text-emerald-300",
+  rejected: "bg-red-100 text-red-800 dark:bg-red-500/25 dark:text-red-300",
 };
 
 // Row highlight colors for table
 export const STATUS_ROW_COLORS: Record<ApplicationStatus, string> = {
-  applied: "",
-  waiting: "",
-  interview: "bg-purple-50/40 dark:bg-purple-950/20",
-  rejected: "bg-red-50/30 dark:bg-red-950/20",
-  offer: "bg-green-50/40 dark:bg-green-950/20",
-  ghost: "bg-gray-50/50 dark:bg-gray-800/30",
-  draft: "",
   inbound: "",
+  applied: "",
+  interview: "bg-purple-50/40 dark:bg-purple-950/20",
+  offer: "bg-green-50/40 dark:bg-green-950/20",
+  rejected: "bg-red-50/30 dark:bg-red-950/20",
 };
 
 // Ordered for Kanban display
 export const STATUS_ORDER: ApplicationStatus[] = [
   "inbound",
-  "draft",
   "applied",
-  "waiting",
   "interview",
   "offer",
   "rejected",
-  "ghost",
 ];
 
 // Preset source values for the source field
@@ -87,12 +75,9 @@ export const SOURCE_PRESETS = [
 
 // Legacy: for any place that still needs a label+color pair
 export const STATUS_OPTIONS: { value: ApplicationStatus; label: string; color: string }[] = [
-  { value: "applied", label: "Beworben", color: STATUS_COLORS.applied },
-  { value: "waiting", label: "Wartend", color: STATUS_COLORS.waiting },
-  { value: "interview", label: "Interview", color: STATUS_COLORS.interview },
-  { value: "rejected", label: "Abgelehnt", color: STATUS_COLORS.rejected },
-  { value: "offer", label: "Angebot", color: STATUS_COLORS.offer },
-  { value: "ghost", label: "Ghosted", color: STATUS_COLORS.ghost },
-  { value: "draft", label: "Entwurf", color: STATUS_COLORS.draft },
   { value: "inbound", label: "Eingehend", color: STATUS_COLORS.inbound },
+  { value: "applied", label: "Beworben", color: STATUS_COLORS.applied },
+  { value: "interview", label: "Interview", color: STATUS_COLORS.interview },
+  { value: "offer", label: "Angebot", color: STATUS_COLORS.offer },
+  { value: "rejected", label: "Abgelehnt", color: STATUS_COLORS.rejected },
 ];


### PR DESCRIPTION
## Summary
- Reduce statuses from 8 (`draft`, `applied`, `waiting`, `interview`, `offer`, `rejected`, `ghost`, `inbound`) to 5 (`inbound`, `applied`, `interview`, `offer`, `rejected`)
- Hide archived applications and documents section from the share page (document download links still work via token)
- Add `llms.txt` → `llm.txt` redirect in Next.js config
- Data migration: `waiting`/`draft` → `applied`, `ghost` → `rejected`

## Test plan
- [ ] Run `npx prisma migrate deploy` to apply data migration
- [ ] Verify Kanban board shows 5 lanes
- [ ] Verify share page excludes archived apps and has no documents section
- [ ] Verify `/llms.txt` redirects to `/llm.txt`
- [ ] Verify document download links still work via share token

🤖 Generated with [Claude Code](https://claude.com/claude-code)