### PR TITLE
fix: address MCP setup review feedback

### DIFF
--- a/components/mcp-client-help.tsx
+++ b/components/mcp-client-help.tsx
@@ -20,16 +20,38 @@ function useBrowserOrigin() {
   return useSyncExternalStore(subscribeToOrigin, getBrowserOrigin, getServerOrigin);
 }
 
+function copyWithTextareaFallback(value: string) {
+  const ta = document.createElement("textarea");
+  ta.value = value;
+  ta.style.position = "fixed";
+  ta.style.opacity = "0";
+  document.body.appendChild(ta);
+  ta.focus();
+  ta.select();
+
+  try {
+    return document.execCommand("copy");
+  } finally {
+    document.body.removeChild(ta);
+  }
+}
+
 function CodeBlock({ value, label }: { value: string; label: string }) {
   const [copied, setCopied] = useState(false);
 
   async function handleCopy() {
+    let didCopy = false;
+
     try {
       await navigator.clipboard.writeText(value);
+      didCopy = true;
+    } catch {
+      didCopy = copyWithTextareaFallback(value);
+    }
+
+    if (didCopy) {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // Clipboard API unavailable or permission denied.
     }
   }
 

--- a/components/mcp-client-help.tsx
+++ b/components/mcp-client-help.tsx
@@ -1,15 +1,36 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useState, useSyncExternalStore } from "react";
 import { Bot, Check, Copy, Info } from "lucide-react";
