### PR TITLE
fix: enforce account-scoped sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Key relationships:
 | `DB_PROVIDER` | Database backend (`prisma` or `firestore`) | `prisma` |
 | `GCS_BUCKET` | Google Cloud Storage bucket name (omit for local filesystem) | — |
 | `UPLOAD_DIR` | Local upload directory path | `./uploads` |
-| `PUBLIC_READ_TOKEN` | Token for the read-only client portal | — |
+| `PUBLIC_READ_TOKEN` | Deprecated; global public-token sharing is disabled, use per-user `/s/{code}` links | — |
 | `RR_API_URL` | Reactive Resume API URL | — |
 | `RR_API_KEY` | Reactive Resume API key | — |
 | `RR_BASE_RESUME_ID` | Base resume to duplicate for tailoring | — |

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -11,7 +11,7 @@
 |---|----------|---------|--------|
 | 1 | CRITICAL | Timing-unsafe PUBLIC_READ_TOKEN comparison | **Fixed** |
 | 2 | CRITICAL | Public token grants access to ALL document files | **Fixed** |
-| 3 | CRITICAL | Share page exposes all users' applications | Noted |
+| 3 | CRITICAL | Share page exposes all users' applications | **Fixed 2026-06-30** |
 | 4 | HIGH | Incomplete rate limiting (documents, users, token, config) | **Fixed** |
 | 5 | HIGH | IP-based rate limiting spoofable via X-Forwarded-For | Noted |
 | 6 | HIGH | In-memory rate limiting doesn't scale across instances | Noted |
@@ -46,19 +46,23 @@ When using the `PUBLIC_READ_TOKEN` query parameter, `readScopeUserId` remained
 attacker with the public share token could enumerate document IDs (sequential
 integers) and download every uploaded file (resumes, PDFs, images).
 
-**Fix:** Removed PUBLIC_READ_TOKEN acceptance from the document file endpoint.
-Document downloads now always require proper authentication.
+**Fix:** `app/api/documents/[id]/file/route.ts` now rejects unauthenticated requests
+regardless of any `token` query parameter. Authenticated session/Bearer requests
+must resolve the document through `loadOwnedDocument(id, auth.readScopeUserId)`.
+Public document sharing remains available only through per-link `/s/[code]`
+routes, which verify the `ShareLink.userId` against the resolved document owner.
 
-### 3. [CRITICAL] Share page exposes all users' applications — Noted
+### 3. [CRITICAL] Share page exposes all users' applications — FIXED 2026-06-30
 
 **Location:** `app/share/page.tsx:233`
 
 `listApplications(null)` returns applications across ALL users. In a multi-user
 deployment, anyone with the share link sees every user's job applications.
 
-**Recommendation:** Either scope the share page to a specific user (pass
-userId in the token or add a `SHARE_USER_ID` env var), or document that this
-feature is single-tenant only.
+**Fix:** `app/share/page.tsx` now requires a per-user `ShareLink` code and calls
+`listApplications(link.userId)` instead of `listApplications(null)`. `/s/[code]`
+redirects to `/share?code=...` without embedding the global public token. This
+keeps each shared portfolio scoped to the link creator.
 
 ### 4. [HIGH] Incomplete rate limiting — FIXED
 

--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { NextRequest } from "next/server";
+import { middleware, config } from "../middleware";
+
+function makeRequest(url: string, ip = "203.0.113.10") {
+  return new NextRequest(url, {
+    headers: {
+      "x-forwarded-for": ip,
+    },
+  });
+}
+
+describe("middleware", () => {
+  it("matches and rate-limits the public share page", () => {
+    expect(config.matcher).toContain("/share");
+
+    const ip = "203.0.113.77";
+    for (let i = 0; i < 30; i++) {
+      const res = middleware(makeRequest("http://localhost/share?code=abc123", ip));
+      expect(res.status).not.toBe(429);
+      expect(res.headers.get("X-RateLimit-Limit")).toBe("30");
+    }
+
+    const blocked = middleware(makeRequest("http://localhost/share?code=abc123", ip));
+    expect(blocked.status).toBe(429);
+  });
+});

--- a/app/api/config/public-token/__tests__/route.test.ts
+++ b/app/api/config/public-token/__tests__/route.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from "vitest";
+
+const { mockRequireAuth } = vi.hoisted(() => ({
+  mockRequireAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/session", () => ({
+  requireAuth: mockRequireAuth,
+}));
+
+import { GET } from "../route";
+
+describe("GET /api/config/public-token", () => {
+  it("requires real auth without the development bypass", async () => {
+    mockRequireAuth.mockResolvedValue(null);
+
+    const res = await GET();
+
+    expect(res.status).toBe(401);
+    expect(mockRequireAuth).toHaveBeenCalledWith({ allowDevBypass: false });
+  });
+
+  it("returns gone for authenticated callers because public tokens are disabled", async () => {
+    mockRequireAuth.mockResolvedValue({
+      userId: "user-1",
+      readScopeUserId: "user-1",
+      user: { id: "user-1", name: null, email: "u@example.com", image: null, isAdmin: false },
+    });
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(410);
+    expect(body.error).toContain("disabled");
+  });
+});

