### PR TITLE
Improve mobile UX for applications on phones

### DIFF
--- a/app/share/page.tsx
+++ b/app/share/page.tsx
@@ -1,11 +1,10 @@
 import { notFound } from "next/navigation";
 import { getDb } from "@/lib/db";
 import { ApplicationStatus, STATUS_COLORS } from "@/types";
-import { format } from "date-fns";
+import type { ApplicationRecord } from "@/lib/db/types";
+import { format, isPast, isToday } from "date-fns";
 import type { Locale } from "date-fns";
 import { de, enUS } from "date-fns/locale";
-
-// ── Translations ──────────────────────────────────────────────────────────────
 
 type Lang = "de" | "en";
 
@@ -76,9 +75,7 @@ const TRANSLATIONS = {
     readOnlyNote:
       "This is a read-only view. Only the owner can make changes.",
   },
-} satisfies Record<Lang, unknown>;
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
+} as const;
 
 function resolveLang(raw: string | undefined): Lang {
   return raw === "en" ? "en" : "de";
@@ -92,8 +89,6 @@ function formatDate(dateVal: Date | string | null, locale: Locale): string {
     return "—";
   }
 }
-
-// ── Sub-components ────────────────────────────────────────────────────────────
 
 function StatusBadge({
   status,
@@ -153,7 +148,70 @@ function LangToggle({
   );
 }
 
-// ── Page ──────────────────────────────────────────────────────────────────────
+function ReadonlyApplicationCard({
+  app,
+  labels,
+  tableLabels,
+  dateLocale,
+}: {
+  app: ApplicationRecord;
+  labels: Record<string, string>;
+  tableLabels: {
+    company: string;
+    role: string;
+    status: string;
+    applied: string;
+    lastContact: string;
+    followUp: string;
+    notes: string;
+    empty: string;
+    heading: string;
+  };
+  dateLocale: Locale;
+}) {
+  const followUpDate = app.followUpAt ? new Date(app.followUpAt) : null;
+  const isOverdue = followUpDate && isPast(followUpDate) && !isToday(followUpDate);
+  const isDueToday = followUpDate && isToday(followUpDate);
+
+  return (
+    <article className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="truncate text-base font-semibold text-gray-900 dark:text-white">{app.company}</h3>
+          <p className="mt-0.5 text-sm text-gray-600 dark:text-gray-300">{app.role}</p>
+        </div>
+        <div className="shrink-0">
+          <StatusBadge status={app.status as ApplicationStatus} labels={labels} />
+        </div>
+      </div>
+
+      <div className="mt-3 grid grid-cols-2 gap-3 text-sm">
+        <div>
+          <div className="text-xs font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">{tableLabels.applied}</div>
+          <div className="mt-1 text-gray-700 dark:text-gray-300">{formatDate(app.appliedAt, dateLocale)}</div>
+        </div>
+        <div>
+          <div className="text-xs font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">{tableLabels.followUp}</div>
+          <div className={`mt-1 font-medium ${
+            isOverdue ? "text-red-600 dark:text-red-400" : isDueToday ? "text-orange-500 dark:text-orange-400" : "text-gray-700 dark:text-gray-300"
+          }`}>
+            {followUpDate ? `${isOverdue ? "⚠ " : isDueToday ? "🔔 " : ""}${formatDate(followUpDate, dateLocale)}` : "—"}
+          </div>
+        </div>
+        <div>
+          <div className="text-xs font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">{tableLabels.lastContact}</div>
+          <div className="mt-1 text-gray-700 dark:text-gray-300">{formatDate(app.lastContact, dateLocale)}</div>
+        </div>
+      </div>
+
+      {app.notes && (
+        <div className="mt-3 rounded-lg bg-gray-50 px-3 py-2 text-sm text-gray-600 dark:bg-gray-900/60 dark:text-gray-300">
+          {app.notes}
+        </div>
+      )}
+    </article>
+  );
+}
 
 interface SharePageProps {
   searchParams: Promise<{ token?: string; lang?: string }>;
@@ -175,12 +233,10 @@ export default async function SharePage({ searchParams }: SharePageProps) {
   const allApplications = await db.listApplications(null);
   const applications = allApplications.filter((a) => !a.archivedAt);
 
-  // Get owner name dynamically from first application's user, or fall back to generic
   const ownerUser = applications[0]?.userId
     ? await db.getUser(applications[0].userId)
     : null;
   const ownerName = ownerUser?.name ?? null;
-
 
   const stats = {
     total: applications.length,
@@ -203,7 +259,6 @@ export default async function SharePage({ searchParams }: SharePageProps) {
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 overflow-x-hidden">
-      {/* Header */}
       <header className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between gap-3 h-16">
@@ -226,7 +281,6 @@ export default async function SharePage({ searchParams }: SharePageProps) {
       </header>
 
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {/* Stats */}
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-8">
           <StatCard label={t.stats.total} value={stats.total} color="blue" />
           <StatCard label={t.stats.active} value={stats.active} color="yellow" />
@@ -234,14 +288,34 @@ export default async function SharePage({ searchParams }: SharePageProps) {
           <StatCard label={t.stats.rejected} value={stats.rejected} color="gray" />
         </div>
 
-        {/* Table */}
         <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden">
           <div className="px-6 py-4 border-b border-gray-100 dark:border-gray-700">
             <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
               {t.table.heading} ({applications.length})
             </h2>
           </div>
-          <div className="overflow-x-auto">
+
+          <div className="p-3 md:hidden">
+            {applications.length === 0 ? (
+              <div className="rounded-xl border border-dashed border-gray-200 px-4 py-10 text-center text-sm text-gray-400 dark:border-gray-700 dark:text-gray-500">
+                {t.table.empty}
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {applications.map((app) => (
+                  <ReadonlyApplicationCard
+                    key={app.id}
+                    app={app}
+                    labels={t.status}
+                    tableLabels={t.table}
+                    dateLocale={dateLocale}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="hidden overflow-x-auto md:block">
             <table className="w-full">
               <thead>
                 <tr className="bg-gray-50 dark:bg-gray-900/50 border-b border-gray-100 dark:border-gray-700">
@@ -301,6 +375,7 @@ export default async function SharePage({ searchParams }: SharePageProps) {
               </tbody>
             </table>
           </div>
+
           <div className="px-4 py-3 border-t border-gray-100 dark:border-gray-700 text-xs text-gray-400 dark:text-gray-500">
             {t.footer(
               applications.length,

--- a/components/application-table.tsx
+++ b/components/application-table.tsx
@@ -67,6 +67,99 @@ function FollowUpCell({ date }: { date: string | null }) {
   );
 }
 
+interface MobileApplicationCardProps {
+  app: Application;
+  onEdit: (app: Application) => void;
+  onDelete: (id: string) => void;
+  onArchive?: (id: string, archive: boolean) => void;
+  showArchived?: boolean;
+}
+
+function MobileApplicationCard({ app, onEdit, onDelete, onArchive, showArchived }: MobileApplicationCardProps) {
+  const t = useTranslations("table");
+  const ta = useTranslations("actions");
+  const locale = useLocale();
+  const dateFnsLocale = locale === "de" ? de : enUS;
+
+  function formatDate(dateStr: string | null): string {
+    if (!dateStr) return "—";
+    try {
+      return format(new Date(dateStr), "dd.MM.yyyy", { locale: dateFnsLocale });
+    } catch {
+      return "—";
+    }
+  }
+
+  return (
+    <article className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="truncate text-base font-semibold text-gray-900 dark:text-white">{app.company}</h3>
+          <p className="mt-0.5 text-sm text-gray-600 dark:text-gray-300">{app.role}</p>
+        </div>
+        <div className="shrink-0">
+          <StatusBadge status={app.status} />
+        </div>
+      </div>
+
+      <div className="mt-3 grid grid-cols-2 gap-3 text-sm">
+        <div>
+          <div className="text-xs font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">{t("applied_at")}</div>
+          <div className="mt-1 text-gray-700 dark:text-gray-300">{formatDate(app.appliedAt)}</div>
+        </div>
+        <div>
+          <div className="text-xs font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">{t("follow_up")}</div>
+          <div className="mt-1"><FollowUpCell date={app.followUpAt} /></div>
+        </div>
+        <div>
+          <div className="text-xs font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">{t("last_contact")}</div>
+          <div className="mt-1 text-gray-700 dark:text-gray-300">{formatDate(app.lastContact)}</div>
+        </div>
+        <div>
+          <div className="text-xs font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">{t("source")}</div>
+          <div className="mt-1 text-gray-700 dark:text-gray-300">{app.source || "—"}</div>
+        </div>
+      </div>
+
+      {app.notes && (
+        <div className="mt-3 rounded-lg bg-gray-50 px-3 py-2 text-sm text-gray-600 dark:bg-gray-900/60 dark:text-gray-300">
+          {app.notes}
+        </div>
+      )}
+
+      {app.contacts && app.contacts.length > 0 && (
+        <div className="mt-3">
+          <div className="mb-1 text-xs font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">{t("contacts")}</div>
+          <ContactPills contacts={app.contacts} />
+        </div>
+      )}
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        <button
+          onClick={() => onEdit(app)}
+          className="flex min-h-[44px] items-center justify-center rounded-lg bg-blue-50 px-3 text-sm font-medium text-blue-700 transition-colors hover:bg-blue-100 dark:bg-blue-500/15 dark:text-blue-300 dark:hover:bg-blue-500/25"
+        >
+          {ta("edit")}
+        </button>
+        {onArchive && (
+          <button
+            onClick={() => onArchive(app.id, !showArchived)}
+            className="flex min-h-[44px] items-center justify-center rounded-lg bg-amber-50 px-3 text-sm font-medium text-amber-700 transition-colors hover:bg-amber-100 dark:bg-amber-500/15 dark:text-amber-300 dark:hover:bg-amber-500/25"
+          >
+            {showArchived ? ta("unarchive") : ta("archive")}
+          </button>
+        )}
+        <button
+          onClick={() => onDelete(app.id)}
+          className="flex min-h-[44px] items-center justify-center rounded-lg bg-red-50 px-3 text-sm font-medium text-red-600 transition-colors hover:bg-red-100 dark:bg-red-500/15 dark:text-red-300 dark:hover:bg-red-500/25"
+        >
+          {ta("delete")}
+        </button>
+      </div>
+    </article>
+  );
+}
+
 interface ApplicationTableProps {
   applications: Application[];
   onEdit: (app: Application) => void;
@@ -203,48 +296,69 @@ export function ApplicationTable({ applications, onEdit, onDelete, onArchive, sh
 
   return (
     <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden">
-      {/* Filters */}
-      <div className="p-4 border-b border-gray-100 dark:border-gray-700 flex flex-wrap gap-3">
-        <input
-          type="text"
-          value={globalFilter}
-          onChange={(e) => setGlobalFilter(e.target.value)}
-          placeholder={ta("search")}
-          className="border border-gray-200 dark:border-gray-600 rounded-lg px-3 py-2 text-sm text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 w-52 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-        />
-        <select
-          value={statusFilter || ""}
-          onChange={(e) => {
-            if (e.target.value) {
-              setColumnFilters([{ id: "status", value: e.target.value }]);
-            } else {
-              setColumnFilters([]);
-            }
-          }}
-          className="border border-gray-200 dark:border-gray-600 rounded-lg px-3 py-2 text-sm text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-        >
-          <option value="">{ta("all_statuses")}</option>
-          {STATUS_ORDER.map((value) => (
-            <option key={value} value={value}>
-              {ts(value)}
-            </option>
-          ))}
-        </select>
-        {(globalFilter || statusFilter) && (
-          <button
-            onClick={() => {
-              setGlobalFilter("");
-              setColumnFilters([]);
+      <div className="sticky top-16 z-[5] border-b border-gray-100 bg-white/95 p-4 backdrop-blur dark:border-gray-700 dark:bg-gray-800/95">
+        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+          <input
+            type="text"
+            value={globalFilter}
+            onChange={(e) => setGlobalFilter(e.target.value)}
+            placeholder={ta("search")}
+            className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 sm:w-52"
+          />
+          <select
+            value={statusFilter || ""}
+            onChange={(e) => {
+              if (e.target.value) {
+                setColumnFilters([{ id: "status", value: e.target.value }]);
+              } else {
+                setColumnFilters([]);
+              }
             }}
-            className="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 underline"
+            className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 sm:w-auto"
           >
-            {ta("filter_reset")}
-          </button>
+            <option value="">{ta("all_statuses")}</option>
+            {STATUS_ORDER.map((value) => (
+              <option key={value} value={value}>
+                {ts(value)}
+              </option>
+            ))}
+          </select>
+          {(globalFilter || statusFilter) && (
+            <button
+              onClick={() => {
+                setGlobalFilter("");
+                setColumnFilters([]);
+              }}
+              className="text-left text-sm text-gray-500 underline hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 sm:text-center"
+            >
+              {ta("filter_reset")}
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="p-3 md:hidden">
+        {table.getRowModel().rows.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-gray-200 px-4 py-10 text-center text-sm text-gray-400 dark:border-gray-700 dark:text-gray-500">
+            {t("empty")}
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {table.getRowModel().rows.map((row) => (
+              <MobileApplicationCard
+                key={row.id}
+                app={row.original}
+                onEdit={onEdit}
+                onDelete={onDelete}
+                onArchive={onArchive}
+                showArchived={showArchived}
+              />
+            ))}
+          </div>
         )}
       </div>
 
-      {/* Table */}
-      <div className="overflow-x-auto">
+      <div className="hidden overflow-x-auto md:block">
         <table className="w-full">
           <thead>
             {table.getHeaderGroups().map((headerGroup) => (
@@ -298,7 +412,6 @@ export function ApplicationTable({ applications, onEdit, onDelete, onArchive, sh
         </table>
       </div>
 
-      {/* Footer */}
       <div className="px-4 py-3 border-t border-gray-100 dark:border-gray-700 text-xs text-gray-400 dark:text-gray-500">
         {t("count", {
           filtered: table.getFilteredRowModel().rows.length,

--- a/components/kanban-view.tsx
+++ b/components/kanban-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import { format, isPast, isToday } from "date-fns";
 import { useQueryClient } from "@tanstack/react-query";
@@ -21,8 +21,6 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import { Application, ApplicationStatus, STATUS_COLORS, STATUS_ORDER } from "@/types";
 
-// ── API ──────────────────────────────────────────────────────────────────────
-
 async function patchStatus(id: string, status: ApplicationStatus): Promise<Application> {
   const res = await fetch(`/api/applications/${id}`, {
     method: "PATCH",
@@ -33,8 +31,6 @@ async function patchStatus(id: string, status: ApplicationStatus): Promise<Appli
   return res.json();
 }
 
-// ── Card ─────────────────────────────────────────────────────────────────────
-
 interface CardProps {
   app: Application;
   onEdit: (a: Application) => void;
@@ -42,6 +38,7 @@ interface CardProps {
 }
 
 function KanbanCard({ app, onEdit, isDragging = false }: CardProps) {
+  const ts = useTranslations("status");
   const followUpDate = app.followUpAt ? new Date(app.followUpAt) : null;
   const isOverdue = followUpDate && isPast(followUpDate) && !isToday(followUpDate);
   const isDueToday = followUpDate && isToday(followUpDate);
@@ -57,30 +54,34 @@ function KanbanCard({ app, onEdit, isDragging = false }: CardProps) {
         }
       `}
     >
-      <div className="font-semibold text-gray-900 dark:text-white text-sm group-hover:text-blue-700 dark:group-hover:text-blue-400 truncate">
-        {app.company}
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="font-semibold text-gray-900 dark:text-white text-sm group-hover:text-blue-700 dark:group-hover:text-blue-400 truncate">
+            {app.company}
+          </div>
+          <div className="text-xs text-gray-500 dark:text-gray-300 mt-0.5 truncate">{app.role}</div>
+        </div>
+        <span className={`inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[11px] font-semibold ${STATUS_COLORS[app.status]}`}>
+          {ts(app.status)}
+        </span>
       </div>
-      <div className="text-xs text-gray-500 dark:text-gray-300 mt-0.5 truncate">{app.role}</div>
 
-      {app.appliedAt && (
-        <div className="text-xs text-gray-400 dark:text-gray-400 mt-2">
-          {format(new Date(app.appliedAt), "dd.MM.yy")}
-        </div>
-      )}
-
-      {followUpDate && (
-        <div
-          className={`text-xs mt-1 font-medium ${
-            isOverdue ? "text-red-600 dark:text-red-400" : isDueToday ? "text-orange-500 dark:text-orange-400" : "text-blue-600 dark:text-blue-400"
-          }`}
-        >
-          {isOverdue ? "⚠ " : isDueToday ? "🔔 " : "📅 "}
-          {format(followUpDate, "dd.MM.yy")}
-        </div>
-      )}
+      <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs text-gray-400 dark:text-gray-400">
+        {app.appliedAt && <span>{format(new Date(app.appliedAt), "dd.MM.yy")}</span>}
+        {followUpDate && (
+          <span
+            className={`font-medium ${
+              isOverdue ? "text-red-600 dark:text-red-400" : isDueToday ? "text-orange-500 dark:text-orange-400" : "text-blue-600 dark:text-blue-400"
+            }`}
+          >
+            {isOverdue ? "⚠ " : isDueToday ? "🔔 " : "📅 "}
+            {format(followUpDate, "dd.MM.yy")}
+          </span>
+        )}
+      </div>
 
       {app.notes && (
-        <div className="text-xs text-gray-400 dark:text-gray-400 mt-1.5 truncate" title={app.notes}>
+        <div className="mt-2 max-h-10 overflow-hidden text-xs text-gray-500 dark:text-gray-400" title={app.notes}>
           {app.notes}
         </div>
       )}
@@ -88,17 +89,13 @@ function KanbanCard({ app, onEdit, isDragging = false }: CardProps) {
   );
 }
 
-// ── Draggable wrapper ─────────────────────────────────────────────────────────
-
 function DraggableCard({ app, onEdit }: { app: Application; onEdit: (a: Application) => void }) {
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
     id: app.id,
     data: { app },
   });
 
-  const style = transform
-    ? { transform: CSS.Translate.toString(transform) }
-    : undefined;
+  const style = transform ? { transform: CSS.Translate.toString(transform) } : undefined;
 
   return (
     <div
@@ -112,8 +109,6 @@ function DraggableCard({ app, onEdit }: { app: Application; onEdit: (a: Applicat
     </div>
   );
 }
-
-// ── Droppable Column ──────────────────────────────────────────────────────────
 
 interface KanbanColumnProps {
   status: ApplicationStatus;
@@ -130,11 +125,7 @@ function KanbanColumn({ status, apps, onEdit, isOver }: KanbanColumnProps) {
   const { setNodeRef } = useDroppable({ id: status });
 
   return (
-    // Column: fixed width so it never gets squeezed.
-    // On mobile the parent snap-scroll makes one column fill ~85vw;
-    // on md+ each column is exactly 260px wide.
     <div className="flex flex-col w-full">
-      {/* Header */}
       <div className="flex items-center gap-2 mb-3">
         <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold ${colorClass}`}>
           {ts(status)}
@@ -142,7 +133,6 @@ function KanbanColumn({ status, apps, onEdit, isOver }: KanbanColumnProps) {
         <span className="text-xs text-gray-400 dark:text-gray-400 font-medium">{apps.length}</span>
       </div>
 
-      {/* Drop zone — scrolls independently so long columns don't blow the page height */}
       <div
         ref={setNodeRef}
         className={`
@@ -165,33 +155,45 @@ function KanbanColumn({ status, apps, onEdit, isOver }: KanbanColumnProps) {
   );
 }
 
-// ── Main View ─────────────────────────────────────────────────────────────────
-
 interface KanbanViewProps {
   applications: Application[];
   onEdit: (app: Application) => void;
 }
 
 export function KanbanView({ applications, onEdit }: KanbanViewProps) {
+  const ts = useTranslations("status");
+  const tk = useTranslations("kanban");
   const queryClient = useQueryClient();
   const [activeApp, setActiveApp] = useState<Application | null>(null);
   const [overColumnId, setOverColumnId] = useState<UniqueIdentifier | null>(null);
+  const [selectedStatus, setSelectedStatus] = useState<ApplicationStatus>(() => {
+    const firstWithItems = STATUS_ORDER.find((status) =>
+      applications.some((app) => app.status === status)
+    );
+    return firstWithItems ?? STATUS_ORDER[0];
+  });
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
-      // Require a small movement before activating drag — preserves click-to-edit
       activationConstraint: { distance: 8 },
     }),
     useSensor(TouchSensor, {
-      // Short delay + tolerance so taps still open cards, swipes drag
       activationConstraint: { delay: 250, tolerance: 5 },
     })
   );
 
-  const grouped: Record<ApplicationStatus, Application[]> = {} as Record<ApplicationStatus, Application[]>;
-  for (const status of STATUS_ORDER) {
-    grouped[status] = applications.filter((a) => a.status === status);
-  }
+  const grouped = useMemo(() => {
+    const next = {} as Record<ApplicationStatus, Application[]>;
+    for (const status of STATUS_ORDER) {
+      next[status] = applications.filter((a) => a.status === status);
+    }
+    return next;
+  }, [applications]);
+
+  const mobileStatuses = useMemo(
+    () => STATUS_ORDER.filter((status) => grouped[status].length > 0 || status === selectedStatus),
+    [grouped, selectedStatus]
+  );
 
   function handleDragStart(event: DragStartEvent) {
     const app = (event.active.data.current as { app: Application }).app;
@@ -214,19 +216,16 @@ export function KanbanView({ applications, onEdit }: KanbanViewProps) {
 
     if (app.status === newStatus) return;
 
-    // Optimistic update — swap status in the cache immediately
     queryClient.setQueryData<Application[]>(["applications"], (prev) =>
       prev?.map((a) => (a.id === app.id ? { ...a, status: newStatus } : a)) ?? []
     );
 
     try {
       const updated = await patchStatus(app.id, newStatus);
-      // Sync server response into cache
       queryClient.setQueryData<Application[]>(["applications"], (prev) =>
         prev?.map((a) => (a.id === updated.id ? updated : a)) ?? []
       );
     } catch {
-      // Revert on error
       queryClient.setQueryData<Application[]>(["applications"], (prev) =>
         prev?.map((a) => (a.id === app.id ? { ...a, status: app.status } : a)) ?? []
       );
@@ -234,46 +233,73 @@ export function KanbanView({ applications, onEdit }: KanbanViewProps) {
   }
 
   return (
-    <DndContext
-      sensors={sensors}
-      onDragStart={handleDragStart}
-      onDragOver={handleDragOver}
-      onDragEnd={handleDragEnd}
-    >
-      {/*
-        Outer container scrolls horizontally on both mobile and desktop.
+    <>
+      <div className="md:hidden space-y-4">
+        <div className="sticky top-16 z-[5] -mx-1 overflow-x-auto rounded-xl border border-gray-200 bg-white/95 px-1 py-1 backdrop-blur dark:border-gray-700 dark:bg-gray-800/95">
+          <div className="flex gap-2 px-1">
+            {mobileStatuses.map((status) => (
+              <button
+                key={status}
+                onClick={() => setSelectedStatus(status)}
+                className={`whitespace-nowrap rounded-full px-3 py-2 text-sm font-medium transition-colors ${
+                  selectedStatus === status
+                    ? "bg-blue-600 text-white"
+                    : "bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+                }`}
+              >
+                {ts(status)} · {grouped[status].length}
+              </button>
+            ))}
+          </div>
+        </div>
 
-        Mobile  (<md): snap-x + snap-mandatory → swipe one column at a time
-                       Each column: 85vw so the next one peeks from the right
-        Desktop (≥md): plain flex row, each column 260px wide, no snapping needed
-      */}
-      <div className="overflow-x-auto pb-4 -mx-1 px-1">
-        <div className="flex flex-nowrap gap-4 snap-x snap-mandatory md:snap-none">
-          {STATUS_ORDER.map((status) => (
-            // Snap anchor per column on mobile; fixed 260px on desktop
-            <div
-              key={status}
-              className="snap-center flex-none w-[85vw] md:w-[260px] flex flex-col"
-            >
-              <KanbanColumn
-                status={status}
-                apps={grouped[status]}
-                onEdit={onEdit}
-                isOver={overColumnId === (status as UniqueIdentifier)}
-              />
+        <div className="space-y-2">
+          {grouped[selectedStatus].length === 0 ? (
+            <div className="rounded-xl border border-dashed border-gray-200 px-4 py-10 text-center text-sm text-gray-400 dark:border-gray-700 dark:text-gray-500">
+              {tk("empty")}
             </div>
-          ))}
+          ) : (
+            grouped[selectedStatus].map((app) => (
+              <KanbanCard key={app.id} app={app} onEdit={onEdit} />
+            ))
+          )}
         </div>
       </div>
 
-      {/* Floating drag overlay — matches column card width */}
-      <DragOverlay dropAnimation={null}>
-        {activeApp ? (
-          <div className="w-[240px]">
-            <KanbanCard app={activeApp} onEdit={() => {}} isDragging />
+      <div className="hidden md:block">
+        <DndContext
+          sensors={sensors}
+          onDragStart={handleDragStart}
+          onDragOver={handleDragOver}
+          onDragEnd={handleDragEnd}
+        >
+          <div className="overflow-x-auto pb-4 -mx-1 px-1">
+            <div className="flex flex-nowrap gap-4">
+              {STATUS_ORDER.map((status) => (
+                <div
+                  key={status}
+                  className="flex-none w-[260px] flex flex-col"
+                >
+                  <KanbanColumn
+                    status={status}
+                    apps={grouped[status]}
+                    onEdit={onEdit}
+                    isOver={overColumnId === (status as UniqueIdentifier)}
+                  />
+                </div>
+              ))}
+            </div>
           </div>
-        ) : null}
-      </DragOverlay>
-    </DndContext>
+
+          <DragOverlay dropAnimation={null}>
+            {activeApp ? (
+              <div className="w-[240px]">
+                <KanbanCard app={activeApp} onEdit={() => {}} isDragging />
+              </div>
+            ) : null}
+          </DragOverlay>
+        </DndContext>
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- add a mobile-first card layout for application browsing while keeping the desktop table intact
- replace horizontal mobile kanban scrolling with a one-column status list and sticky status chips
- apply the same mobile card treatment to the read-only share page

## Testing
- npx eslint components/application-table.tsx components/kanban-view.tsx app/share/page.tsx

## Notes
- npm run lint still fails because of an existing issue in components/theme-switcher.tsx
- npm run build still fails because the repo is already missing Firebase admin/storage modules used outside this PR
