### PR TITLE
Align Hetzner deploy workflow with Coolify

### DIFF
--- a/.github/workflows/deploy-hetzner.yml
+++ b/.github/workflows/deploy-hetzner.yml
@@ -10,12 +10,16 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DEPLOY_PATH: ${{ vars.HETZNER_DEPLOY_PATH || '/root/job-tracker' }}
-  SERVICE_NAME: ${{ vars.HETZNER_SERVICE_NAME || 'job-tracker' }}
+  COOLIFY_APP_DIR: ${{ vars.HETZNER_COOLIFY_APP_DIR || '/data/coolify/applications/tj4r2ezipwho1zvjhg78a5wu' }}
+  COOLIFY_SERVICE: ${{ vars.HETZNER_COOLIFY_SERVICE || 'tj4r2ezipwho1zvjhg78a5wu-064500973574' }}
+  COOLIFY_IMAGE: ${{ vars.HETZNER_COOLIFY_IMAGE || 'tj4r2ezipwho1zvjhg78a5wu' }}
+  DEPLOY_REPO_URL: ${{ vars.HETZNER_DEPLOY_REPO_URL || 'https://github.com/5queezer/nexus-crm.git' }}
+  AUTO_DEPLOY: ${{ vars.HETZNER_AUTO_DEPLOY || 'false' }}
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || vars.HETZNER_AUTO_DEPLOY == 'true'
 
     permissions:
       contents: read
@@ -24,19 +28,129 @@ jobs:
       - name: Deploy on Hetzner VPS
         uses: appleboy/ssh-action@v1
         env:
-          DEPLOY_PATH: ${{ env.DEPLOY_PATH }}
-          SERVICE_NAME: ${{ env.SERVICE_NAME }}
+          COOLIFY_APP_DIR: ${{ env.COOLIFY_APP_DIR }}
+          COOLIFY_SERVICE: ${{ env.COOLIFY_SERVICE }}
+          COOLIFY_IMAGE: ${{ env.COOLIFY_IMAGE }}
+          DEPLOY_REPO_URL: ${{ env.DEPLOY_REPO_URL }}
+          DEPLOY_SHA: ${{ github.sha }}
         with:
           host: ${{ secrets.HETZNER_HOST || secrets.SSH_HOST }}
           username: ${{ secrets.HETZNER_USER || secrets.SSH_USER }}
           key: ${{ secrets.HETZNER_SSH_KEY || secrets.SSH_KEY }}
           port: ${{ secrets.HETZNER_PORT || '22' }}
-          envs: DEPLOY_PATH,SERVICE_NAME
-          script_stop: true
+          envs: COOLIFY_APP_DIR,COOLIFY_SERVICE,COOLIFY_IMAGE,DEPLOY_REPO_URL,DEPLOY_SHA
           script: |
             set -euo pipefail
-            cd "$DEPLOY_PATH"
-            git fetch --prune origin main
-            git checkout main
-            git pull --ff-only origin main
-            DEPLOY_PATH="$DEPLOY_PATH" SERVICE_NAME="$SERVICE_NAME" ./deploy.sh
+
+            workdir="/tmp/nexus-crm-deploy"
+            rm -rf "$workdir"
+            git clone --depth 1 "$DEPLOY_REPO_URL" "$workdir"
+            cd "$workdir"
+            git fetch --depth 1 origin "$DEPLOY_SHA"
+            git checkout "$DEPLOY_SHA"
+
+            image_tag="${COOLIFY_IMAGE}:${DEPLOY_SHA}"
+            docker build -t "$image_tag" .
+
+            cd "$COOLIFY_APP_DIR"
+            cp docker-compose.yaml "docker-compose.yaml.before-${DEPLOY_SHA}-$(date +%Y%m%d%H%M%S)"
+
+            python3 - <<'PY'
+            import os
+            from pathlib import Path
+
+            compose_path = Path("docker-compose.yaml")
+            env_path = Path(".env")
+            service = os.environ["COOLIFY_SERVICE"]
+            image = f"{os.environ['COOLIFY_IMAGE']}:{os.environ['DEPLOY_SHA']}"
+            compose = compose_path.read_text()
+            lines = compose.splitlines()
+
+            in_service = False
+            service_indent = None
+            image_replaced = False
+            has_upload_mount = "nexus-crm-uploads:/app/uploads" in compose
+
+            out = []
+            for line in lines:
+                stripped = line.strip()
+                if stripped == f"{service}:":
+                    in_service = True
+                    service_indent = len(line) - len(line.lstrip())
+                    out.append(line)
+                    continue
+
+                if in_service and service_indent is not None:
+                    indent = len(line) - len(line.lstrip())
+                    if stripped and indent <= service_indent:
+                        if not has_upload_mount:
+                            out.extend([
+                                "        volumes:",
+                                "            - nexus-crm-uploads:/app/uploads",
+                            ])
+                            has_upload_mount = True
+                        in_service = False
+
+                    if in_service and stripped.startswith("image:"):
+                        out.append(f"        image: '{image}'")
+                        image_replaced = True
+                        continue
+
+                    if in_service and stripped == "labels:" and not has_upload_mount:
+                        out.extend([
+                            "        volumes:",
+                            "            - nexus-crm-uploads:/app/uploads",
+                        ])
+                        has_upload_mount = True
+
+                out.append(line)
+
+            if in_service and not has_upload_mount:
+                out.extend([
+                    "        volumes:",
+                    "            - nexus-crm-uploads:/app/uploads",
+                ])
+                has_upload_mount = True
+
+            if not image_replaced:
+                raise SystemExit(f"Could not replace image for service {service}")
+
+            result = "\n".join(out) + "\n"
+            if "\nvolumes:\n" not in result:
+                result = result.replace(
+                    "\nnetworks:\n",
+                    "\nvolumes:\n    nexus-crm-uploads:\n        name: nexus-crm-uploads\nnetworks:\n",
+                    1,
+                )
+            elif "nexus-crm-uploads:" not in result:
+                result = result.replace(
+                    "\nnetworks:\n",
+                    "\n    nexus-crm-uploads:\n        name: nexus-crm-uploads\nnetworks:\n",
+                    1,
+                )
+
+            compose_path.write_text(result)
+
+            if env_path.exists():
+                env_lines = env_path.read_text().splitlines()
+                replaced = False
+                for index, line in enumerate(env_lines):
+                    if line.startswith("SOURCE_COMMIT="):
+                        env_lines[index] = f"SOURCE_COMMIT={os.environ['DEPLOY_SHA']}"
+                        replaced = True
+                        break
+                if not replaced:
+                    env_lines.append(f"SOURCE_COMMIT={os.environ['DEPLOY_SHA']}")
+                env_path.write_text("\n".join(env_lines) + "\n")
+            PY
+
+            docker compose -f docker-compose.yaml up -d "$COOLIFY_SERVICE"
+            docker ps --filter "name=$COOLIFY_SERVICE" --format "{{.Names}} {{.Image}} {{.Status}}"
+
+  auto-deploy-disabled:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && vars.HETZNER_AUTO_DEPLOY != 'true'
+    steps:
+      - run: |
+          echo "Hetzner auto-deploy is disabled because GitHub SSH secrets are not verified."
+          echo "Set repository variable HETZNER_AUTO_DEPLOY=true after fixing HETZNER_SSH_KEY/SSH_KEY."

