### PR TITLE
fix: analytics page crash — React Hook #310 violation

### DIFF
--- a/components/analytics-dashboard.tsx
+++ b/components/analytics-dashboard.tsx
@@ -46,28 +46,6 @@ export function AnalyticsDashboard() {
     queryFn: fetchApplications,
   });
 
-  if (isLoading) {
-    return (
-      <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-          <div className="flex items-center justify-center py-20">
-            <div className="w-8 h-8 border-2 border-blue-600 border-t-transparent rounded-full animate-spin" />
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  if (isError) {
-    return (
-      <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-          <div className="text-center py-20 text-red-500">Failed to load data.</div>
-        </div>
-      </div>
-    );
-  }
-
   const activeApps = useMemo(() => applications.filter((a) => !a.archivedAt), [applications]);
 
   // === Status Breakdown ===
@@ -171,6 +149,28 @@ export function AnalyticsDashboard() {
   }, [activeApps]);
 
   const hasData = activeApps.length > 0;
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <div className="flex items-center justify-center py-20">
+            <div className="w-8 h-8 border-2 border-blue-600 border-t-transparent rounded-full animate-spin" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <div className="text-center py-20 text-red-500">Failed to load data.</div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">


### PR DESCRIPTION
## Summary
- Moved all `useMemo` hooks above the loading/error early returns in `AnalyticsDashboard`
- Hooks were being called conditionally (after `if (isLoading) return ...`), violating React's Rules of Hooks and causing a full white-screen crash

## Changes
- `components/analytics-dashboard.tsx`: Reordered hook calls to run unconditionally before any early returns

## Test plan
- [ ] Navigate to `/analytics` — page renders without crash
- [ ] Verify charts display correctly with data
- [ ] Verify loading spinner still shows while fetching

Closes #32