### PR TITLE
Let MCP clients round-trip document files

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,8 @@ Nexus CRM exposes a [Model Context Protocol](https://modelcontextprotocol.io) se
 | `delete_contact` | Delete a contact |
 | `list_documents` | List all documents |
 | `get_document` | Get document by ID |
+| `upload_document_content` | Upload a document from base64 content |
+| `download_document_content` | Download document content as base64 or signed URL |
 | `update_document_links` | Update document-application links |
 | `delete_document` | Delete a document |
 

--- a/app/api/documents/route.ts
+++ b/app/api/documents/route.ts
@@ -1,17 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import { requireAuth } from "@/lib/session";
-import { uploadFile } from "@/lib/storage";
-import crypto from "crypto";
-
-const MAX_SIZE = 10 * 1024 * 1024; // 10 MB
-const ALLOWED_TYPES = ["application/pdf", "image/jpeg", "image/png", "image/webp"];
-const MIME_TO_EXT: Record<string, string> = {
-  "application/pdf": ".pdf",
-  "image/jpeg": ".jpg",
-  "image/png": ".png",
-  "image/webp": ".webp",
-};
+import {
+  DocumentUploadError,
+  MAX_DOCUMENT_UPLOAD_SIZE,
+  uploadDocument,
+} from "@/lib/documents/upload";
 
 export async function GET(_request: NextRequest) {
   const auth = await requireAuth();
@@ -37,23 +31,9 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "No file provided" }, { status: 400 });
   }
 
-  if (file.size > MAX_SIZE) {
+  if (file.size > MAX_DOCUMENT_UPLOAD_SIZE) {
     return NextResponse.json({ error: "File too large (max 10 MB)" }, { status: 413 });
   }
-
-  if (!ALLOWED_TYPES.includes(file.type)) {
-    return NextResponse.json(
-      { error: "Unsupported file type. Allowed: PDF, JPEG, PNG, WEBP" },
-      { status: 415 }
-    );
-  }
-
-  // Derive extension from validated MIME type, not user-supplied filename
-  const ext = MIME_TO_EXT[file.type] || ".pdf";
-  const storedFilename = `${crypto.randomUUID()}${ext}`;
-
-  const buffer = Buffer.from(await file.arrayBuffer());
-  await uploadFile(storedFilename, buffer, file.type);
 
   let applicationIds: string[] = [];
   if (applicationIdsRaw) {
@@ -67,13 +47,20 @@ export async function POST(request: NextRequest) {
     }
   }
 
-  const document = await getDb().createDocument(auth.userId, {
-    filename: storedFilename,
-    originalName: file.name.slice(0, 255),
-    size: file.size,
-    mimeType: file.type,
-    applicationIds,
-  });
-
-  return NextResponse.json(document, { status: 201 });
+  try {
+    const document = await uploadDocument({
+      userId: auth.userId,
+      originalName: file.name,
+      mimeType: file.type,
+      buffer: Buffer.from(await file.arrayBuffer()),
+      applicationIds,
+    });
+    return NextResponse.json(document, { status: 201 });
+  } catch (err) {
+    if (err instanceof DocumentUploadError) {
+      const status = err.code === "too_large" ? 413 : 415;
+      return NextResponse.json({ error: err.message }, { status });
+    }
+    throw err;
+  }
 }

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -9,6 +9,7 @@ import { normalizeStatus } from "@/types";
 import { verifyMcpAccessToken } from "@/lib/mcp-oauth";
 import { generateAndStoreCv } from "@/lib/cv/generate";
 import { downloadDocumentContent } from "@/lib/documents/download";
+import { uploadDocumentContent } from "@/lib/documents/upload";
 import type { SessionAuthResult, SessionUser } from "@/lib/session";
 import type { UpsertCvProfileInput } from "@/lib/db/types";
 
@@ -497,6 +498,20 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
         content: [{ type: "text", text: JSON.stringify(doc, null, 2) }],
       };
     }
