### PR TITLE
Keep uploads working when GCS credentials are absent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ WORKDIR /app
 ENV NODE_ENV=production
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
+RUN mkdir -p /app/uploads && chown nextjs:nodejs /app/uploads
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/public ./public

--- a/lib/__tests__/storage.test.ts
+++ b/lib/__tests__/storage.test.ts
@@ -1,0 +1,45 @@
+import { mkdtemp, readFile, rm } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@google-cloud/storage", () => ({
+  Storage: vi.fn(() => {
+    throw new Error("GCS should not be initialized");
+  }),
+}));
+
+const originalEnv = { ...process.env };
+const tempDirs: string[] = [];
+
+async function importFreshStorage() {
+  vi.resetModules();
+  return import("../storage");
+}
+
+describe("storage backend selection", () => {
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(async () => {
+    process.env = { ...originalEnv };
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it("falls back to local storage when explicit GCS credentials file is missing", async () => {
+    const uploadDir = await mkdtemp(path.join(tmpdir(), "nexus-storage-"));
+    tempDirs.push(uploadDir);
+
+    process.env.GCS_BUCKET = "configured-bucket";
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = path.join(uploadDir, "missing-key.json");
+    process.env.UPLOAD_DIR = uploadDir;
+
+    const { uploadFile, isGcsBacked } = await importFreshStorage();
+
+    await uploadFile("doc.pdf", Buffer.from("pdf bytes"), "application/pdf");
+
+    expect(isGcsBacked()).toBe(false);
+    await expect(readFile(path.join(uploadDir, "doc.pdf"), "utf8")).resolves.toBe("pdf bytes");
+  });
+});

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -3,7 +3,24 @@ import { writeFile, readFile, unlink, mkdir } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
 
-const useGCS = !!process.env.GCS_BUCKET;
+let warnedAboutMissingGcsCredentials = false;
+
+function shouldUseGcs(): boolean {
+  if (!process.env.GCS_BUCKET) return false;
+
+  const credentialsPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  if (credentialsPath && !existsSync(credentialsPath)) {
+    if (!warnedAboutMissingGcsCredentials) {
+      console.warn(
+        `[storage] GOOGLE_APPLICATION_CREDENTIALS points to missing file ${credentialsPath}; using local upload storage instead.`,
+      );
+      warnedAboutMissingGcsCredentials = true;
+    }
+    return false;
+  }
+
+  return true;
+}
 
 let storage: Storage;
 function getStorage() {
@@ -20,7 +37,7 @@ export async function uploadFile(
   buffer: Buffer,
   contentType: string,
 ): Promise<void> {
-  if (useGCS) {
+  if (shouldUseGcs()) {
     const file = getStorage().bucket(process.env.GCS_BUCKET!).file(filename);
     await file.save(buffer, { contentType });
   } else {
@@ -31,7 +48,7 @@ export async function uploadFile(
 }
 
 export async function downloadFile(filename: string): Promise<Buffer> {
-  if (useGCS) {
+  if (shouldUseGcs()) {
     const file = getStorage().bucket(process.env.GCS_BUCKET!).file(filename);
     const [contents] = await file.download();
     return Buffer.from(contents);
@@ -41,7 +58,7 @@ export async function downloadFile(filename: string): Promise<Buffer> {
 }
 
 export async function deleteFile(filename: string): Promise<void> {
-  if (useGCS) {
+  if (shouldUseGcs()) {
     const file = getStorage().bucket(process.env.GCS_BUCKET!).file(filename);
     await file.delete({ ignoreNotFound: true });
   } else {
@@ -54,7 +71,7 @@ export async function deleteFile(filename: string): Promise<void> {
 }
 
 export function fileExists(filename: string): Promise<boolean> {
-  if (useGCS) {
+  if (shouldUseGcs()) {
     const file = getStorage().bucket(process.env.GCS_BUCKET!).file(filename);
     return file.exists().then(([exists]) => exists);
   } else {
@@ -63,7 +80,7 @@ export function fileExists(filename: string): Promise<boolean> {
 }
 
 export function isGcsBacked(): boolean {
-  return useGCS;
+  return shouldUseGcs();
 }
 
 /**
@@ -74,7 +91,7 @@ export async function getSignedDownloadUrl(
   filename: string,
   expiresInSeconds = 300,
 ): Promise<string> {
-  if (!useGCS) {
+  if (!shouldUseGcs()) {
     throw new Error("Signed URLs require a GCS bucket");
   }
   const file = getStorage().bucket(process.env.GCS_BUCKET!).file(filename);


### PR DESCRIPTION
## Summary
- avoid initializing GCS when `GOOGLE_APPLICATION_CREDENTIALS` points at a missing file
- fall back to local upload storage for that misconfiguration while preserving Cloud Run ADC behavior
- create a writable `/app/uploads` directory in the runtime image
- add regression coverage for the missing-credentials fallback

## Investigation
The live `nexus.vasudev.xyz` domain resolves to the Coolify VPS (`95.216.170.229`), not the Cloud Run service. The active Nexus container logs showed:

```text
Error: The file at /run/secrets/gcs-key.json does not exist, or it is not a file. ENOENT: no such file or directory, lstat '/run/secrets'
```

The container has `GCS_BUCKET` and `GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/gcs-key.json`, but no secret mount.

## Verification
- `npm test`
- `npm run lint`
- `./node_modules/.bin/tsc --noEmit`
- `npm run build`

Notes: build completed with existing Better Auth environment warnings for missing local build env (`BETTER_AUTH_URL`, `BETTER_AUTH_SECRET`).