### PR TITLE
Allow public token access to document file downloads

### DIFF
--- a/app/api/documents/[id]/file/route.ts
+++ b/app/api/documents/[id]/file/route.ts
@@ -1,22 +1,32 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import { requireAuth } from "@/lib/session";
+import { safeCompare } from "@/lib/token";
 import { downloadFile, fileExists } from "@/lib/storage";
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  // Document file downloads always require proper authentication.
-  // The PUBLIC_READ_TOKEN is intentionally NOT accepted here — it is
-  // only meant for the read-only share page, not for downloading files.
+  // Allow access via session/Bearer auth OR via PUBLIC_READ_TOKEN query param
+  // (used for shared document links).
+  let readScopeUserId: string | null | undefined;
+
   const auth = await requireAuth();
-  if (!auth) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (auth) {
+    readScopeUserId = auth.readScopeUserId;
+  } else {
+    const token = request.nextUrl.searchParams.get("token");
+    const expectedToken = process.env.PUBLIC_READ_TOKEN;
+    if (!token || !expectedToken || !safeCompare(token, expectedToken)) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    // Valid public token — allow access to any document (null = no user scope)
+    readScopeUserId = null;
   }
 
   const { id } = await params;
-  const document = await getDb().getDocument(id, auth.readScopeUserId);
+  const document = await getDb().getDocument(id, readScopeUserId ?? null);
   if (!document) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }


### PR DESCRIPTION
## Summary
Modified the document file download endpoint to support access via public read token in addition to session/Bearer authentication. This enables shared document links to download files without requiring user authentication.

## Key Changes
- Added support for `PUBLIC_READ_TOKEN` query parameter authentication as an alternative to session-based auth
- Implemented secure token comparison using `safeCompare()` to prevent timing attacks
- Refactored authentication logic to handle both authenticated users and public token access
- When using public token, `readScopeUserId` is set to `null` to allow access to any document (no user scope restriction)
- Updated comments to clarify that public tokens are now accepted for file downloads (previously only for read-only share pages)

## Implementation Details
- The endpoint now checks for valid session/Bearer auth first
- If no session exists, it attempts to validate the `token` query parameter against `PUBLIC_READ_TOKEN` environment variable
- Uses `safeCompare()` for constant-time token comparison to mitigate timing-based attacks
- Maintains backward compatibility with existing session-based authentication

https://claude.ai/code/session_01T2MYQKtXDBgXEmjBy9me8Y