+  );
+
+  server.tool(
+    "upload_document_content",
+    "Upload a document from base64 content. Supports PDF, JPEG, PNG, and WEBP files up to 10MB. Optionally links the uploaded document to applications owned by the authenticated user.",
+    {
+      filename: z.string().min(1).max(255).describe("Original filename to display, e.g. resume.pdf"),
+      mimeType: z
+        .enum(["application/pdf", "image/jpeg", "image/png", "image/webp"])
+        .describe("MIME type of the uploaded file"),
+      contentBase64: z.string().min(1).describe("Raw file bytes encoded as standard base64"),
+      applicationIds: z.array(z.string()).optional().describe("Application IDs to link"),
+    },
+    async (args) => uploadDocumentContent(args, auth.userId),
   );
 
   server.tool(

--- a/lib/documents/__tests__/upload.test.ts
+++ b/lib/documents/__tests__/upload.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockCreateDocument, mockUploadFile } = vi.hoisted(() => ({
+  mockCreateDocument: vi.fn(),
+  mockUploadFile: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  getDb: () => ({ createDocument: mockCreateDocument }),
+}));
+
+vi.mock("@/lib/storage", () => ({
+  uploadFile: mockUploadFile,
+}));
+
+import {
+  decodeBase64Content,
+  MAX_DOCUMENT_UPLOAD_SIZE,
+  uploadDocument,
+  uploadDocumentContent,
+} from "../upload";
+
+const PDF_BYTES = Buffer.from("%PDF-1.4\n%%EOF\n", "utf8");
+const fixtureDoc = {
+  id: "doc-1",
+  userId: "user-1",
+  filename: "stored.pdf",
+  originalName: "CV.pdf",
+  size: PDF_BYTES.length,
+  mimeType: "application/pdf",
+  uploadedAt: new Date("2025-01-01"),
+  applications: [],
+};
+
+describe("uploadDocument", () => {
+  beforeEach(() => {
+    mockCreateDocument.mockReset();
+    mockUploadFile.mockReset();
+    mockCreateDocument.mockResolvedValue(fixtureDoc);
+  });
+
+  it("stores validated content and creates a document record", async () => {
+    const doc = await uploadDocument({
+      userId: "user-1",
+      originalName: "CV.pdf",
+      mimeType: "application/pdf",
+      buffer: PDF_BYTES,
+      applicationIds: ["app-1"],
+    });
+
+    expect(doc).toBe(fixtureDoc);
+    expect(mockUploadFile).toHaveBeenCalledWith(
+      expect.stringMatching(/^[0-9a-f-]+\.pdf$/),
+      PDF_BYTES,
+      "application/pdf",
+    );
+    expect(mockCreateDocument).toHaveBeenCalledWith("user-1", {
+      filename: expect.stringMatching(/^[0-9a-f-]+\.pdf$/),
+      originalName: "CV.pdf",
+      size: PDF_BYTES.length,
+      mimeType: "application/pdf",
+      applicationIds: ["app-1"],
+    });
+  });
+
+  it("rejects files over 10MB before writing storage", async () => {
+    await expect(
+      uploadDocument({
+        userId: "user-1",
+        originalName: "big.pdf",
+        mimeType: "application/pdf",
+        buffer: Buffer.alloc(MAX_DOCUMENT_UPLOAD_SIZE + 1),
+      }),
+    ).rejects.toThrow(/too large/i);
+
+    expect(mockUploadFile).not.toHaveBeenCalled();
+    expect(mockCreateDocument).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsupported MIME types before writing storage", async () => {
+    await expect(
+      uploadDocument({
+        userId: "user-1",
+        originalName: "notes.txt",
+        mimeType: "text/plain",
+        buffer: Buffer.from("hello"),
+      }),
+    ).rejects.toThrow(/unsupported/i);
+
+    expect(mockUploadFile).not.toHaveBeenCalled();
+    expect(mockCreateDocument).not.toHaveBeenCalled();
+  });
+});
+
+describe("decodeBase64Content", () => {
+  it("decodes standard base64 content", () => {
+    expect(decodeBase64Content(PDF_BYTES.toString("base64")).equals(PDF_BYTES)).toBe(true);
+  });
+
+  it("rejects malformed base64", () => {
+    expect(() => decodeBase64Content("not base64!")).toThrow(/invalid base64/i);
+  });
+});
+
+describe("uploadDocumentContent", () => {
+  beforeEach(() => {
+    mockCreateDocument.mockReset();
+    mockUploadFile.mockReset();
+    mockCreateDocument.mockResolvedValue(fixtureDoc);
+  });
+
+  it("returns an MCP tool response with the created document", async () => {
+    const res = await uploadDocumentContent(
+      {
+        filename: "CV.pdf",
+        mimeType: "application/pdf",
+        contentBase64: PDF_BYTES.toString("base64"),
+      },
+      "user-1",
+    );
+
+    expect(res.isError).toBeUndefined();
+    expect(JSON.parse(res.content[0].text)).toMatchObject({
+      id: "doc-1",
+      originalName: "CV.pdf",
+    });
+  });
+
+  it("returns an MCP error response for invalid base64", async () => {
+    const res = await uploadDocumentContent(
+      {
+        filename: "CV.pdf",
+        mimeType: "application/pdf",
+        contentBase64: "@@",
+      },
+      "user-1",
+    );
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/invalid base64/i);
+    expect(mockUploadFile).not.toHaveBeenCalled();
+  });
+});

