### PR TITLE
fix(mobile): responsive modal layout for small viewports

### DIFF
--- a/components/application-modal.tsx
+++ b/components/application-modal.tsx
@@ -282,23 +282,23 @@ export function ApplicationModal({ application, onClose }: ApplicationModalProps
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm">
-      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-2xl w-full max-w-lg max-h-[90vh] overflow-y-auto">
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center sm:p-4 bg-black/50 backdrop-blur-sm">
+      <div className="bg-white dark:bg-gray-800 rounded-t-2xl sm:rounded-2xl shadow-2xl w-full max-w-lg max-h-[95vh] sm:max-h-[90vh] overflow-y-auto">
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100 dark:border-gray-700 sticky top-0 bg-white dark:bg-gray-800 rounded-t-2xl z-10">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+        <div className="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-gray-100 dark:border-gray-700 sticky top-0 bg-white dark:bg-gray-800 rounded-t-2xl z-10">
+          <h2 className="text-base sm:text-lg font-semibold text-gray-900 dark:text-white pr-2">
             {isEditing ? t("title_edit") : t("title_new")}
           </h2>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors text-xl leading-none"
+            className="shrink-0 flex items-center justify-center w-10 h-10 rounded-lg text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors text-xl leading-none"
           >
             ×
           </button>
         </div>
 
         {/* Form */}
-        <form onSubmit={handleSubmit} className="p-6 space-y-4">
+        <form onSubmit={handleSubmit} className="p-4 sm:p-6 space-y-4">
           {error && (
             <div className="p-3 bg-red-50 dark:bg-red-950/50 border border-red-200 dark:border-red-800/50 text-red-700 dark:text-red-400 rounded-lg text-sm">
               {error}
@@ -399,7 +399,7 @@ export function ApplicationModal({ application, onClose }: ApplicationModalProps
             <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
               {t("salary_range")}
             </label>
-            <div className="flex items-center gap-2">
+            <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2">
               <input
                 type="number"
                 name="salaryMin"
@@ -410,7 +410,7 @@ export function ApplicationModal({ application, onClose }: ApplicationModalProps
                 placeholder={t("salary_min_placeholder")}
                 className="w-full border border-gray-200 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               />
-              <span className="text-gray-400 text-sm shrink-0">–</span>
+              <span className="hidden sm:block text-gray-400 text-sm shrink-0">–</span>
               <input
                 type="number"
                 name="salaryMax"


### PR DESCRIPTION
## Summary
- Modal slides up from bottom on mobile (sheet-style), centered on desktop
- Fixed overlapping title/close button and cramped inputs on ~390px viewports

## Changes
- `components/application-modal.tsx`: Bottom-sheet pattern, larger close button tap target, stacked budget fields, responsive padding

## Test plan
- [ ] Open "Neue Opportunity" on ~390px viewport — modal fills screen from bottom
- [ ] Title readable, close button easily tappable (44px+)
- [ ] Budget fields stack vertically on mobile
- [ ] Desktop layout unchanged (centered modal)

Closes #36