### PR TITLE
fix: modal default status + duplicate badge

### DIFF
--- a/components/application-modal.tsx
+++ b/components/application-modal.tsx
@@ -129,7 +129,7 @@ export function ApplicationModal({ application, onClose }: ApplicationModalProps
   const [form, setForm] = useState<FormData>({
     company: application?.company || "",
     role: application?.role || "",
-    status: (application?.status as ApplicationStatus) || "applied",
+    status: (application?.status as ApplicationStatus) || "inbound",
     appliedAt: toDateInput(application?.appliedAt),
     lastContact: toDateInput(application?.lastContact),
     followUpAt: toDateInput(application?.followUpAt),
@@ -353,11 +353,6 @@ export function ApplicationModal({ application, onClose }: ApplicationModalProps
                 </option>
               ))}
             </select>
-            <div className="mt-1.5">
-              <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_COLORS[form.status]}`}>
-                {ts(form.status)}
-              </span>
-            </div>
           </div>
 
           <div>


### PR DESCRIPTION
## Summary
- Default status for new opportunities changed from "Kontaktiert" (applied) to "Neuer Lead" (inbound)
- Removed duplicate StatusBadge that rendered below the status dropdown

## Changes
- `components/application-modal.tsx`: Default status → `"inbound"`, removed badge div below select

## Test plan
- [ ] Open "+ Neue Opportunity" — status defaults to "Neuer Lead"
- [ ] No colored badge appears below the status dropdown
- [ ] Editing existing opportunity preserves its current status

Closes #33