--- a/lib/documents/upload.ts
+++ b/lib/documents/upload.ts
@@ -1,0 +1,127 @@
+import crypto from "crypto";
+import { getDb } from "@/lib/db";
+import { uploadFile } from "@/lib/storage";
+import type { DocumentRecord } from "@/lib/db/types";
+
+export const MAX_DOCUMENT_UPLOAD_SIZE = 10 * 1024 * 1024; // 10 MB
+export const ALLOWED_DOCUMENT_MIME_TYPES = [
+  "application/pdf",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+] as const;
+
+const MIME_TO_EXT: Record<string, string> = {
+  "application/pdf": ".pdf",
+  "image/jpeg": ".jpg",
+  "image/png": ".png",
+  "image/webp": ".webp",
+};
+
+export type DocumentUploadErrorCode =
+  | "invalid_base64"
+  | "too_large"
+  | "unsupported_type";
+
+export class DocumentUploadError extends Error {
+  constructor(
+    readonly code: DocumentUploadErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "DocumentUploadError";
+  }
+}
+
+export type UploadDocumentInput = {
+  userId: string;
+  originalName: string;
+  mimeType: string;
+  buffer: Buffer;
+  applicationIds?: string[];
+};
+
+export type McpToolResponse = {
+  content: { type: "text"; text: string }[];
+  isError?: boolean;
+};
+
+export function decodeBase64Content(contentBase64: string): Buffer {
+  const normalized = contentBase64.replace(/\s/g, "");
+  if (!normalized || !/^[A-Za-z0-9+/]*={0,2}$/.test(normalized)) {
+    throw new DocumentUploadError("invalid_base64", "Invalid base64 content");
+  }
+
+  const decoded = Buffer.from(normalized, "base64");
+  const encoded = decoded.toString("base64");
+  if (encoded.replace(/=+$/, "") !== normalized.replace(/=+$/, "")) {
+    throw new DocumentUploadError("invalid_base64", "Invalid base64 content");
+  }
+
+  return decoded;
+}
+
+export async function uploadDocument({
+  userId,
+  originalName,
+  mimeType,
+  buffer,
+  applicationIds = [],
+}: UploadDocumentInput): Promise<DocumentRecord> {
+  if (buffer.length > MAX_DOCUMENT_UPLOAD_SIZE) {
+    throw new DocumentUploadError("too_large", "File too large (max 10 MB)");
+  }
+
+  if (!ALLOWED_DOCUMENT_MIME_TYPES.includes(mimeType as (typeof ALLOWED_DOCUMENT_MIME_TYPES)[number])) {
+    throw new DocumentUploadError(
+      "unsupported_type",
+      "Unsupported file type. Allowed: PDF, JPEG, PNG, WEBP",
+    );
+  }
+
+  const ext = MIME_TO_EXT[mimeType] || ".pdf";
+  const storedFilename = `${crypto.randomUUID()}${ext}`;
+  await uploadFile(storedFilename, buffer, mimeType);
+
+  return getDb().createDocument(userId, {
+    filename: storedFilename,
+    originalName: originalName.slice(0, 255),
+    size: buffer.length,
+    mimeType,
+    applicationIds,
+  });
+}
+
+export async function uploadDocumentContent(
+  args: {
+    filename: string;
+    mimeType: string;
+    contentBase64: string;
+    applicationIds?: string[];
+  },
+  userId: string,
+): Promise<McpToolResponse> {
+  try {
+    const doc = await uploadDocument({
+      userId,
+      originalName: args.filename,
+      mimeType: args.mimeType,
+      buffer: decodeBase64Content(args.contentBase64),
+      applicationIds: args.applicationIds,
+    });
+    return {
+      content: [{ type: "text", text: JSON.stringify(doc, null, 2) }],
+    };
+  } catch (err) {
+    if (err instanceof DocumentUploadError) {
+      return {
+        content: [{ type: "text", text: err.message }],
+        isError: true,
+      };
+    }
+    return {
+      content: [{ type: "text", text: "Failed to upload document" }],
+      isError: true,
+    };
+  }
+}