--- a/README.md
+++ b/README.md
@@ -541,7 +541,9 @@ The compose file mounts `./data` for the Prisma directory and `./uploads` for fi
 
 ### Hetzner VPS (CI/CD)
 
-The active GitHub Actions deploy workflow is `.github/workflows/deploy-hetzner.yml`. On push to `main`, it SSHes into the Hetzner VPS, fast-forwards the server checkout, and runs `./deploy.sh`.
+The active GitHub Actions deploy workflow is `.github/workflows/deploy-hetzner.yml`. The live `nexus.vasudev.xyz` deployment is managed by Coolify on the Hetzner VPS, so the workflow builds a Docker image on the VPS and updates the Coolify-generated Docker Compose application.
+
+Automatic deploys on push to `main` are disabled unless repository variable `HETZNER_AUTO_DEPLOY` is set to `true`. This prevents noisy failed deploys when the GitHub SSH deploy key is missing or stale. Manual runs through `workflow_dispatch` are still available.
 
 Required GitHub secrets:
 
@@ -552,15 +554,21 @@ Required GitHub secrets:
 
 Optional repository variables:
 
-- `HETZNER_DEPLOY_PATH` (defaults to `/root/job-tracker`)
-- `HETZNER_SERVICE_NAME` (defaults to `job-tracker`)
+- `HETZNER_AUTO_DEPLOY` (`true` enables deploys on push to `main`; default is disabled)
+- `HETZNER_COOLIFY_APP_DIR` (defaults to `/data/coolify/applications/tj4r2ezipwho1zvjhg78a5wu`)
+- `HETZNER_COOLIFY_SERVICE` (defaults to `tj4r2ezipwho1zvjhg78a5wu-064500973574`)
+- `HETZNER_COOLIFY_IMAGE` (defaults to `tj4r2ezipwho1zvjhg78a5wu`)
+- `HETZNER_DEPLOY_REPO_URL` (defaults to `https://github.com/5queezer/nexus-crm.git`)
 
 The old Cloud Run workflow in `.github/workflows/deploy-gcp.yml` is commented out so it cannot run on pushes to `main`.
 
 ### Manual / VPS
 
 ```bash
-./deploy.sh   # installs deps, applies migrations, builds, copies standalone output, restarts systemd service
+docker build -t tj4r2ezipwho1zvjhg78a5wu:<sha> .
+cd /data/coolify/applications/tj4r2ezipwho1zvjhg78a5wu
+# Update docker-compose.yaml image tag, then:
+docker compose -f docker-compose.yaml up -d tj4r2ezipwho1zvjhg78a5wu-064500973574
 ```
 
 The standalone output (via `next.config.ts` `output: "standalone"`) produces a self-contained `server.js` in `.next/standalone/`.


### PR DESCRIPTION
## Summary
- Stop push-triggered Hetzner deploy failures while the GitHub SSH secret is unverified.
- Update the manual Hetzner deploy workflow to target the live Coolify Docker Compose application instead of the old `/root/job-tracker` systemd checkout.
- Remove the unsupported `script_stop` input from `appleboy/ssh-action@v1`.
- Document the Coolify deploy variables and the `HETZNER_AUTO_DEPLOY` guard.

## Investigation
The failed workflow run `27509288662` failed before deployment with SSH authentication:

```text
ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain
```

The job also warned that `script_stop` is not a valid input for `appleboy/ssh-action@v1`.

The old workflow was configured for `/root/job-tracker` and `job-tracker`, but the live `nexus.vasudev.xyz` host is Coolify-managed under `/data/coolify/applications/tj4r2ezipwho1zvjhg78a5wu` with service `tj4r2ezipwho1zvjhg78a5wu-064500973574`.

## Verification
- `git diff --check`
- Ruby YAML load of `.github/workflows/deploy-hetzner.yml`
- Confirmed the Hetzner VPS has `python3` for the compose patch step

## Follow-up
The GitHub secret `HETZNER_SSH_KEY` or `SSH_KEY` still needs to be replaced with a private key accepted by the VPS. After that, set repository variable `HETZNER_AUTO_DEPLOY=true` to restore automatic push deploys.