### PR TITLE
🔒 Fix race condition in admin demotion check

### DIFF
--- a/app/api/admin/users/[id]/route.ts
+++ b/app/api/admin/users/[id]/route.ts
@@ -26,23 +26,25 @@ export async function PATCH(
     );
   }
 
-  const users = await getDb().listUsers();
-  const target = users.find((user) => user.id === id);
+  const db = getDb();
 
+  const target = await db.getUser(id);
   if (!target) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
 
-  const adminCount = users.filter((user) => user.isAdmin).length;
-  if (target.isAdmin && !body.isAdmin && adminCount <= 1) {
-    return NextResponse.json(
-      { error: "At least one admin user is required" },
-      { status: 400 }
-    );
+  let updated;
+  try {
+    updated = await db.updateUserAdmin(id, body.isAdmin);
+  } catch (error) {
+    if (error instanceof Error && error.message === "AT_LEAST_ONE_ADMIN_REQUIRED") {
+      return NextResponse.json(
+        { error: "At least one admin user is required" },
+        { status: 400 }
+      );
+    }
+    throw error;
   }
-
-  const db = getDb();
-  const updated = await db.updateUserAdmin(id, body.isAdmin);
 
   // Write audit log
   const action = body.isAdmin ? "grant_admin" : "revoke_admin";

--- a/lib/db/__tests__/admin-security.test.ts
+++ b/lib/db/__tests__/admin-security.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PrismaAdapter } from "../prisma-adapter";
+import { prisma } from "@/lib/prisma";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    user: {
+      count: vi.fn(),
+      update: vi.fn(),
+      findUnique: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}));
+
+describe("PrismaAdapter — updateUserAdmin security", () => {
+  let adapter: PrismaAdapter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adapter = new PrismaAdapter();
+  });
+
+  it("allows granting admin status", async () => {
+    const mockUser = { id: "user-1", isAdmin: true, email: "admin@example.com", name: "Admin" };
+    (prisma.$transaction as any).mockImplementation(async (callback: any) => {
+      return callback(prisma);
+    });
+    (prisma.user.update as any).mockResolvedValue(mockUser);
+
+    const result = await adapter.updateUserAdmin("user-1", true);
+
+    expect(result.isAdmin).toBe(true);
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      data: { isAdmin: true },
+      select: { id: true, name: true, email: true, isAdmin: true },
+    });
+  });
+
+  it("prevents demoting the last admin", async () => {
+    (prisma.$transaction as any).mockImplementation(async (callback: any) => {
+      return callback(prisma);
+    });
+    // Mock that there is only 1 admin
+    (prisma.user.count as any).mockResolvedValue(1);
+    // Mock that the user being updated IS an admin
+    (prisma.user.findUnique as any).mockResolvedValue({ id: "user-1", isAdmin: true });
+
+    await expect(adapter.updateUserAdmin("user-1", false))
+      .rejects.toThrow("AT_LEAST_ONE_ADMIN_REQUIRED");
+
+    expect(prisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it("allows demoting an admin if there are others", async () => {
+    const mockUser = { id: "user-1", isAdmin: false, email: "user@example.com", name: "User" };
+    (prisma.$transaction as any).mockImplementation(async (callback: any) => {
+      return callback(prisma);
+    });
+    // Mock that there are 2 admins
+    (prisma.user.count as any).mockResolvedValue(2);
+    // Mock that the user being updated IS an admin
+    (prisma.user.findUnique as any).mockResolvedValue({ id: "user-1", isAdmin: true });
+    (prisma.user.update as any).mockResolvedValue(mockUser);
+
+    const result = await adapter.updateUserAdmin("user-1", false);
+
+    expect(result.isAdmin).toBe(false);
+    expect(prisma.user.update).toHaveBeenCalled();
+  });
+});

--- a/lib/db/firestore-adapter.ts
+++ b/lib/db/firestore-adapter.ts
@@ -690,10 +690,32 @@ export class FirestoreAdapter implements DatabaseAdapter {
   }
 
   async updateUserAdmin(id: string, isAdmin: boolean): Promise<UserRecord> {
-    return prisma.user.update({
-      where: { id },
-      data: { isAdmin },
-      select: { id: true, name: true, email: true, isAdmin: true },
+    return prisma.$transaction(async (tx) => {
+      // If we are trying to demote an admin, ensure at least one admin remains
+      if (!isAdmin) {
+        const target = await tx.user.findUnique({
+          where: { id },
+          select: { isAdmin: true },
+        });
+
+        if (target?.isAdmin) {
+          const adminCount = await tx.user.count({
+            where: { isAdmin: true },
+          });
+
+          if (adminCount <= 1) {
+            throw new Error("AT_LEAST_ONE_ADMIN_REQUIRED");
+          }
+        }
+      }
+
+      return tx.user.update({
+        where: { id },
+        data: { isAdmin },
+        select: { id: true, name: true, email: true, isAdmin: true },
+      });
+    }, {
+      isolationLevel: "Serializable",
     });
   }
 

--- a/lib/db/prisma-adapter.ts
+++ b/lib/db/prisma-adapter.ts
@@ -503,10 +503,32 @@ export class PrismaAdapter implements DatabaseAdapter {
   }
 
   async updateUserAdmin(id: string, isAdmin: boolean): Promise<UserRecord> {
-    return prisma.user.update({
-      where: { id },
-      data: { isAdmin },
-      select: { id: true, name: true, email: true, isAdmin: true },
+    return prisma.$transaction(async (tx) => {
+      // If we are trying to demote an admin, ensure at least one admin remains
+      if (!isAdmin) {
+        const target = await tx.user.findUnique({
+          where: { id },
+          select: { isAdmin: true },
+        });
+
+        if (target?.isAdmin) {
+          const adminCount = await tx.user.count({
+            where: { isAdmin: true },
+          });
+
+          if (adminCount <= 1) {
+            throw new Error("AT_LEAST_ONE_ADMIN_REQUIRED");
+          }
+        }
+      }
+
+      return tx.user.update({
+        where: { id },
+        data: { isAdmin },
+        select: { id: true, name: true, email: true, isAdmin: true },
+      });
+    }, {
+      isolationLevel: "Serializable",
     });
   }
 


### PR DESCRIPTION
🎯 **What:** Fixed a race condition in the admin demotion logic that could lead to a system with zero administrators.

⚠️ **Risk:** If left unfixed, an attacker (or accidental concurrent actions) could demote all administrators, locking everyone out of administrative functions and requiring manual database intervention.

🛡️ **Solution:** Moved the admin count validation into a database transaction using the `Serializable` isolation level. This ensures that the check for the last admin and the subsequent demotion happen as an atomic unit, preventing concurrent updates from compromising the system.

---
*PR created automatically by Jules for task [7105417211860944763](https://jules.google.com/task/7105417211860944763) started by @5queezer*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents removal of the last admin user from the system, ensuring at least one admin always exists for account management.

* **Tests**
  * Added comprehensive security tests for admin role management functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->