+
+function subscribeToOrigin(callback: () => void) {
+  const id = window.setTimeout(callback, 0);
+  return () => window.clearTimeout(id);
+}
+
+function getBrowserOrigin() {
+  return window.location.origin;
+}
+
+function getServerOrigin() {
+  return null;
+}
+
+function useBrowserOrigin() {
+  return useSyncExternalStore(subscribeToOrigin, getBrowserOrigin, getServerOrigin);
+}
 
 function CodeBlock({ value, label }: { value: string; label: string }) {
   const [copied, setCopied] = useState(false);
 
   async function handleCopy() {
-    await navigator.clipboard.writeText(value);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API unavailable or permission denied.
+    }
   }
 
   return (
@@ -33,23 +54,19 @@ function CodeBlock({ value, label }: { value: string; label: string }) {
 }
 
 export function McpClientHelp() {
-  const origin = typeof window === "undefined" ? "https://nexus.vasudev.xyz" : window.location.origin;
+  const origin = useBrowserOrigin();
 
-  const mcpUrl = `${origin}/api/mcp`;
-  const oauthMetadataUrl = `${origin}/.well-known/oauth-authorization-server`;
-  const protectedResourceUrl = `${origin}/.well-known/oauth-protected-resource`;
+  const mcpUrl = origin ? `${origin}/api/mcp` : "";
+  const oauthMetadataUrl = origin ? `${origin}/.well-known/oauth-authorization-server` : "";
+  const protectedResourceUrl = origin ? `${origin}/.well-known/oauth-protected-resource` : "";
 
-  const claudeDesktopConfig = useMemo(
+  const headerBasedConfig = useMemo(
     () =>
       JSON.stringify(
         {
-          mcpServers: {
-            "nexus-crm": {
-              url: mcpUrl,
-              headers: {
-                Authorization: ["Bearer", "jt_<your-token>"].join(" "),
-              },
-            },
+          url: mcpUrl,
+          headers: {
+            Authorization: "Bearer jt_<your-token>",
           },
         },
         null,
@@ -75,38 +92,48 @@ export function McpClientHelp() {
           <div className="flex gap-2">
             <Info className="mt-0.5 h-4 w-4 shrink-0" />
             <p>
-              Recommended: use OAuth in Claude.ai or ChatGPT. Use the API token below only for clients that support static Authorization headers.
+              Recommended: use OAuth in Claude.ai, Claude Desktop custom connectors, or ChatGPT. Use the API token below only for clients that explicitly support static Authorization headers.
             </p>
           </div>
         </div>
 
         <div>
-          <h4 className="font-semibold text-gray-900 dark:text-white">1. Claude.ai or ChatGPT custom connector</h4>
+          <h4 className="font-semibold text-gray-900 dark:text-white">1. Claude or ChatGPT custom connector</h4>
           <ol className="mt-2 list-decimal space-y-1 pl-5 text-xs text-gray-600 dark:text-gray-400">
             <li>Open the connector / MCP server settings in Claude or ChatGPT.</li>
             <li>Add a custom connector named <strong>Nexus CRM</strong>.</li>
             <li>Paste the MCP server URL below.</li>
             <li>Choose OAuth if prompted, then sign in with your Nexus CRM account and approve the connection.</li>
           </ol>
-          <div className="mt-3 grid gap-3 sm:grid-cols-2">
-            <CodeBlock value={mcpUrl} label="MCP server URL" />
-            <CodeBlock value={oauthMetadataUrl} label="OAuth discovery URL" />
-          </div>
-          <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
-            If a client asks for protected-resource metadata, use <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-gray-900">{protectedResourceUrl}</code>.
-          </p>
+          {origin ? (
+            <div className="mt-3 grid gap-3 sm:grid-cols-2">
+              <CodeBlock value={mcpUrl} label="MCP server URL" />
+              <CodeBlock value={oauthMetadataUrl} label="OAuth discovery URL" />
+            </div>
+          ) : (
+            <div className="mt-3 rounded-lg border border-gray-200 bg-gray-50 p-3 text-xs text-gray-500 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-400">
+              Loading setup URLs…
+            </div>
+          )}
+          {origin && (
+            <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+              If a client asks for protected-resource metadata, use <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-gray-900">{protectedResourceUrl}</code>.
+            </p>
+          )}
         </div>
 
         <div>
-          <h4 className="font-semibold text-gray-900 dark:text-white">2. Claude Desktop or other header-based clients</h4>
+          <h4 className="font-semibold text-gray-900 dark:text-white">2. API-token fallback for header-based clients</h4>
           <ol className="mt-2 list-decimal space-y-1 pl-5 text-xs text-gray-600 dark:text-gray-400">
             <li>Generate an API token in the panel below and copy it immediately.</li>
-            <li>Paste this JSON into your MCP client config.</li>
-            <li>Replace <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-gray-900">jt_&lt;your-token&gt;</code> with your generated token.</li>
+            <li>Use this only in clients that support custom HTTP headers for remote MCP servers.</li>
+            <li>Do not paste this into Claude Desktop&apos;s local server config; Claude Desktop remote MCP should use custom connectors / OAuth.</li>
           </ol>
-          <div className="mt-3">
-            <CodeBlock value={claudeDesktopConfig} label="claude_desktop_config.json" />
-          </div>
+          {origin && (
+            <div className="mt-3">
+              <CodeBlock value={headerBasedConfig} label="Generic header-based remote MCP config" />
+            </div>
+          )}
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Handles clipboard copy failures without unhandled promise rejections
- Removes the hardcoded SSR origin fallback to avoid hydration mismatches on preview/local deployments
- Replaces the invalid Claude Desktop local config example with OAuth/custom connector guidance and a generic header-based fallback

## Review feedback addressed
- CodeRabbit: clipboard write rejection handling
- CodeRabbit: SSR/client origin hydration mismatch
- CodeRabbit nit: clearer direct Authorization header example
- Codex: do not present remote `url`/`headers` as `claude_desktop_config.json`

## Test Plan
- `npm run lint` (passes; existing warnings only)
- `npm test`
- `npm run build` (passes; existing Better Auth env warnings during static generation)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved setup guidance with updated headings, recommendations, and configuration examples.
  * Connector URLs now load dynamically from the current browser location, with a loading state until they’re available.
  * Added a more reliable copy action for code blocks when the standard clipboard method fails.

* **Bug Fixes**
  * Fixed URL generation during server-side rendering to avoid using a hardcoded origin.
  * Updated the remote MCP configuration to match the current environment more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->