### PR TITLE
feat: add MCP client setup help

### DIFF
--- a/components/mcp-client-help.tsx
+++ b/components/mcp-client-help.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Bot, Check, Copy, Info } from "lucide-react";
+
+function CodeBlock({ value, label }: { value: string; label: string }) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    await navigator.clipboard.writeText(value);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-gray-200 bg-gray-950 dark:border-gray-700">
+      <div className="flex items-center justify-between border-b border-white/10 px-3 py-2">
+        <span className="text-xs font-medium text-gray-300">{label}</span>
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-gray-300 transition hover:bg-white/10 hover:text-white"
+        >
+          {copied ? <Check className="h-3.5 w-3.5 text-green-400" /> : <Copy className="h-3.5 w-3.5" />}
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+      <pre className="overflow-x-auto p-3 text-xs leading-5 text-gray-100">
+        <code>{value}</code>
+      </pre>
+    </div>
+  );
+}
+
+export function McpClientHelp() {
+  const origin = typeof window === "undefined" ? "https://nexus.vasudev.xyz" : window.location.origin;
+
+  const mcpUrl = `${origin}/api/mcp`;
+  const oauthMetadataUrl = `${origin}/.well-known/oauth-authorization-server`;
+  const protectedResourceUrl = `${origin}/.well-known/oauth-protected-resource`;
+
+  const claudeDesktopConfig = useMemo(
+    () =>
+      JSON.stringify(
+        {
+          mcpServers: {
+            "nexus-crm": {
+              url: mcpUrl,
+              headers: {
+                Authorization: ["Bearer", "jt_<your-token>"].join(" "),
+              },
+            },
+          },
+        },
+        null,
+        2
+      ),
+    [mcpUrl]
+  );
+
+  return (
+    <section className="overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+      <div className="border-b border-gray-200 bg-gray-50/50 p-4 dark:border-gray-700 dark:bg-gray-900/20">
+        <h3 className="flex items-center gap-2 font-semibold text-gray-900 dark:text-white">
+          <Bot className="h-4 w-4 text-blue-600" />
+          MCP client setup
+        </h3>
+        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+          Connect Claude or ChatGPT to Nexus CRM so the assistant can list, create, update, and attach documents to your opportunities.
+        </p>
+      </div>
+
+      <div className="space-y-5 p-4 text-sm text-gray-700 dark:text-gray-300">
+        <div className="rounded-lg border border-blue-100 bg-blue-50 p-3 text-xs text-blue-900 dark:border-blue-900/50 dark:bg-blue-950/30 dark:text-blue-200">
+          <div className="flex gap-2">
+            <Info className="mt-0.5 h-4 w-4 shrink-0" />
+            <p>
+              Recommended: use OAuth in Claude.ai or ChatGPT. Use the API token below only for clients that support static Authorization headers.
+            </p>
+          </div>
+        </div>
+
+        <div>
+          <h4 className="font-semibold text-gray-900 dark:text-white">1. Claude.ai or ChatGPT custom connector</h4>
+          <ol className="mt-2 list-decimal space-y-1 pl-5 text-xs text-gray-600 dark:text-gray-400">
+            <li>Open the connector / MCP server settings in Claude or ChatGPT.</li>
+            <li>Add a custom connector named <strong>Nexus CRM</strong>.</li>
+            <li>Paste the MCP server URL below.</li>
+            <li>Choose OAuth if prompted, then sign in with your Nexus CRM account and approve the connection.</li>
+          </ol>
+          <div className="mt-3 grid gap-3 sm:grid-cols-2">
+            <CodeBlock value={mcpUrl} label="MCP server URL" />
+            <CodeBlock value={oauthMetadataUrl} label="OAuth discovery URL" />
+          </div>
+          <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+            If a client asks for protected-resource metadata, use <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-gray-900">{protectedResourceUrl}</code>.
+          </p>
+        </div>
+
+        <div>
+          <h4 className="font-semibold text-gray-900 dark:text-white">2. Claude Desktop or other header-based clients</h4>
+          <ol className="mt-2 list-decimal space-y-1 pl-5 text-xs text-gray-600 dark:text-gray-400">
+            <li>Generate an API token in the panel below and copy it immediately.</li>
+            <li>Paste this JSON into your MCP client config.</li>
+            <li>Replace <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-gray-900">jt_&lt;your-token&gt;</code> with your generated token.</li>
+          </ol>
+          <div className="mt-3">
+            <CodeBlock value={claudeDesktopConfig} label="claude_desktop_config.json" />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/settings-client.tsx
+++ b/components/settings-client.tsx
@@ -7,6 +7,7 @@ import { EmailIntegration } from "./email-integration";
 import { ScannedEmails } from "./scanned-emails";
 import { ApiToken } from "./api-token";
 import { AppHeader } from "./app-header";
+import { McpClientHelp } from "./mcp-client-help";
 
 interface SettingsClientProps {
   user: {
@@ -26,6 +27,7 @@ export function SettingsClient({ user }: SettingsClientProps) {
       <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
         <EmailIntegration />
         <ScannedEmails />
+        <McpClientHelp />
         <ApiToken />
         <AppSettingsPanel />
         {user.isAdmin && (


### PR DESCRIPTION
## Summary
- Adds an MCP client setup card to Settings with copyable URLs and Claude Desktop JSON
- Explains recommended OAuth setup for Claude.ai / ChatGPT custom connectors
- Points header-based clients to the existing API token panel

## Test Plan
- `npm run lint` (passes; existing warnings only)
- `npm test`
- `npm run build` (passes; existing Better Auth env warnings during static generation)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-app MCP client setup guide in Settings.
  * Users can now view discovery and OAuth-related URLs plus a ready-to-copy JSON configuration for header-based clients.
  * Code snippets include a one-click copy action with temporary confirmation feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->