--- a/app/api/config/public-token/route.ts
+++ b/app/api/config/public-token/route.ts
@@ -1,17 +1,18 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { requireAuth } from "@/lib/session";
 
 /**
- * Returns the PUBLIC_READ_TOKEN so authenticated users can construct
- * shareable download URLs client-side without the token being baked
- * into the JavaScript bundle.
+ * Deprecated: global PUBLIC_READ_TOKEN based file/share access is disabled.
+ * Share access must use per-user ShareLink codes (/s/[code]).
  */
-export async function GET(request: NextRequest) {
+export async function GET() {
   const session = await requireAuth();
   if (!session) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const token = process.env.PUBLIC_READ_TOKEN ?? "";
-  return NextResponse.json({ token });
+  return NextResponse.json(
+    { error: "Public read tokens are disabled. Use per-link share URLs instead." },
+    { status: 410 }
+  );
 }

--- a/app/api/config/public-token/route.ts
+++ b/app/api/config/public-token/route.ts
@@ -6,7 +6,7 @@ import { requireAuth } from "@/lib/session";
  * Share access must use per-user ShareLink codes (/s/[code]).
  */
 export async function GET() {
-  const session = await requireAuth();
+  const session = await requireAuth({ allowDevBypass: false });
   if (!session) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/app/api/documents/[id]/file/__tests__/route.test.ts
+++ b/app/api/documents/[id]/file/__tests__/route.test.ts
@@ -100,16 +100,25 @@ describe("GET /api/documents/[id]/file", () => {
   });
 
   it("rejects unauthenticated public-token download attempts", async () => {
+    const previousToken = process.env.PUBLIC_READ_TOKEN;
     process.env.PUBLIC_READ_TOKEN = "legacy-public-token";
     mockRequireAuth.mockResolvedValue(null);
 
-    const res = await GET(
-      makeRequest("http://localhost/api/documents/doc-1/file?token=legacy-public-token"),
-      makeParams("doc-1")
-    );
+    try {
+      const res = await GET(
+        makeRequest("http://localhost/api/documents/doc-1/file?token=legacy-public-token"),
+        makeParams("doc-1")
+      );
 
-    expect(res.status).toBe(401);
-    expect(mockLoadOwnedDocument).not.toHaveBeenCalled();
-    expect(mockDownloadFile).not.toHaveBeenCalled();
+      expect(res.status).toBe(401);
+      expect(mockLoadOwnedDocument).not.toHaveBeenCalled();
+      expect(mockDownloadFile).not.toHaveBeenCalled();
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env.PUBLIC_READ_TOKEN;
+      } else {
+        process.env.PUBLIC_READ_TOKEN = previousToken;
+      }
+    }
   });
 });

--- a/app/api/documents/[id]/file/__tests__/route.test.ts
+++ b/app/api/documents/[id]/file/__tests__/route.test.ts
@@ -19,10 +19,6 @@ vi.mock("@/lib/storage", () => ({
   downloadFile: mockDownloadFile,
 }));
 
