### PR TITLE
[codex] Route deploys to Hetzner

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -1,63 +1,78 @@
-name: Deploy to Cloud Run
+# Disabled: production deploys now target the Hetzner VPS through
+# .github/workflows/deploy-hetzner.yml. Keep this Cloud Run workflow commented
+# out so pushes to main do not trigger the wrong deployment target.
+
+name: Cloud Run deploy disabled
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
 
-env:
-  PROJECT_ID: job-tracker-vasudev
-  REGION: europe-west1
-  SERVICE: job-tracker
-  REPO: europe-west1-docker.pkg.dev/job-tracker-vasudev/job-tracker
-
 jobs:
-  deploy:
+  disabled:
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-      id-token: write
-
     steps:
-      - uses: actions/checkout@v4
+      - run: echo "Cloud Run deployment is disabled. Use the Deploy to Hetzner workflow."
 
-      - id: auth
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-
-      - uses: google-github-actions/setup-gcloud@v2
-
-      - name: Configure Docker
-        run: gcloud auth configure-docker europe-west1-docker.pkg.dev --quiet
-
-      - name: Prisma DB Push
-        run: |
-          npm ci
-          export DATABASE_URL=$(gcloud secrets versions access latest --secret="DATABASE_URL")
-          npx prisma db push --skip-generate
-
-      - name: Build and push
-        run: |
-          docker build -t ${{ env.REPO }}/app:${{ github.sha }} -t ${{ env.REPO }}/app:latest .
-          docker push ${{ env.REPO }}/app:${{ github.sha }}
-          docker push ${{ env.REPO }}/app:latest
-
-      - name: Deploy to Cloud Run
-        run: |
-          gcloud run deploy ${{ env.SERVICE }} \
-            --image ${{ env.REPO }}/app:${{ github.sha }} \
-            --region ${{ env.REGION }} \
-            --project ${{ env.PROJECT_ID }} \
-            --platform managed \
-            --allow-unauthenticated \
-            --port 8080 \
-            --memory 512Mi \
-            --cpu 1 \
-            --min-instances 0 \
-            --max-instances 2 \
-            --set-env-vars "NODE_ENV=production" \
-            --set-env-vars "GCS_BUCKET=job-tracker-vasudev-uploads" \
-            --set-secrets "DATABASE_URL=DATABASE_URL:latest,BETTER_AUTH_SECRET=BETTER_AUTH_SECRET:latest,BETTER_AUTH_URL=BETTER_AUTH_URL:latest,GOOGLE_CLIENT_ID=GOOGLE_CLIENT_ID:latest,GOOGLE_CLIENT_SECRET=GOOGLE_CLIENT_SECRET:latest,ALLOWED_EMAIL=ALLOWED_EMAIL:latest,PUBLIC_READ_TOKEN=PUBLIC_READ_TOKEN:latest,RR_API_URL=RR_API_URL:latest,RR_API_KEY=RR_API_KEY:latest,RR_BASE_RESUME_ID=RR_BASE_RESUME_ID:latest"
+# name: Deploy to Cloud Run
+#
+# on:
+#   push:
+#     branches: [main]
+#   workflow_dispatch:
+#
+# env:
+#   PROJECT_ID: job-tracker-vasudev
+#   REGION: europe-west1
+#   SERVICE: job-tracker
+#   REPO: europe-west1-docker.pkg.dev/job-tracker-vasudev/job-tracker
+#
+# jobs:
+#   deploy:
+#     runs-on: ubuntu-latest
+#
+#     permissions:
+#       contents: read
+#       id-token: write
+#
+#     steps:
+#       - uses: actions/checkout@v4
+#
+#       - id: auth
+#         uses: google-github-actions/auth@v2
+#         with:
+#           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+#           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+#
+#       - uses: google-github-actions/setup-gcloud@v2
+#
+#       - name: Configure Docker
+#         run: gcloud auth configure-docker europe-west1-docker.pkg.dev --quiet
+#
+#       - name: Prisma DB Push
+#         run: |
+#           npm ci
+#           export DATABASE_URL=$(gcloud secrets versions access latest --secret="DATABASE_URL")
+#           npx prisma db push --skip-generate
+#
+#       - name: Build and push
+#         run: |
+#           docker build -t ${{ env.REPO }}/app:${{ github.sha }} -t ${{ env.REPO }}/app:latest .
+#           docker push ${{ env.REPO }}/app:${{ github.sha }}
+#           docker push ${{ env.REPO }}/app:latest
+#
+#       - name: Deploy to Cloud Run
+#         run: |
+#           gcloud run deploy ${{ env.SERVICE }} \
+#             --image ${{ env.REPO }}/app:${{ github.sha }} \
+#             --region ${{ env.REGION }} \
+#             --project ${{ env.PROJECT_ID }} \
+#             --platform managed \
+#             --allow-unauthenticated \
+#             --port 8080 \
+#             --memory 512Mi \
+#             --cpu 1 \
+#             --min-instances 0 \
+#             --max-instances 2 \
+#             --set-env-vars "NODE_ENV=production" \
+#             --set-env-vars "GCS_BUCKET=job-tracker-vasudev-uploads" \
+#             --set-secrets "DATABASE_URL=DATABASE_URL:latest,BETTER_AUTH_SECRET=BETTER_AUTH_SECRET:latest,BETTER_AUTH_URL=BETTER_AUTH_URL:latest,GOOGLE_CLIENT_ID=GOOGLE_CLIENT_ID:latest,GOOGLE_CLIENT_SECRET=GOOGLE_CLIENT_SECRET:latest,ALLOWED_EMAIL=ALLOWED_EMAIL:latest,PUBLIC_READ_TOKEN=PUBLIC_READ_TOKEN:latest,RR_API_URL=RR_API_URL:latest,RR_API_KEY=RR_API_KEY:latest,RR_BASE_RESUME_ID=RR_BASE_RESUME_ID:latest"

