### PR TITLE
feat: UX polish — clickable rows, stats, dates, form defaults, nav

### DIFF
--- a/components/application-modal.tsx
+++ b/components/application-modal.tsx
@@ -130,7 +130,7 @@ export function ApplicationModal({ application, onClose }: ApplicationModalProps
     company: application?.company || "",
     role: application?.role || "",
     status: (application?.status as ApplicationStatus) || "inbound",
-    appliedAt: toDateInput(application?.appliedAt),
+    appliedAt: toDateInput(application?.appliedAt) || (application ? "" : new Date().toISOString().split("T")[0]),
     lastContact: toDateInput(application?.lastContact),
     followUpAt: toDateInput(application?.followUpAt),
     notes: application?.notes || "",

--- a/components/application-table.tsx
+++ b/components/application-table.tsx
@@ -62,7 +62,7 @@ function FollowUpCell({ date }: { date: string | null }) {
     >
       {overdue && "⚠ "}
       {due && "🔔 "}
-      {format(d, "dd.MM.yy")}
+      {format(d, "dd.MM.yyyy")}
     </span>
   );
 }
@@ -197,7 +197,12 @@ export function ApplicationTable({ applications, onEdit, onDelete, onArchive, sh
       header: t("company"),
       cell: (info) => (
         <div className="flex items-center gap-1.5">
-          <span className="font-medium text-gray-900 dark:text-white">{info.getValue()}</span>
+          <button
+            onClick={() => onEdit(info.row.original)}
+            className="font-medium text-gray-900 dark:text-white hover:text-blue-600 dark:hover:text-blue-400 transition-colors text-left"
+          >
+            {info.getValue()}
+          </button>
           {info.row.original.remote && (
             <span className="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-semibold bg-emerald-100 text-emerald-800 dark:bg-emerald-500/20 dark:text-emerald-300">
               Remote
@@ -220,7 +225,7 @@ export function ApplicationTable({ applications, onEdit, onDelete, onArchive, sh
       cell: (info) => {
         const val = info.getValue();
         return val ? (
-          <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-cyan-100 text-cyan-800 dark:bg-cyan-500/20 dark:text-cyan-300">
+          <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-cyan-100 text-cyan-800 dark:bg-cyan-500/20 dark:text-cyan-300 whitespace-nowrap">
             {val}
           </span>
         ) : (

--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -158,6 +158,7 @@ export function Dashboard({ user, shareUrl }: DashboardProps) {
 
   const stats = {
     total: activeApplications.length,
+    inbound: activeApplications.filter((a) => a.status === "inbound").length,
     active: activeApplications.filter((a) =>
       (["applied", "interview"] as ApplicationStatus[]).includes(a.status)
     ).length,
@@ -206,7 +207,6 @@ export function Dashboard({ user, shareUrl }: DashboardProps) {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16 gap-3">
             <div className="flex min-w-0 items-center gap-3">
-              <span className="shrink-0 text-2xl">📊</span>
               <h1 className="truncate text-lg font-bold text-gray-900 dark:text-white sm:text-xl">
                 {customTitle || tapp("title")}
               </h1>
@@ -230,20 +230,20 @@ export function Dashboard({ user, shareUrl }: DashboardProps) {
                   href="/settings"
                   className="flex items-center min-h-[44px] px-2 text-sm font-medium text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-white transition-colors"
                 >
-                  🛡️ {tn("settings")}
+                  {tn("settings")}
                 </Link>
               )}
               <Link
                 href="/documents"
                 className="flex items-center min-h-[44px] px-2 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-white transition-colors"
               >
-                📁 {tn("documents")}
+                {tn("documents")}
               </Link>
               <Link
                 href="/analytics"
                 className="flex items-center min-h-[44px] px-2 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-white transition-colors"
               >
-                📊 {tn("analytics")}
+                {tn("analytics")}
               </Link>
               <a
                 href={shareUrl}
@@ -252,7 +252,7 @@ export function Dashboard({ user, shareUrl }: DashboardProps) {
                 className="flex items-center min-h-[44px] px-2 text-sm text-blue-500 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 transition-colors"
                 title="Client portal link"
               >
-                🔗 Share
+                Share
               </a>
               <button
                 onClick={handleLogout}
@@ -295,14 +295,14 @@ export function Dashboard({ user, shareUrl }: DashboardProps) {
               className="flex items-center gap-2 min-h-[44px] px-2 text-sm text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors"
               onClick={() => setMobileMenuOpen(false)}
             >
-              📁 {tn("documents")}
+              {tn("documents")}
             </Link>
             <Link
               href="/analytics"
               className="flex items-center gap-2 min-h-[44px] px-2 text-sm text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors"
               onClick={() => setMobileMenuOpen(false)}
             >
-              📊 {tn("analytics")}
+              {tn("analytics")}
             </Link>
             <a
               href={shareUrl}
@@ -311,7 +311,7 @@ export function Dashboard({ user, shareUrl }: DashboardProps) {
               className="flex items-center gap-2 min-h-[44px] px-2 text-sm text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 transition-colors"
               onClick={() => setMobileMenuOpen(false)}
             >
-              🔗 Share
+              Share
             </a>
             <button
               onClick={() => { handleLogout(); setMobileMenuOpen(false); }}
@@ -352,11 +352,12 @@ export function Dashboard({ user, shareUrl }: DashboardProps) {
         )}
 
         {/* Stats */}
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-8">
+        <div className="grid grid-cols-2 sm:grid-cols-5 gap-4 mb-8">
           <StatCard label={ts("total")} value={stats.total} color="blue" />
+          <StatCard label={ts("inbound")} value={stats.inbound} color="teal" />
           <StatCard label={ts("active")} value={stats.active} color="yellow" />
           <StatCard label={ts("offers")} value={stats.offers} color="green" />
-          <StatCard label={ts("rejected")} value={stats.rejected} color="gray" />
+          <StatCard label={ts("rejected")} value={stats.rejected} color="red" />
         </div>
 
         {/* Toolbar */}
@@ -462,13 +463,15 @@ function StatCard({
 }: {
   label: string;
   value: number;
-  color: "blue" | "yellow" | "green" | "gray";
+  color: "blue" | "teal" | "yellow" | "green" | "gray" | "red";
 }) {
   const colors = {
     blue: "bg-blue-50 text-blue-700 dark:bg-blue-500/15 dark:text-blue-300",
+    teal: "bg-teal-50 text-teal-700 dark:bg-teal-500/15 dark:text-teal-300",
     yellow: "bg-yellow-50 text-yellow-700 dark:bg-amber-500/15 dark:text-amber-300",
     green: "bg-green-50 text-green-700 dark:bg-emerald-500/15 dark:text-emerald-300",
     gray: "bg-gray-100 text-gray-600 dark:bg-gray-700/40 dark:text-gray-200",
+    red: "bg-red-50 text-red-600 dark:bg-red-500/15 dark:text-red-300",
   };
 
   return (

--- a/messages/de.json
+++ b/messages/de.json
@@ -13,6 +13,7 @@
   },
   "stats": {
     "total": "Gesamt",
+    "inbound": "Neue Leads",
     "active": "Aktiv",
     "offers": "Abschluss",
     "rejected": "Verloren"

--- a/messages/en.json
+++ b/messages/en.json
@@ -13,6 +13,7 @@
   },
   "stats": {
     "total": "Total",
+    "inbound": "New Leads",
     "active": "Active",
     "offers": "Closing",
     "rejected": "Lost"


### PR DESCRIPTION
## Summary
Bundle of 7 UX improvements addressing daily usability friction.

## Changes
1. **Click company name to edit** — table company cell is now a clickable button opening the edit modal
2. **Consistent date format** — follow-up dates now use `dd.MM.yyyy` (was `dd.MM.yy`)
3. **"Neue Leads" stat tile** — added inbound count tile so all statuses are visible in stats
4. **"Erstellt am" default** — new opportunity form defaults applied date to today
5. **"Verloren" tile color** — changed from gray to red for visual completeness
6. **Source badge nowrap** — `linkedin-inmail` no longer wraps inside its badge
7. **Nav emoji removal** — removed inconsistent emoji icons from navigation for cleaner look

## Test plan
- [ ] Click company name in table → edit modal opens
- [ ] Follow-up dates show 4-digit year (dd.MM.yyyy)
- [ ] 5 stat tiles visible: Gesamt, Neue Leads, Aktiv, Abschluss, Verloren
- [ ] New opportunity form has today's date pre-filled in "Erstellt am"
- [ ] Verloren tile has red background
- [ ] Source badges don't wrap
- [ ] No emojis in nav items

Closes #37