### PR TITLE
fix: mobile card overlap + move API key to settings

### DIFF
--- a/components/application-table.tsx
+++ b/components/application-table.tsx
@@ -390,7 +390,7 @@ export function ApplicationTable({ applications, onEdit, onDelete, onArchive, sh
         </div>
       </div>
 
-      <div className="p-3 md:hidden">
+      <div className="p-3 pt-4 md:hidden">
         {table.getRowModel().rows.length === 0 ? (
           <div className="rounded-xl border border-dashed border-gray-200 px-4 py-10 text-center text-sm text-gray-400 dark:border-gray-700 dark:text-gray-500">
             {t("empty")}

--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -14,7 +14,6 @@ import { Application, ApplicationStatus } from "@/types";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { format } from "date-fns";
-import { ApiToken } from "./api-token";
 
 interface DashboardProps {
   user: {
@@ -100,7 +99,6 @@ export function Dashboard({ user, shareUrl }: DashboardProps) {
   const [viewMode, setViewMode] = useState<ViewMode>("table");
   const [showArchived, setShowArchived] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const [isApiTokenPanelOpen, setIsApiTokenPanelOpen] = useState(false);
 
   const { data: applications = [], isLoading, isError } = useQuery({
     queryKey: ["applications"],
@@ -210,14 +208,6 @@ export function Dashboard({ user, shareUrl }: DashboardProps) {
                   🛡️ {tn("settings")}
                 </Link>
               )}
-              <button
-                onClick={() => setIsApiTokenPanelOpen((v) => !v)}
-                className={`flex items-center min-h-[44px] px-2 text-sm font-medium transition-colors ${
-                  isApiTokenPanelOpen ? "text-blue-600" : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-white"
-                }`}
-              >
-                🔑 API
-              </button>
               <Link
                 href="/documents"
                 className="flex items-center min-h-[44px] px-2 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-white transition-colors"
@@ -328,12 +318,6 @@ export function Dashboard({ user, shareUrl }: DashboardProps) {
           <StatCard label={ts("offers")} value={stats.offers} color="green" />
           <StatCard label={ts("rejected")} value={stats.rejected} color="gray" />
         </div>
-
-        {isApiTokenPanelOpen && (
-          <div className="mb-8">
-            <ApiToken />
-          </div>
-        )}
 
         {/* Toolbar */}
         <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">

--- a/components/settings-client.tsx
+++ b/components/settings-client.tsx
@@ -10,6 +10,7 @@ import { AuditLog } from "./audit-log";
 import { AppSettingsPanel } from "./app-settings";
 import { EmailIntegration } from "./email-integration";
 import { ScannedEmails } from "./scanned-emails";
+import { ApiToken } from "./api-token";
 
 interface SettingsClientProps {
   user: {
@@ -60,6 +61,7 @@ export function SettingsClient({ user }: SettingsClientProps) {
       <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
         <EmailIntegration />
         <ScannedEmails />
+        <ApiToken />
         <AppSettingsPanel />
         {user.isAdmin && (
           <>


### PR DESCRIPTION
## Summary
- Fixed first mobile card being overlapped by the fixed navbar by adding top padding
- Moved API key management from dashboard header toggle to the Settings page

## Changes
- `components/application-table.tsx`: Added `pt-4` to mobile card container
- `components/dashboard.tsx`: Removed API token button/panel and import
- `components/settings-client.tsx`: Added `<ApiToken />` component to settings

## Test plan
- [ ] On mobile, first card in table view is fully visible (not under navbar)
- [ ] API key section appears on Settings page
- [ ] No API key button in dashboard header
- [ ] API key generate/revoke still works from Settings

Closes #29