-vi.mock("@/lib/token", () => ({
-  safeCompare: (a: string, b: string) => a === b,
-}));
-
 import { GET } from "../route";
 
 const fixtureDoc = {
@@ -103,10 +99,17 @@ describe("GET /api/documents/[id]/file", () => {
     expect(mockLoadOwnedDocument).toHaveBeenCalledWith("doc-1", "user-2");
   });
 
-  it("returns 401 when unauthenticated and no public token is provided", async () => {
+  it("rejects unauthenticated public-token download attempts", async () => {
+    process.env.PUBLIC_READ_TOKEN = "legacy-public-token";
     mockRequireAuth.mockResolvedValue(null);
-    const res = await GET(makeRequest(), makeParams("doc-1"));
+
+    const res = await GET(
+      makeRequest("http://localhost/api/documents/doc-1/file?token=legacy-public-token"),
+      makeParams("doc-1")
+    );
+
     expect(res.status).toBe(401);
     expect(mockLoadOwnedDocument).not.toHaveBeenCalled();
+    expect(mockDownloadFile).not.toHaveBeenCalled();
   });
 });

--- a/app/api/documents/[id]/file/route.ts
+++ b/app/api/documents/[id]/file/route.ts
@@ -1,32 +1,19 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/session";
-import { safeCompare } from "@/lib/token";
 import { downloadFile } from "@/lib/storage";
 import { loadOwnedDocument } from "@/lib/documents/fetch";
 
 export async function GET(
-  request: NextRequest,
+  _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  // Allow access via session/Bearer auth OR via PUBLIC_READ_TOKEN query param
-  // (used for shared document links).
-  let readScopeUserId: string | null;
-
   const auth = await requireAuth();
-  if (auth) {
-    readScopeUserId = auth.readScopeUserId;
-  } else {
-    const token = request.nextUrl.searchParams.get("token");
-    const expectedToken = process.env.PUBLIC_READ_TOKEN;
-    if (!token || !expectedToken || !safeCompare(token, expectedToken)) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-    // Valid public token — allow access to any document (null = no user scope)
-    readScopeUserId = null;
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   const { id } = await params;
-  const result = await loadOwnedDocument(id, readScopeUserId);
+  const result = await loadOwnedDocument(id, auth.readScopeUserId);
   if (!result.ok) {
     const message = result.reason === "not_found" ? "Not found" : "File not found on disk";
     return NextResponse.json({ error: message }, { status: 404 });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,11 +3,37 @@ import { requireAuth } from "@/lib/session";
 import { Dashboard } from "@/components/dashboard";
 import { getDb } from "@/lib/db";
 import { generateShortCode } from "@/lib/token";
+import type { ShareLinkRecord } from "@/lib/db/types";
+
+function firstParam(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+async function ensureSharePageLink(userId: string): Promise<ShareLinkRecord | null> {
+  if (userId === "dev-user") {
+    return null;
+  }
+
+  const db = getDb();
+  const existing = await db.findShareLink(userId, "share_page", null);
+  if (existing) return existing;
+
+  try {
+    const created = await db.createShareLink(userId, {
+      code: generateShortCode(),
+      targetType: "share_page",
+      targetId: null,
+    });
+    return (await db.findShareLink(userId, "share_page", null)) ?? created;
+  } catch {
+    return db.findShareLink(userId, "share_page", null);
+  }
+}
 
 export default async function Home({
   searchParams,
 }: {
-  searchParams: Promise<{ status?: string; source?: string; search?: string }>;
+  searchParams: Promise<{ status?: string | string[]; source?: string | string[]; search?: string | string[] }>;
 }) {
   const session = await requireAuth();
   const params = await searchParams;
@@ -17,17 +43,11 @@ export default async function Home({
   }
 
   let shareUrl = "/share";
-  const db = getDb();
   const baseUrl = process.env.BETTER_AUTH_URL ?? "";
-  let link = await db.findShareLink(session.user.id, "share_page", null);
-  if (!link) {
-    link = await db.createShareLink(session.user.id, {
-      code: generateShortCode(),
-      targetType: "share_page",
-      targetId: null,
-    });
+  const link = await ensureSharePageLink(session.user.id);
+  if (link) {
+    shareUrl = `${baseUrl}/s/${link.code}`;
   }
-  shareUrl = `${baseUrl}/s/${link.code}`;
 
-  return <Dashboard user={session.user} shareUrl={shareUrl} initialStatus={params.status} initialSource={params.source} initialSearch={params.search} />;
+  return <Dashboard user={session.user} shareUrl={shareUrl} initialStatus={firstParam(params.status)} initialSource={firstParam(params.source)} initialSearch={firstParam(params.search)} />;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,20 +17,17 @@ export default async function Home({
   }
 
   let shareUrl = "/share";
-  const shareToken = process.env.PUBLIC_READ_TOKEN ?? "";
-  if (shareToken) {
-    const db = getDb();
-    const baseUrl = process.env.BETTER_AUTH_URL ?? "";
-    let link = await db.findShareLink(session.user.id, "share_page", null);
-    if (!link) {
-      link = await db.createShareLink(session.user.id, {
-        code: generateShortCode(),
-        targetType: "share_page",
-        targetId: null,
-      });
-    }
-    shareUrl = `${baseUrl}/s/${link.code}`;
+  const db = getDb();
+  const baseUrl = process.env.BETTER_AUTH_URL ?? "";
+  let link = await db.findShareLink(session.user.id, "share_page", null);
+  if (!link) {
+    link = await db.createShareLink(session.user.id, {
+      code: generateShortCode(),
+      targetType: "share_page",
+      targetId: null,
+    });
   }
+  shareUrl = `${baseUrl}/s/${link.code}`;
 
   return <Dashboard user={session.user} shareUrl={shareUrl} initialStatus={params.status} initialSource={params.source} initialSearch={params.search} />;
 }

--- a/app/s/[code]/__tests__/route.test.ts
+++ b/app/s/[code]/__tests__/route.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockGetShareLinkByCode, mockGetDocument, mockFileExists, mockDownloadFile } = vi.hoisted(() => ({
+  mockGetShareLinkByCode: vi.fn(),
+  mockGetDocument: vi.fn(),
+  mockFileExists: vi.fn(),
+  mockDownloadFile: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  getDb: () => ({
+    getShareLinkByCode: mockGetShareLinkByCode,
+    getDocument: mockGetDocument,
+  }),
+}));
+
+vi.mock("@/lib/storage", () => ({
+  fileExists: mockFileExists,
+  downloadFile: mockDownloadFile,
+}));
+
+import { GET } from "../route";
+
+function makeRequest(url = "http://localhost/s/share123") {
+  return new NextRequest(url);
+}
+
+function makeParams(code = "share123") {
+  return { params: Promise.resolve({ code }) };
+}
+
+describe("GET /s/[code]", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.BETTER_AUTH_URL = "https://nexus.example.com";
+    process.env.PUBLIC_READ_TOKEN = "legacy-public-token";
+  });
+
+  it("redirects share-page links using the per-link code, not the global public token", async () => {
+    mockGetShareLinkByCode.mockResolvedValue({
+      id: "1",
+      code: "share123",
+      userId: "user-1",
+      targetType: "share_page",
+      targetId: null,
+      createdAt: new Date(),
+    });
+
+    const res = await GET(makeRequest("http://localhost/s/share123?lang=en"), makeParams("share123"));
+
+    expect(res.status).toBe(307);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toBe("https://nexus.example.com/share?code=share123&lang=en");
+    expect(location).not.toContain("legacy-public-token");
+    expect(location).not.toContain("token=");
+  });
+
+  it("loads document share targets scoped to the link owner's userId", async () => {
+    mockGetShareLinkByCode.mockResolvedValue({
+      id: "1",
+      code: "doc123",
+      userId: "user-1",
+      targetType: "document",
+      targetId: "42",
+      createdAt: new Date(),
+    });
+    mockGetDocument.mockResolvedValue({
+      id: "42",
+      userId: "user-1",
+      filename: "stored.pdf",
+      originalName: "CV.pdf",
+      mimeType: "application/pdf",
+      size: 8,
+      uploadedAt: new Date(),
+    });
+    mockFileExists.mockResolvedValue(true);
+    mockDownloadFile.mockResolvedValue(Buffer.from("pdf-bytes"));
+
+    const res = await GET(makeRequest("http://localhost/s/doc123"), makeParams("doc123"));
+
+    expect(mockGetDocument).toHaveBeenCalledWith("42", "user-1");
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects a document share if the resolved document owner does not match the link owner", async () => {
+    mockGetShareLinkByCode.mockResolvedValue({
+      id: "1",
+      code: "doc123",
+      userId: "user-1",
+      targetType: "document",
+      targetId: "42",
+      createdAt: new Date(),
+    });
+    mockGetDocument.mockResolvedValue({
+      id: "42",
+      userId: "user-2",
+      filename: "stored.pdf",
+      originalName: "CV.pdf",
+      mimeType: "application/pdf",
+      size: 8,
+      uploadedAt: new Date(),
+    });
+
+    const res = await GET(makeRequest("http://localhost/s/doc123"), makeParams("doc123"));
+
+    expect(mockDownloadFile).not.toHaveBeenCalled();
+    expect(res.status).toBe(404);
+  });
+});

--- a/app/s/[code]/__tests__/route.test.ts
+++ b/app/s/[code]/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { NextRequest } from "next/server";
 
 const { mockGetShareLinkByCode, mockGetDocument, mockFileExists, mockDownloadFile } = vi.hoisted(() => ({
@@ -31,10 +31,27 @@ function makeParams(code = "share123") {
 }
 
 describe("GET /s/[code]", () => {
+  const previousBetterAuthUrl = process.env.BETTER_AUTH_URL;
+  const previousPublicReadToken = process.env.PUBLIC_READ_TOKEN;
+
   beforeEach(() => {
     vi.resetAllMocks();
     process.env.BETTER_AUTH_URL = "https://nexus.example.com";
     process.env.PUBLIC_READ_TOKEN = "legacy-public-token";
+  });
+
+  afterEach(() => {
+    if (previousBetterAuthUrl === undefined) {
+      delete process.env.BETTER_AUTH_URL;
+    } else {
+      process.env.BETTER_AUTH_URL = previousBetterAuthUrl;
+    }
+
+    if (previousPublicReadToken === undefined) {
+      delete process.env.PUBLIC_READ_TOKEN;
+    } else {
+      process.env.PUBLIC_READ_TOKEN = previousPublicReadToken;
+    }
   });
 
   it("redirects share-page links using the per-link code, not the global public token", async () => {

--- a/app/s/[code]/route.ts
+++ b/app/s/[code]/route.ts
@@ -17,20 +17,16 @@ export async function GET(
   }
 
   if (link.targetType === "share_page") {
-    const token = process.env.PUBLIC_READ_TOKEN;
-    if (!token) {
-      return NOT_FOUND;
-    }
     const lang = request.nextUrl.searchParams.get("lang");
     const langParam = lang === "en" ? "&lang=en" : "";
     const base = process.env.BETTER_AUTH_URL || request.url;
-    const url = new URL(`/share?token=${token}${langParam}`, base);
+    const url = new URL(`/share?code=${encodeURIComponent(code)}${langParam}`, base);
     return NextResponse.redirect(url);
   }
 
   if (link.targetType === "document" && link.targetId) {
-    const doc = await db.getDocument(link.targetId, null);
-    if (!doc || !(await fileExists(doc.filename))) {
+    const doc = await db.getDocument(link.targetId, link.userId);
+    if (!doc || doc.userId !== link.userId || !(await fileExists(doc.filename))) {
       return NOT_FOUND;
     }
 

--- a/app/share/page.tsx
+++ b/app/share/page.tsx
@@ -213,12 +213,18 @@ function ReadonlyApplicationCard({
   );
 }
 
+function firstParam(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
 interface SharePageProps {
-  searchParams: Promise<{ code?: string; lang?: string }>;
+  searchParams: Promise<{ code?: string | string[]; lang?: string | string[] }>;
 }
 
 export default async function SharePage({ searchParams }: SharePageProps) {
-  const { code, lang: langParam } = await searchParams;
+  const params = await searchParams;
+  const code = firstParam(params.code);
+  const langParam = firstParam(params.lang);
 
   if (!code) {
     notFound();

--- a/app/share/page.tsx
+++ b/app/share/page.tsx
@@ -1,6 +1,5 @@
 import { notFound } from "next/navigation";
 import { getDb } from "@/lib/db";
-import { safeCompare } from "@/lib/token";
 import { ApplicationStatus, STATUS_COLORS } from "@/types";
 import type { ApplicationRecord } from "@/lib/db/types";
 import { format, isPast, isToday } from "date-fns";
@@ -132,15 +131,15 @@ function StatCard({
 
 function LangToggle({
   current,
-  token,
+  code,
 }: {
   current: Lang;
-  token: string;
+  code: string;
 }) {
   const other: Lang = current === "de" ? "en" : "de";
   return (
     <a
-      href={`/share?token=${token}&lang=${other}`}
+      href={`/share?code=${encodeURIComponent(code)}&lang=${other}`}
       className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 text-sm font-medium text-gray-600 dark:text-gray-300 transition-colors"
       title={other === "en" ? "Switch to English" : "Auf Deutsch wechseln"}
     >
@@ -215,14 +214,19 @@ function ReadonlyApplicationCard({
 }
 
 interface SharePageProps {
-  searchParams: Promise<{ token?: string; lang?: string }>;
+  searchParams: Promise<{ code?: string; lang?: string }>;
 }
 
 export default async function SharePage({ searchParams }: SharePageProps) {
-  const { token, lang: langParam } = await searchParams;
-  const expectedToken = process.env.PUBLIC_READ_TOKEN;
+  const { code, lang: langParam } = await searchParams;
 
-  if (!expectedToken || !token || !safeCompare(token, expectedToken)) {
+  if (!code) {
+    notFound();
+  }
+
+  const db = getDb();
+  const link = await db.getShareLinkByCode(code);
+  if (!link || link.targetType !== "share_page") {
     notFound();
   }
 
@@ -230,13 +234,10 @@ export default async function SharePage({ searchParams }: SharePageProps) {
   const t = TRANSLATIONS[lang];
   const dateLocale = lang === "de" ? de : enUS;
 
-  const db = getDb();
-  const allApplications = await db.listApplications(null);
+  const allApplications = await db.listApplications(link.userId);
   const applications = allApplications.filter((a) => !a.archivedAt);
 
-  const ownerUser = applications[0]?.userId
-    ? await db.getUser(applications[0].userId)
-    : null;
+  const ownerUser = await db.getUser(link.userId);
   const ownerName = ownerUser?.name ?? null;
 
   const stats = {
@@ -271,7 +272,7 @@ export default async function SharePage({ searchParams }: SharePageProps) {
               </div>
             </div>
             <div className="flex shrink-0 items-center gap-2 sm:gap-3">
-              <LangToggle current={lang} token={token} />
+              <LangToggle current={lang} code={code} />
               <span className="hidden sm:inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-green-100 text-green-700 text-xs font-medium">
                 <span className="w-1.5 h-1.5 rounded-full bg-green-500 inline-block" />
                 {t.readOnly}

--- a/docs/security/account-isolation-audit-2026-06-30.md
+++ b/docs/security/account-isolation-audit-2026-06-30.md
@@ -1,0 +1,147 @@
+# Nexus CRM Account-Isolation Security Audit
+
+**Date:** 2026-06-30  
+**Scope:** Authenticated account isolation, share/public routes, document access, MCP/API surfaces, DB scoping, and dependency scan.
+
+## Executive summary
+
+Two critical cross-account exposure paths were confirmed and fixed:
+
+1. The legacy global `PUBLIC_READ_TOKEN` document download path allowed unauthenticated access to any document ID when the token was known.
+2. The public share page used `listApplications(null)`, which returned applications for every user instead of the share-link owner.
+
+The fixes remove global public-token based data access and scope share views to the `ShareLink.userId` creator.
+
+## Critical fixes applied
+
+### 1. Disable global public-token document downloads
+
+**Affected route:** `app/api/documents/[id]/file/route.ts`
+
+Before:
+
+- Unauthenticated requests with `?token=<PUBLIC_READ_TOKEN>` set `readScopeUserId = null`.
+- `loadOwnedDocument(id, null)` could resolve any user's document.
+
+After:
+
+- The route requires `requireAuth()` for all downloads.
+- Any `token` query parameter is ignored.
+- Documents are loaded with `auth.readScopeUserId`.
+
+Regression test:
+
+- `app/api/documents/[id]/file/__tests__/route.test.ts`
+- Test name: `rejects unauthenticated public-token download attempts`
+
+### 2. Scope public share pages to the share-link owner
+
+**Affected routes/pages:**
+
+- `app/s/[code]/route.ts`
+- `app/share/page.tsx`
+- `app/page.tsx`
+
+Before:
+
+- `/s/{code}` for `share_page` redirected to `/share?token=<PUBLIC_READ_TOKEN>`.
+- `/share` validated the global token and then called `listApplications(null)`.
+- `null` means global read scope, so a shared page could include every user's applications.
+
+After:
+
+- `/s/{code}` redirects to `/share?code={code}`.
+- `/share` resolves the `ShareLink` by code, verifies `targetType === "share_page"`, and calls `listApplications(link.userId)`.
+- `LangToggle` preserves `code`, not a global token.
+
+Regression test:
+
+- `app/s/[code]/__tests__/route.test.ts`
+- Tests verify:
+  - share redirects use `code`, not `token`
+  - document share targets call `getDocument(targetId, link.userId)`
+  - document owner mismatch returns 404
+
+### 3. Scope public document share links to the link owner
+
+**Affected route:** `app/s/[code]/route.ts`
+
+Before:
+
+- Document share links called `getDocument(link.targetId, null)`.
+
+After:
+
+- Document share links call `getDocument(link.targetId, link.userId)`.
+- The returned document must also have `doc.userId === link.userId` before file bytes are returned.
+
+### 4. Deprecate public-token config endpoint
+
+**Affected route:** `app/api/config/public-token/route.ts`
+
+Before:
+
+- Any authenticated user could retrieve the global `PUBLIC_READ_TOKEN`.
+
+After:
+
+- Auth is still required, but the endpoint returns `410 Gone` with a message directing clients to per-link share URLs.
+
+## Positive isolation findings
+
+- `Application` and `Document` models include `userId` owner fields.
+- Core application CRUD uses `auth.userId` for writes and `auth.readScopeUserId` for reads.
+- Non-admin writes remain scoped through adapter methods:
+  - `updateApplication(id, userId, ...)`
+  - `deleteApplication(id, userId)`
+  - `updateDocumentLinks(id, userId, ...)`
+  - `deleteDocument(id, userId)`
+- Contact creation verifies parent application ownership before calling the adapter.
+- Document upload/linking verifies referenced application IDs belong to the user.
+- Email scanned/imported data is scoped by `auth.userId`.
+- Token-management endpoint rejects Bearer-token based token rotation.
+- MCP application/document tools use `auth.readScopeUserId` for reads and `auth.userId` for writes.
+
+## Remaining design/security risks
+
+### Admin global read access
+
+Current design sets `readScopeUserId = null` for admins. This means admin accounts can read all applications/documents via normal read endpoints and MCP tools. If admins should only manage users and not see user data, this must be changed to an explicit impersonation/audited support-access model.
+
+### Dependency vulnerabilities
+
+`npm audit --omit=dev --audit-level=moderate` reports vulnerable transitive/runtime dependencies, including high/critical advisories in packages such as `next`, `protobufjs`, `axios`, `hono`, `dompurify` via Swagger UI, and Google/Firebase dependencies. This should be handled in a separate dependency-upgrade PR because some fixes may require major/breaking updates.
+
+### Rate limiting architecture
+
+Existing notes still apply: IP-based in-memory rate limiting is not a strong distributed control if the app runs multiple instances or if `X-Forwarded-For` trust is not hardened at the proxy boundary.
+
+## Validation evidence
+
+Commands run after the fix:
+
+```bash
+npx vitest run 'app/api/documents/[id]/file/__tests__/route.test.ts' 'app/s/[code]/__tests__/route.test.ts'
+# 2 files passed, 7 tests passed
+
+npm run lint
+# passed with existing warnings only
+
+npm test
+# 15 files passed, 116 tests passed
+
+npm run build
+# passed
+```
+
+Static runtime scan confirmed the fixed routes no longer contain:
+
+- `listApplications(null)`
+- `getDocument(link.targetId, null)`
+- `readScopeUserId = null`
+- `/share?token=`
+- `?token=<PUBLIC_READ_TOKEN>`
+
+## Recommendation
+
+Merge and deploy the account-isolation fixes before onboarding additional users or relying on public share links in a multi-user setting.

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -60,7 +60,9 @@ export async function getSession() {
  * (comma-separated list), only those emails are permitted for session auth.
  * The first allowed user is bootstrapped as admin if no admin exists yet.
  */
-export async function requireAuth(): Promise<SessionAuthResult | null> {
+export async function requireAuth(options: { allowDevBypass?: boolean } = {}): Promise<SessionAuthResult | null> {
+  const { allowDevBypass = true } = options;
+
   // 1. Check Bearer token
   const headerList = await headers();
   const authHeader = headerList.get("authorization");
@@ -73,7 +75,7 @@ export async function requireAuth(): Promise<SessionAuthResult | null> {
   if (session) return session;
 
   // 3. Dev bypass: return a fake admin user when no session exists
-  if (process.env.NODE_ENV === "development") {
+  if (allowDevBypass && process.env.NODE_ENV === "development") {
     return {
       userId: "dev-user",
       readScopeUserId: null,

--- a/middleware.ts
+++ b/middleware.ts
@@ -19,6 +19,7 @@ export function middleware(req: NextRequest): NextResponse {
     : pathname.startsWith("/api/applications") ? "applications"
     : pathname.startsWith("/api/documents") ? "documents"
     : pathname.startsWith("/api/email") ? "email"
+    : pathname === "/share" ? "general"
     : pathname.startsWith("/s/") ? "general"
     : pathname.startsWith("/api/") ? "general"
     : null;
@@ -54,5 +55,5 @@ export function middleware(req: NextRequest): NextResponse {
 }
 
 export const config = {
-  matcher: ["/api/:path*", "/s/:path*"],
+  matcher: ["/api/:path*", "/s/:path*", "/share"],
 };

--- a/public/llm.txt
+++ b/public/llm.txt
@@ -27,9 +27,11 @@ Multi-tenant: each user only sees their own data. Admin users (isAdmin flag) byp
 - At least one admin user must always exist (last-admin protection)
 
 ### Share token (read-only public)
-- Query param: `/share?token=$SHARE_TOKEN`
-- Read-only view of all applications and documents
-- Token set via environment variable — never hardcoded
+- Share URL: `/s/{code}` (per-user ShareLink code)
+- `/share?code={code}` is scoped to the ShareLink creator
+- Global `PUBLIC_READ_TOKEN` based sharing is disabled
+- Read-only view of the link creator's non-archived applications
+- Codes are stored server-side in `ShareLink` records
 
 ---
 
@@ -59,7 +61,7 @@ Multi-tenant: each user only sees their own data. Admin users (isAdmin flag) byp
 | POST | /api/documents | session or token | Upload (multipart/form-data, field: file; PDF/JPEG/PNG/WEBP up to 10MB) |
 | PATCH | /api/documents/:id | session or token | Update: rename (`{ "originalName": "new.pdf" }`) or update links (`{ "applicationIds": [...] }`) |
 | DELETE | /api/documents/:id | session or token | Delete |
-| GET | /api/documents/:id/file | session, token, or share token | Download file |
+| GET | /api/documents/:id/file | session or token | Download file |
 
 ### Token management
 | Method | Path | Auth | Description |
@@ -103,7 +105,7 @@ Content-Type: application/json
 ```
 
 ## Security notes
-- PUBLIC_READ_TOKEN is a server-side env var only
+- Global PUBLIC_READ_TOKEN based sharing is disabled; use per-link `/s/{code}` URLs
 - NEXT_PUBLIC_* env vars do NOT contain any tokens
 - Rate limiting applies to API routes
 - All document uploads are type-checked and limited to 10MB

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Nexus CRM API",
     "version": "1.0.0",
-    "description": "REST API for the Nexus CRM application.\n\n## Authentication\n\nTwo auth methods are supported:\n\n- **BearerAuth** – `Authorization: Bearer <token>`. Per-user API token generated in the dashboard. Scoped to the token owner's data (admin tokens get cross-tenant read access).\n- **CookieAuth** – Session cookie set by the Better Auth `/api/auth` flow (Google OAuth).\n\nToken management (POST/DELETE `/api/token`) requires a session cookie. The file download endpoint also accepts a `PUBLIC_READ_TOKEN` query parameter for share links."
+    "description": "REST API for the Nexus CRM application.\n\n## Authentication\n\nTwo auth methods are supported:\n\n- **BearerAuth** \u2013 `Authorization: Bearer <token>`. Per-user API token generated in the dashboard. Scoped to the token owner's data (admin tokens get cross-tenant read access).\n- **CookieAuth** \u2013 Session cookie set by the Better Auth `/api/auth` flow (Google OAuth).\n\nToken management (POST/DELETE `/api/token`) requires a session cookie. File downloads require CookieAuth or BearerAuth; unauthenticated sharing uses per-link `/s/{code}` URLs scoped to the link owner."
   },
   "servers": [
     {
@@ -657,20 +657,11 @@
       "get": {
         "operationId": "downloadDocumentFile",
         "summary": "Download document file",
-        "description": "Streams the raw file with the original filename as the download name.\n\nAccess is permitted via any of:\n- Session cookie (`CookieAuth`)\n- `?token=<PUBLIC_READ_TOKEN>` query parameter (share links / readonly embeds)\n\nThe public token is obtained from `GET /api/config/public-token`.",
+        "description": "Streams the raw file with the original filename as the download name. Access requires a session cookie or per-user Bearer token scoped to the document owner. Public read tokens are disabled; unauthenticated document sharing is handled via per-link `/s/{code}` URLs.",
         "tags": ["Documents"],
         "security": [
-          { "CookieAuth": [] },
-          {}
-        ],
-        "parameters": [
-          {
-            "name": "token",
-            "in": "query",
-            "required": false,
-            "schema": { "type": "string" },
-            "description": "Public read token (`PUBLIC_READ_TOKEN`). Allows unauthenticated file access for share links."
-          }
+          { "BearerAuth": [] },
+          { "CookieAuth": [] }
         ],
         "responses": {
           "200": {
@@ -852,26 +843,25 @@
     "/api/config/public-token": {
       "get": {
         "operationId": "getPublicToken",
-        "summary": "Get public read token",
-        "description": "Returns the `PUBLIC_READ_TOKEN` so authenticated clients can construct shareable file download URLs without the token being exposed in the JavaScript bundle. **Requires a session** (cookie auth only).",
+        "summary": "Public read token disabled",
+        "description": "Deprecated endpoint. Global PUBLIC_READ_TOKEN based access is disabled to prevent cross-account data exposure. Use per-link share URLs (`/s/{code}`) instead.",
         "tags": ["Config"],
         "security": [
           { "BearerAuth": [] },
           { "CookieAuth": [] }
         ],
         "responses": {
-          "200": {
-            "description": "The public read token.",
+          "410": {
+            "description": "Public read tokens are disabled.",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["token"],
+                  "required": ["error"],
                   "properties": {
-                    "token": {
+                    "error": {
                       "type": "string",
-                      "description": "Value of the `PUBLIC_READ_TOKEN` env var. Pass as `?token=<value>` to `GET /api/documents/{id}/file`.",
-                      "example": "pub_abc123"
+                      "example": "Public read tokens are disabled. Use per-link share URLs instead."
                     }
                   }
                 }


### PR DESCRIPTION
## Summary
- disables legacy global `PUBLIC_READ_TOKEN` based document/share access
- scopes `/share?code=...` to the owning `ShareLink.userId`
- scopes `/s/{code}` document downloads to the link owner and verifies owner match
- rate-limits `/share` bearer-code access path
- updates OpenAPI/LLM/README/security audit docs

## Critical findings fixed
1. Direct `/api/documents/{id}/file?token=...` could previously become an unscoped document read.
2. Public share page previously used `listApplications(null)`, exposing all users' applications in multi-user deployments.
3. Document share links previously resolved `getDocument(..., null)` instead of the link owner's userId.

## Validation
- `npx vitest run __tests__/middleware.test.ts app/api/documents/[id]/file/__tests__/route.test.ts app/s/[code]/__tests__/route.test.ts` ✅ 8 tests passed
- `npm run lint` ✅ passed with existing warnings only
- `npm test` ✅ 16 files passed, 117 tests passed
- `npm run build` ✅ passed
- Independent subagent security review: no blockers for stated account-isolation objective

## Notes
- Admin accounts still intentionally have global read scope via `readScopeUserId = null`; documented as a design risk if admins should not see tenant data.
- Dependency audit still reports vulnerable transitive packages; should be handled in a separate dependency-upgrade PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Share links now use per-link codes (`/s/{code}`) for shared access, including redirects and read-only sharing pages.
  - Shared document access is now tied to the link owner, improving consistency across shared views.

- **Bug Fixes**
  - Removed global public-token access from file downloads and sharing flows.
  - Strengthened access checks so shared documents and applications only show when properly authorized.
  - Added rate limiting coverage for the share page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->