### PR TITLE
[codex] Make Hetzner deploy follow Coolify service rotation

### DIFF
--- a/.github/workflows/deploy-hetzner.yml
+++ b/.github/workflows/deploy-hetzner.yml
@@ -11,7 +11,7 @@ concurrency:
 
 env:
   COOLIFY_APP_DIR: ${{ vars.HETZNER_COOLIFY_APP_DIR || '/data/coolify/applications/tj4r2ezipwho1zvjhg78a5wu' }}
-  COOLIFY_SERVICE: ${{ vars.HETZNER_COOLIFY_SERVICE || 'tj4r2ezipwho1zvjhg78a5wu-064500973574' }}
+  COOLIFY_SERVICE: ${{ vars.HETZNER_COOLIFY_SERVICE || '' }}
   COOLIFY_IMAGE: ${{ vars.HETZNER_COOLIFY_IMAGE || 'tj4r2ezipwho1zvjhg78a5wu' }}
   DEPLOY_REPO_URL: ${{ vars.HETZNER_DEPLOY_REPO_URL || 'https://github.com/5queezer/nexus-crm.git' }}
   AUTO_DEPLOY: ${{ vars.HETZNER_AUTO_DEPLOY || 'false' }}
@@ -53,6 +53,26 @@ jobs:
             docker build -t "$image_tag" .
 
             cd "$COOLIFY_APP_DIR"
+            if [ -z "${COOLIFY_SERVICE:-}" ]; then
+              COOLIFY_SERVICE=$(python3 - <<'PY'
+            from pathlib import Path
+
+            for line in Path("docker-compose.yaml").read_text().splitlines():
+                stripped = line.strip()
+                indent = len(line) - len(line.lstrip())
+                if indent == 4 and stripped.endswith(":"):
+                    print(stripped[:-1])
+                    break
+            PY
+              )
+            fi
+
+            if [ -z "${COOLIFY_SERVICE:-}" ]; then
+              echo "Could not determine Coolify compose service name." >&2
+              exit 1
+            fi
+
+            export COOLIFY_SERVICE
             cp docker-compose.yaml "docker-compose.yaml.before-${DEPLOY_SHA}-$(date +%Y%m%d%H%M%S)"
 
             python3 - <<'PY'

--- a/.github/workflows/deploy-hetzner.yml
+++ b/.github/workflows/deploy-hetzner.yml
@@ -53,19 +53,31 @@ jobs:
             docker build -t "$image_tag" .
 
             cd "$COOLIFY_APP_DIR"
-            if [ -z "${COOLIFY_SERVICE:-}" ]; then
-              COOLIFY_SERVICE=$(python3 - <<'PY'
+            COOLIFY_SERVICE=$(python3 - <<'PY'
+            import os
+            import sys
             from pathlib import Path
 
+            configured = os.environ.get("COOLIFY_SERVICE", "").strip()
+            services = []
             for line in Path("docker-compose.yaml").read_text().splitlines():
                 stripped = line.strip()
                 indent = len(line) - len(line.lstrip())
                 if indent == 4 and stripped.endswith(":"):
-                    print(stripped[:-1])
-                    break
+                    services.append(stripped[:-1])
+
+            if configured and configured in services:
+                print(configured)
+            elif services:
+                if configured:
+                    print(
+                        f"Configured Coolify service '{configured}' was not found; "
+                        f"using '{services[0]}' from docker-compose.yaml.",
+                        file=sys.stderr,
+                    )
+                print(services[0])
             PY
-              )
-            fi
+            )
 
             if [ -z "${COOLIFY_SERVICE:-}" ]; then
               echo "Could not determine Coolify compose service name." >&2

--- a/README.md
+++ b/README.md
@@ -543,7 +543,7 @@ The compose file mounts `./data` for the Prisma directory and `./uploads` for fi
 
 The active GitHub Actions deploy workflow is `.github/workflows/deploy-hetzner.yml`. The live `nexus.vasudev.xyz` deployment is managed by Coolify on the Hetzner VPS, so the workflow builds a Docker image on the VPS and updates the Coolify-generated Docker Compose application.
 
-Automatic deploys on push to `main` are disabled unless repository variable `HETZNER_AUTO_DEPLOY` is set to `true`. This prevents noisy failed deploys when the GitHub SSH deploy key is missing or stale. Manual runs through `workflow_dispatch` are still available.
+Automatic deploys on push to `main` are enabled when repository variable `HETZNER_AUTO_DEPLOY` is set to `true`. Manual runs through `workflow_dispatch` are also available.
 
 Required GitHub secrets:
 
@@ -554,9 +554,9 @@ Required GitHub secrets:
 
 Optional repository variables:
 
-- `HETZNER_AUTO_DEPLOY` (`true` enables deploys on push to `main`; default is disabled)
+- `HETZNER_AUTO_DEPLOY` (`true` enables deploys on push to `main`)
 - `HETZNER_COOLIFY_APP_DIR` (defaults to `/data/coolify/applications/tj4r2ezipwho1zvjhg78a5wu`)
-- `HETZNER_COOLIFY_SERVICE` (defaults to `tj4r2ezipwho1zvjhg78a5wu-064500973574`)
+- `HETZNER_COOLIFY_SERVICE` (optional override; by default the workflow reads the current service name from Coolify's compose file)
 - `HETZNER_COOLIFY_IMAGE` (defaults to `tj4r2ezipwho1zvjhg78a5wu`)
 - `HETZNER_DEPLOY_REPO_URL` (defaults to `https://github.com/5queezer/nexus-crm.git`)
 

--- a/README.md
+++ b/README.md
@@ -556,7 +556,7 @@ Optional repository variables:
 
 - `HETZNER_AUTO_DEPLOY` (`true` enables deploys on push to `main`)
 - `HETZNER_COOLIFY_APP_DIR` (defaults to `/data/coolify/applications/tj4r2ezipwho1zvjhg78a5wu`)
-- `HETZNER_COOLIFY_SERVICE` (optional override; by default the workflow reads the current service name from Coolify's compose file)
+- `HETZNER_COOLIFY_SERVICE` (optional override; if empty or stale, the workflow reads the current service name from Coolify's compose file)
 - `HETZNER_COOLIFY_IMAGE` (defaults to `tj4r2ezipwho1zvjhg78a5wu`)
 - `HETZNER_DEPLOY_REPO_URL` (defaults to `https://github.com/5queezer/nexus-crm.git`)
 


### PR DESCRIPTION
## What changed

- Updated the Hetzner deploy workflow to discover the current Coolify compose service name from `/data/coolify/applications/.../docker-compose.yaml`.
- Kept `HETZNER_COOLIFY_SERVICE` as an optional override.
- Updated the README to match the enabled auto-deploy setup.

## Why

Coolify rotates the generated service/container suffix during deployments. The merged workflow had a stale service name and failed after successfully building the Docker image.

## Validation

- Parsed all workflow YAML files locally.
- Ran `git diff --check` on the changed files.
- Tested the service discovery snippet directly on the Hetzner compose file; it returned the current service name.