### PR TITLE
ci: extend Hetzner deploy command timeout

### DIFF
--- a/.github/workflows/deploy-hetzner.yml
+++ b/.github/workflows/deploy-hetzner.yml
@@ -38,6 +38,7 @@ jobs:
           username: ${{ secrets.HETZNER_USER || secrets.SSH_USER }}
           key: ${{ secrets.HETZNER_SSH_KEY || secrets.SSH_KEY }}
           port: ${{ secrets.HETZNER_PORT || '22' }}
+          command_timeout: 30m
           envs: COOLIFY_APP_DIR,COOLIFY_SERVICE,COOLIFY_IMAGE,DEPLOY_REPO_URL,DEPLOY_SHA
           script: |
             set -euo pipefail


### PR DESCRIPTION
## Summary
- Extends the Hetzner SSH deploy command timeout to 30 minutes.
- The previous deploy failed while Docker was still running `npm run build` inside the remote build, ending with `Run Command Timeout` after ~10 minutes.

## Verification
- `git diff --check`
- `npx --yes prettier --check .github/workflows/deploy-hetzner.yml`

## Notes
- Follow-up to failed direct deployment of commit `5d5d447`.
- Future application changes should go through PR + CI/CD checks before deployment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended the deployment command timeout to help remote deployments complete more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->