--- a/.github/workflows/deploy-hetzner.yml
+++ b/.github/workflows/deploy-hetzner.yml
@@ -1,0 +1,42 @@
+name: Deploy to Hetzner
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  DEPLOY_PATH: ${{ vars.HETZNER_DEPLOY_PATH || '/root/job-tracker' }}
+  SERVICE_NAME: ${{ vars.HETZNER_SERVICE_NAME || 'job-tracker' }}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Deploy on Hetzner VPS
+        uses: appleboy/ssh-action@v1
+        env:
+          DEPLOY_PATH: ${{ env.DEPLOY_PATH }}
+          SERVICE_NAME: ${{ env.SERVICE_NAME }}
+        with:
+          host: ${{ secrets.HETZNER_HOST || secrets.SSH_HOST }}
+          username: ${{ secrets.HETZNER_USER || secrets.SSH_USER }}
+          key: ${{ secrets.HETZNER_SSH_KEY || secrets.SSH_KEY }}
+          port: ${{ secrets.HETZNER_PORT || '22' }}
+          envs: DEPLOY_PATH,SERVICE_NAME
+          script_stop: true
+          script: |
+            set -euo pipefail
+            cd "$DEPLOY_PATH"
+            git fetch --prune origin main
+            git checkout main
+            git pull --ff-only origin main
+            DEPLOY_PATH="$DEPLOY_PATH" SERVICE_NAME="$SERVICE_NAME" ./deploy.sh

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ A lead and opportunity management suite for tracking your sales pipeline. Manage
 | **Validation** | [Zod 4](https://zod.dev) — runtime schema validation |
 | **AI Integration** | [@modelcontextprotocol/sdk](https://modelcontextprotocol.io) — MCP server |
 | **File Storage** | Google Cloud Storage or local filesystem |
-| **Hosting** | [Google Cloud Run](https://cloud.google.com/run) — container hosting |
+| **Hosting** | Hetzner VPS with systemd |
 | **Database Hosting** | [Neon](https://neon.tech) — serverless PostgreSQL |
 | **Testing** | [Vitest 4](https://vitest.dev) |
-| **CI/CD** | GitHub Actions — lint, build, test, deploy to Cloud Run |
+| **CI/CD** | GitHub Actions — lint, build, test, deploy to Hetzner |
 
 ---
 
@@ -226,7 +226,8 @@ In development mode, if no Google OAuth session exists, a fake admin user (`dev@
 ├── docker-compose.yml            # Self-hosted deployment
 └── .github/workflows/
     ├── ci.yml                    # Lint + build + test
-    └── deploy-gcp.yml            # Cloud Run CI/CD
+    ├── deploy-hetzner.yml        # Hetzner VPS CI/CD
+    └── deploy-gcp.yml            # Disabled Cloud Run reference
 ```
 
 ### Database Adapter Layer
@@ -538,27 +539,28 @@ docker compose up -d
 
 The compose file mounts `./data` for the Prisma directory and `./uploads` for file storage.
 
-### GCP Cloud Run (CI/CD)
+### Hetzner VPS (CI/CD)
 
-The repo includes a GitHub Actions workflow (`.github/workflows/deploy-gcp.yml`) that on push to `main`:
+The active GitHub Actions deploy workflow is `.github/workflows/deploy-hetzner.yml`. On push to `main`, it SSHes into the Hetzner VPS, fast-forwards the server checkout, and runs `./deploy.sh`.
 
-1. Pushes schema updates (`prisma db push`)
-2. Builds a Docker image
-3. Pushes to Artifact Registry (`europe-west1`)
-4. Deploys to Cloud Run with secrets from Secret Manager
+Required GitHub secrets:
 
-Uses Workload Identity Federation — no service account keys. Requires these GitHub secrets:
+- `HETZNER_HOST` (or existing `SSH_HOST`)
+- `HETZNER_USER` (or existing `SSH_USER`)
+- `HETZNER_SSH_KEY` (or existing `SSH_KEY`)
+- `HETZNER_PORT` (optional; defaults to `22`)
 
-- `GCP_WORKLOAD_IDENTITY_PROVIDER`
-- `GCP_SERVICE_ACCOUNT`
+Optional repository variables:
 
-Cloud Run configuration: 512Mi memory, 1 CPU, 0–2 instances, port 8080.
+- `HETZNER_DEPLOY_PATH` (defaults to `/root/job-tracker`)
+- `HETZNER_SERVICE_NAME` (defaults to `job-tracker`)
+
+The old Cloud Run workflow in `.github/workflows/deploy-gcp.yml` is commented out so it cannot run on pushes to `main`.
 
 ### Manual / VPS
 
 ```bash
-npm run build
-./deploy.sh   # builds, copies standalone output, restarts systemd service
+./deploy.sh   # installs deps, applies migrations, builds, copies standalone output, restarts systemd service
 ```
 
 The standalone output (via `next.config.ts` `output: "standalone"`) produces a self-contained `server.js` in `.next/standalone/`.

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,8 +1,28 @@
 #!/bin/bash
-set -e
-cd /root/job-tracker
+set -euo pipefail
+
+DEPLOY_PATH="${DEPLOY_PATH:-/root/job-tracker}"
+SERVICE_NAME="${SERVICE_NAME:-job-tracker}"
+
+cd "$DEPLOY_PATH"
+
+if [ -z "${DATABASE_URL:-}" ]; then
+	if [ -f .env.production ]; then
+		set -a
+		. ./.env.production
+		set +a
+	elif [ -f .env ]; then
+		set -a
+		. ./.env
+		set +a
+	fi
+fi
+
+npm ci
+npx prisma generate
+npx prisma migrate deploy
 npm run build
 cp -r .next/static .next/standalone/.next/static
 cp -r public .next/standalone/public 2>/dev/null || true
-systemctl restart job-tracker
-echo "✅ Deployed"
+systemctl restart "$SERVICE_NAME"
+echo "Deployed"


### PR DESCRIPTION
## What changed

- Disabled the push-triggered Cloud Run deployment workflow while keeping the old Cloud Run commands commented as reference.
- Added an active Hetzner SSH deployment workflow for pushes to `main` and manual dispatch.
- Updated `deploy.sh` so the workflow can reuse it with configurable deploy path and systemd service defaults.
- Updated README deployment docs from Cloud Run to Hetzner.

## Why

The live deployment resolves to Hetzner, so the Cloud Run workflow was targeting the wrong platform and failing.

## Validation

- Parsed all workflow YAML files.
- Verified Cloud Run no longer has a push trigger.
- Verified Hetzner deploy has `push` and `workflow_dispatch` triggers.
- Ran `bash -n deploy.sh`.
- Ran `git diff --check` on the changed files.