--- a/public/llm.txt
+++ b/public/llm.txt
@@ -56,7 +56,7 @@ Multi-tenant: each user only sees their own data. Admin users (isAdmin flag) byp
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
 | GET | /api/documents | session or token | List documents |
-| POST | /api/documents | session or token | Upload (multipart/form-data, field: file) |
+| POST | /api/documents | session or token | Upload (multipart/form-data, field: file; PDF/JPEG/PNG/WEBP up to 10MB) |
 | PATCH | /api/documents/:id | session or token | Update: rename (`{ "originalName": "new.pdf" }`) or update links (`{ "applicationIds": [...] }`) |
 | DELETE | /api/documents/:id | session or token | Delete |
 | GET | /api/documents/:id/file | session, token, or share token | Download file |
@@ -79,6 +79,14 @@ Multi-tenant: each user only sees their own data. Admin users (isAdmin flag) byp
 ## Application status values
 `inbound` | `applied` | `interview` | `offer` | `rejected`
 
+## MCP document tools
+- `list_documents`: list document metadata
+- `get_document`: get document metadata by ID
+- `upload_document_content`: upload PDF/JPEG/PNG/WEBP content up to 10MB using standard base64
+- `download_document_content`: download small files inline as base64; returns a signed URL for larger GCS-backed files
+- `update_document_links`: replace linked application IDs
+- `delete_document`: delete document metadata and stored content
+
 ## Example: create application via API token
 ```
 POST /api/applications
@@ -97,7 +105,7 @@ Content-Type: application/json
 ## Security notes
 - PUBLIC_READ_TOKEN is a server-side env var only
 - NEXT_PUBLIC_* env vars do NOT contain any tokens
-- Rate limiting: 60 req/min per IP on API routes
-- All inputs validated; max upload size 15MB
-- Row Level Security: userId enforced at query level via lib/tenant.ts
+- Rate limiting applies to API routes
+- All document uploads are type-checked and limited to 10MB
+- User scoping is enforced by the database adapter
 - Admin privileges managed per-user in the database, not via env vars


### PR DESCRIPTION
## Summary
- add `upload_document_content` MCP tool for base64 PDF/image uploads
- share REST and MCP document upload validation/storage logic
- document MCP upload/download tools in README and LLM guide

## Verification
- `npm test`
- `npm run lint`
- `./node_modules/.bin/tsc --noEmit`
- `npm run build`

Notes: build completed with existing Better Auth environment warnings for missing `BETTER_AUTH_URL`/`BETTER_AUTH_SECRET`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP tools for uploading documents as base64 and downloading documents as base64 or signed URL.
  * Document uploads now enforced with 10MB size limit and restricted to PDF, JPEG, PNG, and WEBP formats.

* **Documentation**
  * Updated API documentation and security notes with explicit upload format requirements and size constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->