### PR TITLE
feat: simplify opportunities workspace UX

### DIFF
--- a/components/__tests__/action-menu.test.tsx
+++ b/components/__tests__/action-menu.test.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { ActionMenu } from "../action-menu";
+
+describe("ActionMenu", () => {
+  it("renders one accessible trigger and keeps actions progressively disclosed", () => {
+    const html = renderToStaticMarkup(
+      <ActionMenu
+        label="Actions for OpenAI"
+        items={[
+          { id: "edit", label: "Edit", onSelect: vi.fn() },
+          { id: "delete", label: "Delete", destructive: true, onSelect: vi.fn() },
+        ]}
+      />,
+    );
+
+    expect(html).toContain('aria-label="Actions for OpenAI"');
+    expect(html).toContain('aria-haspopup="menu"');
+    expect(html).toContain('aria-expanded="false"');
+    expect(html).not.toContain('role="menu"');
+    expect(html).not.toContain(">Edit<");
+    expect(html).not.toContain(">Delete<");
+  });
+
+  it("supports a labeled workspace utility trigger", () => {
+    const html = renderToStaticMarkup(
+      <ActionMenu label="More actions" buttonText="More" items={[]} />,
+    );
+
+    expect(html).toContain('aria-label="More actions"');
+    expect(html).toContain(">More<");
+  });
+});

--- a/components/action-menu.tsx
+++ b/components/action-menu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ReactNode, useEffect, useRef, useState } from "react";
+import { KeyboardEvent as ReactKeyboardEvent, ReactNode, useEffect, useRef, useState } from "react";
 import { MoreHorizontal } from "lucide-react";
 
 export interface ActionMenuItem {
@@ -24,31 +24,57 @@ interface ActionMenuProps {
 export function ActionMenu({ label, items, buttonText, align = "right", className = "" }: ActionMenuProps) {
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  function closeMenu({ restoreFocus = false } = {}) {
+    setOpen(false);
+    if (restoreFocus) requestAnimationFrame(() => triggerRef.current?.focus());
+  }
 
   useEffect(() => {
     if (!open) return;
 
     function closeOnOutsidePointer(event: MouseEvent | TouchEvent) {
-      if (rootRef.current && !rootRef.current.contains(event.target as Node)) setOpen(false);
+      if (rootRef.current && !rootRef.current.contains(event.target as Node)) closeMenu();
     }
 
-    function closeOnEscape(event: KeyboardEvent) {
-      if (event.key === "Escape") setOpen(false);
+    function closeOnDocumentKey(event: KeyboardEvent) {
+      if (event.key === "Escape") closeMenu({ restoreFocus: true });
+      if (event.key === "Tab") closeMenu();
     }
 
     document.addEventListener("mousedown", closeOnOutsidePointer);
     document.addEventListener("touchstart", closeOnOutsidePointer);
-    document.addEventListener("keydown", closeOnEscape);
+    document.addEventListener("keydown", closeOnDocumentKey);
+    requestAnimationFrame(() => {
+      menuRef.current?.querySelector<HTMLButtonElement>('[role="menuitem"]:not(:disabled)')?.focus();
+    });
     return () => {
       document.removeEventListener("mousedown", closeOnOutsidePointer);
       document.removeEventListener("touchstart", closeOnOutsidePointer);
-      document.removeEventListener("keydown", closeOnEscape);
+      document.removeEventListener("keydown", closeOnDocumentKey);
     };
   }, [open]);
+
+  function handleMenuKeyDown(event: ReactKeyboardEvent<HTMLDivElement>) {
+    if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+    const enabledItems = Array.from(
+      menuRef.current?.querySelectorAll<HTMLButtonElement>('[role="menuitem"]:not(:disabled)') ?? [],
+    );
+    if (enabledItems.length === 0) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const currentIndex = enabledItems.indexOf(document.activeElement as HTMLButtonElement);
+    const direction = event.key === "ArrowDown" ? 1 : -1;
+    const nextIndex = (currentIndex + direction + enabledItems.length) % enabledItems.length;
+    enabledItems[nextIndex].focus();
+  }
 
   return (
     <div ref={rootRef} className={`relative ${className}`}>
       <button
+        ref={triggerRef}
         type="button"
         aria-label={label}
         aria-haspopup="menu"
@@ -57,6 +83,7 @@ export function ActionMenu({ label, items, buttonText, align = "right", classNam
           event.stopPropagation();
           setOpen((value) => !value);
         }}
+        onKeyDown={(event) => event.stopPropagation()}
         className={buttonText
           ? "nexus-button-ghost min-h-10 whitespace-nowrap px-3"
           : "flex h-10 w-10 items-center justify-center rounded-xl text-slate-400 transition hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-white/[0.07] dark:hover:text-white"
@@ -71,8 +98,10 @@ export function ActionMenu({ label, items, buttonText, align = "right", classNam
 
       {open && (
         <div
+          ref={menuRef}
           role="menu"
           aria-label={label}
+          onKeyDown={handleMenuKeyDown}
           className={`absolute z-40 mt-2 min-w-56 overflow-hidden rounded-xl border border-slate-200 bg-white p-1.5 shadow-xl dark:border-white/[0.1] dark:bg-[#151617] ${align === "right" ? "right-0" : "left-0"}`}
         >
           {items.map((item) => (
@@ -84,7 +113,7 @@ export function ActionMenu({ label, items, buttonText, align = "right", classNam
                 onClick={(event) => {
                   event.stopPropagation();
                   if (item.disabled) return;
-                  setOpen(false);
+                  closeMenu({ restoreFocus: true });
                   item.onSelect?.();
                 }}
                 className={`flex min-h-10 w-full items-center justify-between gap-4 rounded-lg px-3 py-2 text-left text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-40 ${

--- a/components/action-menu.tsx
+++ b/components/action-menu.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { ReactNode, useEffect, useRef, useState } from "react";
+import { MoreHorizontal } from "lucide-react";
+
+export interface ActionMenuItem {
+  id: string;
+  label: ReactNode;
+  onSelect?: () => void;
+  disabled?: boolean;
+  destructive?: boolean;
+  separatorBefore?: boolean;
+  hint?: ReactNode;
+}
+
+interface ActionMenuProps {
+  label: string;
+  items: ActionMenuItem[];
+  buttonText?: string;
+  align?: "left" | "right";
+  className?: string;
+}
+
+export function ActionMenu({ label, items, buttonText, align = "right", className = "" }: ActionMenuProps) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    function closeOnOutsidePointer(event: MouseEvent | TouchEvent) {
+      if (rootRef.current && !rootRef.current.contains(event.target as Node)) setOpen(false);
+    }
+
+    function closeOnEscape(event: KeyboardEvent) {
+      if (event.key === "Escape") setOpen(false);
+    }
+
+    document.addEventListener("mousedown", closeOnOutsidePointer);
+    document.addEventListener("touchstart", closeOnOutsidePointer);
+    document.addEventListener("keydown", closeOnEscape);
+    return () => {
+      document.removeEventListener("mousedown", closeOnOutsidePointer);
+      document.removeEventListener("touchstart", closeOnOutsidePointer);
+      document.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [open]);
+
+  return (
+    <div ref={rootRef} className={`relative ${className}`}>
+      <button
+        type="button"
+        aria-label={label}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={(event) => {
+          event.stopPropagation();
+          setOpen((value) => !value);
+        }}
+        className={buttonText
+          ? "nexus-button-ghost min-h-10 whitespace-nowrap px-3"
+          : "flex h-10 w-10 items-center justify-center rounded-xl text-slate-400 transition hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-white/[0.07] dark:hover:text-white"
+        }
+      >
+        {buttonText ? (
+          <><span>{buttonText}</span><MoreHorizontal className="h-4 w-4" /></>
+        ) : (
+          <MoreHorizontal className="h-5 w-5" />
+        )}
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          aria-label={label}
+          className={`absolute z-40 mt-2 min-w-56 overflow-hidden rounded-xl border border-slate-200 bg-white p-1.5 shadow-xl dark:border-white/[0.1] dark:bg-[#151617] ${align === "right" ? "right-0" : "left-0"}`}
+        >
+          {items.map((item) => (
+            <div key={item.id} className={item.separatorBefore ? "mt-1 border-t border-slate-100 pt-1 dark:border-white/[0.08]" : ""}>
+              <button
+                type="button"
+                role="menuitem"
+                disabled={item.disabled}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  if (item.disabled) return;
+                  setOpen(false);
+                  item.onSelect?.();
+                }}
+                className={`flex min-h-10 w-full items-center justify-between gap-4 rounded-lg px-3 py-2 text-left text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-40 ${
+                  item.destructive
+                    ? "text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-500/10"
+                    : "text-slate-700 hover:bg-slate-100 dark:text-slate-200 dark:hover:bg-white/[0.07]"
+                }`}
+              >
+                <span>{item.label}</span>
+                {item.hint && <span className="text-xs font-normal text-slate-400 dark:text-slate-500">{item.hint}</span>}
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/action-menu.tsx
+++ b/components/action-menu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { KeyboardEvent as ReactKeyboardEvent, ReactNode, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { MoreHorizontal } from "lucide-react";
 
 export interface ActionMenuItem {
@@ -23,6 +24,7 @@ interface ActionMenuProps {
 
 export function ActionMenu({ label, items, buttonText, align = "right", className = "" }: ActionMenuProps) {
   const [open, setOpen] = useState(false);
+  const [menuPosition, setMenuPosition] = useState({ top: 0, left: 0 });
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -32,11 +34,23 @@ export function ActionMenu({ label, items, buttonText, align = "right", classNam
     if (restoreFocus) requestAnimationFrame(() => triggerRef.current?.focus());
   }
 
+  function updateMenuPosition() {
+    const triggerRect = triggerRef.current?.getBoundingClientRect();
+    if (!triggerRect) return;
+    const menuWidth = 224;
+    const preferredLeft = align === "right" ? triggerRect.right - menuWidth : triggerRect.left;
+    setMenuPosition({
+      top: triggerRect.bottom + 8,
+      left: Math.min(Math.max(8, preferredLeft), window.innerWidth - menuWidth - 8),
+    });
+  }
+
   useEffect(() => {
     if (!open) return;
 
     function closeOnOutsidePointer(event: MouseEvent | TouchEvent) {
-      if (rootRef.current && !rootRef.current.contains(event.target as Node)) closeMenu();
+      const target = event.target as Node;
+      if (!rootRef.current?.contains(target) && !menuRef.current?.contains(target)) closeMenu();
     }
 
     function closeOnDocumentKey(event: KeyboardEvent) {
@@ -44,18 +58,29 @@ export function ActionMenu({ label, items, buttonText, align = "right", classNam
       if (event.key === "Tab") closeMenu();
     }
 
+    const triggerRect = triggerRef.current?.getBoundingClientRect();
+
     document.addEventListener("mousedown", closeOnOutsidePointer);
     document.addEventListener("touchstart", closeOnOutsidePointer);
     document.addEventListener("keydown", closeOnDocumentKey);
     requestAnimationFrame(() => {
-      menuRef.current?.querySelector<HTMLButtonElement>('[role="menuitem"]:not(:disabled)')?.focus();
+      const menu = menuRef.current;
+      if (!menu) return;
+      const menuRect = menu.getBoundingClientRect();
+      if (menuRect.bottom > window.innerHeight - 8) {
+        setMenuPosition((position) => ({
+          ...position,
+          top: Math.max(8, triggerRect ? triggerRect.top - menuRect.height - 8 : 8),
+        }));
+      }
+      menu.querySelector<HTMLButtonElement>('[role="menuitem"]:not(:disabled)')?.focus();
     });
     return () => {
       document.removeEventListener("mousedown", closeOnOutsidePointer);
       document.removeEventListener("touchstart", closeOnOutsidePointer);
       document.removeEventListener("keydown", closeOnDocumentKey);
     };
-  }, [open]);
+  }, [align, open]);
 
   function handleMenuKeyDown(event: ReactKeyboardEvent<HTMLDivElement>) {
     if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
@@ -81,6 +106,7 @@ export function ActionMenu({ label, items, buttonText, align = "right", classNam
         aria-expanded={open}
         onClick={(event) => {
           event.stopPropagation();
+          if (!open) updateMenuPosition();
           setOpen((value) => !value);
         }}
         onKeyDown={(event) => event.stopPropagation()}
@@ -96,13 +122,14 @@ export function ActionMenu({ label, items, buttonText, align = "right", classNam
         )}
       </button>
 
-      {open && (
+      {open && typeof document !== "undefined" && createPortal(
         <div
           ref={menuRef}
           role="menu"
           aria-label={label}
           onKeyDown={handleMenuKeyDown}
-          className={`absolute z-40 mt-2 min-w-56 overflow-hidden rounded-xl border border-slate-200 bg-white p-1.5 shadow-xl dark:border-white/[0.1] dark:bg-[#151617] ${align === "right" ? "right-0" : "left-0"}`}
+          style={{ top: menuPosition.top, left: menuPosition.left }}
+          className="fixed z-[100] min-w-56 overflow-hidden rounded-xl border border-slate-200 bg-white p-1.5 shadow-xl dark:border-white/[0.1] dark:bg-[#151617]"
         >
           {items.map((item) => (
             <div key={item.id} className={item.separatorBefore ? "mt-1 border-t border-slate-100 pt-1 dark:border-white/[0.08]" : ""}>
@@ -127,7 +154,8 @@ export function ActionMenu({ label, items, buttonText, align = "right", classNam
               </button>
             </div>
           ))}
-        </div>
+        </div>,
+        document.body,
       )}
     </div>
   );

--- a/components/application-table.tsx
+++ b/components/application-table.tsx
@@ -17,6 +17,7 @@ import { Application, ApplicationStatus, Contact, STATUS_COLORS, STATUS_ROW_COLO
 import { format, isPast, isToday } from "date-fns";
 import { de, enUS } from "date-fns/locale";
 import { useLocale } from "next-intl";
+import { ActionMenu } from "./action-menu";
 
 const columnHelper = createColumnHelper<Application>();
 
@@ -93,7 +94,18 @@ function MobileApplicationCard({ app, onEdit, onDelete, onArchive, showArchived 
   }
 
   return (
-    <article className="rounded-2xl border border-slate-200/80 bg-white/85 p-4 shadow-sm backdrop-blur dark:border-white/[0.08] dark:bg-white/[0.035]">
+    <article
+      className="cursor-pointer rounded-2xl border border-slate-200/80 bg-white/85 p-4 shadow-sm backdrop-blur transition hover:border-indigo-300 hover:shadow-md dark:border-white/[0.08] dark:bg-white/[0.035] dark:hover:border-indigo-500/50"
+      onClick={() => onEdit(app)}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onEdit(app);
+        }
+      }}
+      role="button"
+      tabIndex={0}
+    >
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
           <h3 className="flex items-center gap-1.5 text-base font-semibold text-gray-900 dark:text-white">
@@ -177,27 +189,18 @@ function MobileApplicationCard({ app, onEdit, onDelete, onArchive, showArchived 
         </div>
       )}
 
-      <div className="mt-4 flex flex-wrap gap-2">
-        <button
-          onClick={() => onEdit(app)}
-          className="flex min-h-[44px] items-center justify-center rounded-lg bg-blue-50 px-3 text-sm font-medium text-blue-700 transition-colors hover:bg-blue-100 dark:bg-blue-500/15 dark:text-blue-300 dark:hover:bg-blue-500/25"
-        >
-          {ta("edit")}
-        </button>
-        {onArchive && (
-          <button
-            onClick={() => onArchive(app.id, !showArchived)}
-            className="flex min-h-[44px] items-center justify-center rounded-lg bg-amber-50 px-3 text-sm font-medium text-amber-700 transition-colors hover:bg-amber-100 dark:bg-amber-500/15 dark:text-amber-300 dark:hover:bg-amber-500/25"
-          >
-            {showArchived ? ta("unarchive") : ta("archive")}
-          </button>
-        )}
-        <button
-          onClick={() => onDelete(app.id)}
-          className="flex min-h-[44px] items-center justify-center rounded-lg bg-red-50 px-3 text-sm font-medium text-red-600 transition-colors hover:bg-red-100 dark:bg-red-500/15 dark:text-red-300 dark:hover:bg-red-500/25"
-        >
-          {ta("delete")}
-        </button>
+      <div className="mt-4 flex justify-end" onClick={(event) => event.stopPropagation()}>
+        <ActionMenu
+          label={ta("opportunity_actions", { company: app.company || t("company") })}
+          buttonText={ta("more")}
+          items={[
+            { id: "edit", label: ta("edit"), onSelect: () => onEdit(app) },
+            ...(onArchive
+              ? [{ id: "archive", label: showArchived ? ta("unarchive") : ta("archive"), onSelect: () => onArchive(app.id, !showArchived) }]
+              : []),
+            { id: "delete", label: ta("delete"), destructive: true, separatorBefore: true, onSelect: () => onDelete(app.id) },
+          ]}
+        />
       </div>
     </article>
   );
@@ -383,28 +386,16 @@ export function ApplicationTable({ applications, onEdit, onDelete, onArchive, sh
       id: "actions",
       header: "",
       cell: ({ row }) => (
-        <div className="flex items-center">
-          <button
-            onClick={() => onEdit(row.original)}
-            className="flex items-center min-h-[44px] px-1.5 text-blue-600 hover:text-blue-800 text-sm font-medium transition-colors"
-          >
-            {ta("edit")}
-          </button>
-          {onArchive && (
-            <button
-              onClick={() => onArchive(row.original.id, !showArchived)}
-              className="flex items-center min-h-[44px] px-1.5 text-amber-600 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-300 text-sm font-medium transition-colors"
-            >
-              {showArchived ? ta("unarchive") : ta("archive")}
-            </button>
-          )}
-          <button
-            onClick={() => onDelete(row.original.id)}
-            className="flex items-center min-h-[44px] px-1.5 text-red-500 hover:text-red-700 text-sm font-medium transition-colors"
-          >
-            {ta("delete")}
-          </button>
-        </div>
+        <ActionMenu
+          label={ta("opportunity_actions", { company: row.original.company || t("company") })}
+          items={[
+            { id: "edit", label: ta("edit"), onSelect: () => onEdit(row.original) },
+            ...(onArchive
+              ? [{ id: "archive", label: showArchived ? ta("unarchive") : ta("archive"), onSelect: () => onArchive(row.original.id, !showArchived) }]
+              : []),
+            { id: "delete", label: ta("delete"), destructive: true, separatorBefore: true, onSelect: () => onDelete(row.original.id) },
+          ]}
+        />
       ),
     }),
   ];

--- a/components/application-table.tsx
+++ b/components/application-table.tsx
@@ -77,6 +77,24 @@ interface MobileApplicationCardProps {
   showArchived?: boolean;
 }
 
+function ApplicationActionMenu({ app, onEdit, onDelete, onArchive, showArchived, buttonText }: MobileApplicationCardProps & { buttonText?: string }) {
+  const t = useTranslations("table");
+  const ta = useTranslations("actions");
+  return (
+    <ActionMenu
+      label={ta("opportunity_actions", { company: app.company || t("company") })}
+      buttonText={buttonText}
+      items={[
+        { id: "edit", label: ta("edit"), onSelect: () => onEdit(app) },
+        ...(onArchive
+          ? [{ id: "archive", label: showArchived ? ta("unarchive") : ta("archive"), onSelect: () => onArchive(app.id, !showArchived) }]
+          : []),
+        { id: "delete", label: ta("delete"), destructive: true, separatorBefore: true, onSelect: () => onDelete(app.id) },
+      ]}
+    />
+  );
+}
+
 function MobileApplicationCard({ app, onEdit, onDelete, onArchive, showArchived }: MobileApplicationCardProps) {
   const t = useTranslations("table");
   const ta = useTranslations("actions");
@@ -98,6 +116,7 @@ function MobileApplicationCard({ app, onEdit, onDelete, onArchive, showArchived 
       className="cursor-pointer rounded-2xl border border-slate-200/80 bg-white/85 p-4 shadow-sm backdrop-blur transition hover:border-indigo-300 hover:shadow-md dark:border-white/[0.08] dark:bg-white/[0.035] dark:hover:border-indigo-500/50"
       onClick={() => onEdit(app)}
       onKeyDown={(event) => {
+        if (event.target !== event.currentTarget) return;
         if (event.key === "Enter" || event.key === " ") {
           event.preventDefault();
           onEdit(app);
@@ -173,7 +192,10 @@ function MobileApplicationCard({ app, onEdit, onDelete, onArchive, showArchived 
           <div className={notesExpanded ? "" : "line-clamp-3"}>{app.notes}</div>
           {app.notes.length > 120 && (
             <button
-              onClick={() => setNotesExpanded((v) => !v)}
+              onClick={(event) => {
+                event.stopPropagation();
+                setNotesExpanded((value) => !value);
+              }}
               className="mt-1 text-xs font-medium text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
             >
               {notesExpanded ? ta("show_less") : ta("show_more")}
@@ -190,17 +212,7 @@ function MobileApplicationCard({ app, onEdit, onDelete, onArchive, showArchived 
       )}
 
       <div className="mt-4 flex justify-end" onClick={(event) => event.stopPropagation()}>
-        <ActionMenu
-          label={ta("opportunity_actions", { company: app.company || t("company") })}
-          buttonText={ta("more")}
-          items={[
-            { id: "edit", label: ta("edit"), onSelect: () => onEdit(app) },
-            ...(onArchive
-              ? [{ id: "archive", label: showArchived ? ta("unarchive") : ta("archive"), onSelect: () => onArchive(app.id, !showArchived) }]
-              : []),
-            { id: "delete", label: ta("delete"), destructive: true, separatorBefore: true, onSelect: () => onDelete(app.id) },
-          ]}
-        />
+        <ApplicationActionMenu app={app} onEdit={onEdit} onDelete={onDelete} onArchive={onArchive} showArchived={showArchived} buttonText={ta("more")} />
       </div>
     </article>
   );
@@ -386,16 +398,7 @@ export function ApplicationTable({ applications, onEdit, onDelete, onArchive, sh
       id: "actions",
       header: "",
       cell: ({ row }) => (
-        <ActionMenu
-          label={ta("opportunity_actions", { company: row.original.company || t("company") })}
-          items={[
-            { id: "edit", label: ta("edit"), onSelect: () => onEdit(row.original) },
-            ...(onArchive
-              ? [{ id: "archive", label: showArchived ? ta("unarchive") : ta("archive"), onSelect: () => onArchive(row.original.id, !showArchived) }]
-              : []),
-            { id: "delete", label: ta("delete"), destructive: true, separatorBefore: true, onSelect: () => onDelete(row.original.id) },
-          ]}
-        />
+        <ApplicationActionMenu app={row.original} onEdit={onEdit} onDelete={onDelete} onArchive={onArchive} showArchived={showArchived} />
       ),
     }),
   ];

--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import { ApplicationTable } from "./application-table";
 import { ApplicationModal } from "./application-modal";
@@ -13,6 +13,7 @@ import { KeyboardShortcutBar } from "./keyboard-shortcut-bar";
 import { KeyboardShortcutDialog } from "./keyboard-shortcut-dialog";
 import { BulkActionBar } from "./bulk-action-bar";
 import { OnboardingWizard } from "./onboarding-wizard";
+import { ActionMenu, ActionMenuItem } from "./action-menu";
 import { Application, ApplicationStatus, STATUS_ORDER } from "@/types";
 import { format } from "date-fns";
 
@@ -215,6 +216,52 @@ export function Dashboard({ user, shareUrl, initialStatus, initialSource, initia
     }
     return { ...counts, highPriority: counts[5] + counts[4] };
   }, [activeApplications]);
+
+  const workspaceActions: ActionMenuItem[] = [
+    {
+      id: "toggle-archive",
+      label: showArchived ? ta("show_active") : ta("show_archive"),
+      hint: !showArchived && archivedApplications.length > 0 ? archivedApplications.length : undefined,
+      onSelect: () => setShowArchived((value) => !value),
+    },
+    {
+      id: "export",
+      label: ta("export_csv"),
+      onSelect: () => exportToCsv(visibleApplications),
+    },
+  ];
+
+  if (!showArchived) {
+    for (const days of ARCHIVE_THRESHOLDS) {
+      const cutoff = new Date();
+      cutoff.setDate(cutoff.getDate() - days);
+      const count = activeApplications.filter((application) => {
+        const date = application.appliedAt ? new Date(application.appliedAt) : new Date(application.createdAt);
+        return date < cutoff;
+      }).length;
+      workspaceActions.push({
+        id: `archive-age-${days}`,
+        label: ta("archive_old_option", { days }),
+        hint: count || undefined,
+        disabled: count === 0 || bulkArchiveMutation.isPending,
+        separatorBefore: days === ARCHIVE_THRESHOLDS[0],
+        onSelect: () => handleBulkArchive(days),
+      });
+    }
+    for (const stars of RATING_THRESHOLDS) {
+      const count = activeApplications.filter(
+        (application) => application.rating != null && application.rating <= stars,
+      ).length;
+      workspaceActions.push({
+        id: `archive-rating-${stars}`,
+        label: ta(stars === 1 ? "archive_rating_option_one" : "archive_rating_option", { stars }),
+        hint: count || undefined,
+        disabled: count === 0 || bulkArchiveMutation.isPending,
+        separatorBefore: stars === RATING_THRESHOLDS[0],
+        onSelect: () => handleBulkArchiveByRating(stars),
+      });
+    }
+  }
 
   // Overdue follow-ups banner (only active pipeline statuses, non-archived)
   const [dismissedOverdue, setDismissedOverdue] = useState<Set<string>>(() => {
@@ -475,14 +522,6 @@ export function Dashboard({ user, shareUrl, initialStatus, initialSource, initia
           </div>
           <div className="flex flex-wrap gap-2">
             <button
-              onClick={() => setIsCommandPaletteOpen(true)}
-              className="nexus-button-ghost min-h-10"
-              type="button"
-            >
-              ⌘K
-              <span className="text-slate-400">{tapp("command")}</span>
-            </button>
-            <button
               onClick={handleNewApplication}
               className="nexus-button-primary min-h-10"
               type="button"
@@ -493,25 +532,14 @@ export function Dashboard({ user, shareUrl, initialStatus, initialSource, initia
           </div>
         </div>
 
-        {/* Combined pipeline + triage overview */}
-        <section className="mb-6 rounded-2xl border border-slate-200/80 bg-white/80 px-4 py-3 shadow-sm backdrop-blur-xl dark:border-white/[0.08] dark:bg-white/[0.035] sm:px-5">
-          <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
+        {/* Decision-oriented overview */}
+        <section className="mb-6 rounded-2xl border border-slate-200/80 bg-white/80 px-4 py-4 shadow-sm backdrop-blur-xl dark:border-white/[0.08] dark:bg-white/[0.035] sm:px-5">
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4 sm:gap-6">
             <StatItem label={ts("total")} value={stats.total} className="text-blue-600 dark:text-blue-300" />
-            <StatItem label={ts("inbound")} value={stats.inbound} className="text-teal-600 dark:text-teal-300" />
             <StatItem label={ts("active")} value={stats.active} className="text-amber-600 dark:text-amber-300" />
-            <StatItem label={ts("offers")} value={stats.offers} className="text-emerald-600 dark:text-emerald-300" />
-            <StatItem label={ts("rejected")} value={stats.rejected} className="text-red-500 dark:text-red-300" />
-            <div className="hidden w-px self-stretch bg-slate-200 dark:bg-white/[0.08] sm:block" aria-hidden="true" />
-            <StatItem label={t("triage_this_week")} value={triageStats.thisWeek} className="text-slate-900 dark:text-white" />
-            <StatItem label={`5/5 ${t("triage_perfect")}`} value={triageStats[5]} className="text-green-600 dark:text-green-300" />
-            <StatItem label={`4/5 ${t("triage_strong")}`} value={triageStats[4]} className="text-blue-600 dark:text-blue-300" />
-            <StatItem label={`3/5 ${t("triage_consider")}`} value={triageStats[3]} className="text-yellow-600 dark:text-yellow-300" />
+            <StatItem label={ts("new_this_week")} value={triageStats.thisWeek} className="text-slate-900 dark:text-white" />
+            <StatItem label={ts("high_priority")} value={triageStats.highPriority} className="text-emerald-600 dark:text-emerald-300" />
           </div>
-          {triageStats.highPriority > 0 && (
-            <p className="mt-2 text-sm font-medium text-green-700 dark:text-green-400">
-              {t("triage_action", { count: triageStats.highPriority })}
-            </p>
-          )}
         </section>
 
         {/* Toolbar */}
@@ -521,11 +549,11 @@ export function Dashboard({ user, shareUrl, initialStatus, initialSource, initia
               {showArchived ? ta("archive") : t("applications")} ({visibleApplications.length})
             </h2>
           </div>
-          <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
-            <div className="inline-flex w-full items-center overflow-hidden rounded-lg border border-gray-200 text-sm dark:border-gray-600 sm:w-auto">
+          <div className="flex w-full items-center gap-2 sm:w-auto">
+            <div className="inline-flex min-w-0 flex-1 items-center overflow-hidden rounded-lg border border-gray-200 text-sm dark:border-gray-600 sm:flex-none">
               <button
                 onClick={() => setViewMode("table")}
-                className={`flex-1 px-3 py-1.5 font-medium transition-colors whitespace-nowrap sm:flex-none ${
+                className={`flex-1 px-3 py-2 font-medium transition-colors whitespace-nowrap sm:flex-none ${
                   viewMode === "table"
                     ? "bg-blue-600 text-white"
                     : "text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
@@ -535,7 +563,7 @@ export function Dashboard({ user, shareUrl, initialStatus, initialSource, initia
               </button>
               <button
                 onClick={() => setViewMode("kanban")}
-                className={`flex-1 px-3 py-1.5 font-medium transition-colors whitespace-nowrap sm:flex-none ${
+                className={`flex-1 px-3 py-2 font-medium transition-colors whitespace-nowrap sm:flex-none ${
                   viewMode === "kanban"
                     ? "bg-blue-600 text-white"
                     : "text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
@@ -544,35 +572,7 @@ export function Dashboard({ user, shareUrl, initialStatus, initialSource, initia
                 {tn("kanban_view")}
               </button>
             </div>
-
-            <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto">
-              <button
-                onClick={() => setShowArchived((v) => !v)}
-                className={`flex flex-1 items-center justify-center gap-1.5 whitespace-nowrap rounded-lg border px-3 py-2 text-sm font-medium transition-colors sm:flex-none ${
-                  showArchived
-                    ? "border-amber-300 dark:border-amber-600 bg-amber-50 dark:bg-amber-950/30 text-amber-700 dark:text-amber-300"
-                    : "border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
-                }`}
-              >
-                {showArchived ? ta("show_active") : ta("show_archive")}
-                {archivedApplications.length > 0 && !showArchived && (
-                  <span className="ml-1 inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-gray-200 px-1 text-xs font-bold text-gray-700 dark:bg-gray-600 dark:text-gray-200">
-                    {archivedApplications.length}
-                  </span>
-                )}
-              </button>
-
-              {!showArchived && <ArchiveOldDropdown applications={activeApplications} onArchive={handleBulkArchive} onArchiveByRating={handleBulkArchiveByRating} isPending={bulkArchiveMutation.isPending} />}
-
-              <button
-                onClick={() => exportToCsv(visibleApplications)}
-                title={ta("export_csv")}
-                className="flex flex-1 items-center justify-center gap-1.5 whitespace-nowrap rounded-lg border border-gray-200 px-3 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700 sm:flex-none"
-              >
-                <span>↓</span>
-                {ta("export_csv")}
-              </button>
-            </div>
+            <ActionMenu label={ta("more_actions")} buttonText={ta("more")} items={workspaceActions} />
           </div>
         </div>
 
@@ -640,124 +640,6 @@ export function Dashboard({ user, shareUrl, initialStatus, initialSource, initia
 
 const ARCHIVE_THRESHOLDS = [30, 60, 90, 180] as const;
 const RATING_THRESHOLDS = [1, 2, 3] as const;
-
-function ArchiveOldDropdown({
-  applications,
-  onArchive,
-  onArchiveByRating,
-  isPending,
-}: {
-  applications: Application[];
-  onArchive: (days: number) => void;
-  onArchiveByRating: (maxRating: number) => void;
-  isPending: boolean;
-}) {
-  const ta = useTranslations("actions");
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-
-  const countForDays = useCallback(
-    (days: number) => {
-      const cutoff = new Date();
-      cutoff.setDate(cutoff.getDate() - days);
-      return applications.filter((a) => {
-        const d = a.appliedAt ? new Date(a.appliedAt) : new Date(a.createdAt);
-        return d < cutoff;
-      }).length;
-    },
-    [applications]
-  );
-
-  const countForRating = useCallback(
-    (maxRating: number) =>
-      applications.filter((a) => a.rating !== null && a.rating !== undefined && a.rating <= maxRating).length,
-    [applications]
-  );
-
-  useEffect(() => {
-    function handleClickOutside(e: MouseEvent) {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    }
-    if (open) {
-      document.addEventListener("mousedown", handleClickOutside);
-      return () => document.removeEventListener("mousedown", handleClickOutside);
-    }
-  }, [open]);
-
-  return (
-    <div ref={ref} className="relative flex-1 sm:flex-none">
-      <button
-        onClick={() => setOpen((v) => !v)}
-        disabled={isPending}
-        className={`flex w-full items-center justify-center gap-1.5 whitespace-nowrap rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
-          open
-            ? "border-amber-300 dark:border-amber-600 bg-amber-50 dark:bg-amber-950/30 text-amber-700 dark:text-amber-300"
-            : "border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
-        } ${isPending ? "opacity-50 cursor-wait" : ""}`}
-      >
-        {isPending ? ta("archive_old_archiving") : ta("bulk_archive")}
-        <span className="text-xs">{open ? "▲" : "▼"}</span>
-      </button>
-      {open && (
-        <div className="absolute right-0 z-20 mt-1 w-56 rounded-lg border border-gray-200 bg-white shadow-lg dark:border-gray-600 dark:bg-gray-800">
-          {ARCHIVE_THRESHOLDS.map((days) => {
-            const count = countForDays(days);
-            return (
-              <button
-                key={`age-${days}`}
-                onClick={() => {
-                  setOpen(false);
-                  onArchive(days);
-                }}
-                disabled={count === 0}
-                className="flex w-full items-center justify-between px-4 py-2.5 text-sm text-left transition-colors hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed first:rounded-t-lg"
-              >
-                <span className="text-gray-700 dark:text-gray-200">
-                  {ta("archive_old_option", { days })}
-                </span>
-                {count > 0 && (
-                  <span className="inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-amber-100 px-1.5 text-xs font-bold text-amber-700 dark:bg-amber-900/50 dark:text-amber-300">
-                    {count}
-                  </span>
-                )}
-              </button>
-            );
-          })}
-          <div className="border-t border-gray-200 dark:border-gray-600 px-4 py-1.5">
-            <span className="text-xs font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">
-              {ta("archive_by_rating")}
-            </span>
-          </div>
-          {RATING_THRESHOLDS.map((stars) => {
-            const count = countForRating(stars);
-            return (
-              <button
-                key={`rating-${stars}`}
-                onClick={() => {
-                  setOpen(false);
-                  onArchiveByRating(stars);
-                }}
-                disabled={count === 0}
-                className="flex w-full items-center justify-between px-4 py-2.5 text-sm text-left transition-colors hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed last:rounded-b-lg"
-              >
-                <span className="text-gray-700 dark:text-gray-200">
-                  {ta(stars === 1 ? "archive_rating_option_one" : "archive_rating_option", { stars })}
-                </span>
-                {count > 0 && (
-                  <span className="inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-amber-100 px-1.5 text-xs font-bold text-amber-700 dark:bg-amber-900/50 dark:text-amber-300">
-                    {count}
-                  </span>
-                )}
-              </button>
-            );
-          })}
-        </div>
-      )}
-    </div>
-  );
-}
 
 function StatItem({ label, value, className }: { label: string; value: number; className?: string }) {
   return (

--- a/messages/de.json
+++ b/messages/de.json
@@ -21,7 +21,9 @@
     "inbound": "Neue Leads",
     "active": "Aktiv",
     "offers": "Abschluss",
-    "rejected": "Verloren"
+    "rejected": "Verloren",
+    "new_this_week": "Neu diese Woche",
+    "high_priority": "Hohe Priorität"
   },
   "actions": {
     "new_application": "Neue Opportunity",
@@ -51,7 +53,10 @@
     "archive_rating_option": "{stars} Sterne und darunter",
     "archive_rating_confirm": "{count} Opportunities mit {stars} Sternen und darunter archivieren?",
     "show_more": "Mehr anzeigen",
-    "show_less": "Weniger anzeigen"
+    "show_less": "Weniger anzeigen",
+    "more": "Mehr",
+    "more_actions": "Weitere Aktionen",
+    "opportunity_actions": "Aktionen für {company}"
   },
   "table": {
     "company": "Kunde",

--- a/messages/en.json
+++ b/messages/en.json
@@ -21,7 +21,9 @@
     "inbound": "New Leads",
     "active": "Active",
     "offers": "Closing",
-    "rejected": "Lost"
+    "rejected": "Lost",
+    "new_this_week": "New this week",
+    "high_priority": "High priority"
   },
   "actions": {
     "new_application": "New Opportunity",
@@ -51,7 +53,10 @@
     "archive_rating_option": "{stars} stars and below",
     "archive_rating_confirm": "Archive {count} opportunities rated {stars} stars and below?",
     "show_more": "Show more",
-    "show_less": "Show less"
+    "show_less": "Show less",
+    "more": "More",
+    "more_actions": "More actions",
+    "opportunity_actions": "Actions for {company}"
   },
   "table": {
     "company": "Account",

--- a/openspec/changes/simplify-opportunities-workspace/.openspec.yaml
+++ b/openspec/changes/simplify-opportunities-workspace/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-11

--- a/openspec/changes/simplify-opportunities-workspace/design.md
+++ b/openspec/changes/simplify-opportunities-workspace/design.md
@@ -1,0 +1,58 @@
+## Context
+
+The current page exposes controls in the global header, page heading, summary panel, workspace toolbar, table filter bar, and every opportunity row. The summary panel mixes pipeline status counts with triage distribution, producing nine equally weighted values. Existing behavior is valuable, but its presentation lacks progressive disclosure.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make opportunity review the dominant visual task.
+- Keep one obvious page-level primary action.
+- Surface only decision-oriented summary signals.
+- Consolidate infrequent utilities without removing functionality.
+- Improve desktop and mobile action density and accessibility.
+
+**Non-Goals:**
+- Changing application data, API contracts, permissions, or business rules.
+- Removing table, Kanban, archive, export, or bulk archival capabilities.
+- Redesigning unrelated Documents, Analytics, Resume AI, or Settings pages.
+
+## Decisions
+
+### Use progressive disclosure for secondary actions
+
+Archive access, CSV export, and rule-based bulk archive move into one labeled overflow menu. Row and mobile-card mutations use a single per-item menu. This preserves discoverability through labels and accessible menu semantics while reducing persistent controls.
+
+Alternative considered: remove rarely used actions entirely. Rejected because the user asked for cleanup rather than capability loss.
+
+### Reduce summary information to four signals
+
+The overview displays total active opportunities, active pipeline, incoming this week, and high-priority triage count. Detailed status and triage distributions remain available through table filters and Analytics instead of competing on the main page.
+
+Alternative considered: make the nine metrics horizontally scrollable or collapsible. Rejected because it retains unnecessary cognitive load and weakens the default hierarchy.
+
+### Keep creation as the only primary page action
+
+The command palette remains available through Cmd/Ctrl+K and the keyboard hint, but its dedicated page-heading button is removed. “New Opportunity” remains visibly emphasized.
+
+### Keep filters near table content
+
+Search and filters remain inside the table surface because they directly transform table results. Workspace-level controls stay in the workspace heading, separating view/navigation concerns from filtering concerns.
+
+### Build a reusable accessible menu primitive
+
+A small client-side action menu handles outside click, Escape, focusable labeled trigger, and destructive-action styling. It is shared by workspace utilities and row/card actions to keep behavior consistent without adding a dependency.
+
+## Risks / Trade-offs
+
+- [Secondary actions become one click deeper] → Use a clearly labeled “More” trigger at workspace level and an accessible ellipsis trigger per opportunity.
+- [Users may miss the command palette] → Preserve Cmd/Ctrl+K, keyboard hint bar, and command palette behavior.
+- [Reduced overview hides distribution detail] → Keep Analytics and existing filtering as detail destinations.
+- [Menus can introduce keyboard/accessibility regressions] → Add interaction tests and explicit ARIA labels/roles; validate Escape and outside-click dismissal.
+
+## Migration Plan
+
+Ship as a presentation-only frontend change. No migration is required. Rollback consists of reverting the UI commit; persisted data and APIs are unaffected.
+
+## Open Questions
+
+None. The supplied annotated screenshot gives sufficient direction for hierarchy and density.

--- a/openspec/changes/simplify-opportunities-workspace/proposal.md
+++ b/openspec/changes/simplify-opportunities-workspace/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The opportunities workspace gives secondary utilities and nine summary values nearly the same visual weight as the core task of reviewing and updating opportunities. This creates button sprawl, weak hierarchy, and a dense overview that is hard to scan—especially on smaller screens.
+
+## What Changes
+
+- Establish one primary page action: create a new opportunity.
+- Remove the visible command-palette button while preserving its keyboard shortcut.
+- Reduce the overview to four decision-oriented signals: total pipeline, active pipeline, new this week, and high-priority opportunities.
+- Consolidate view selection, archive access, CSV export, and bulk archival into one calm workspace toolbar with secondary actions in an overflow menu.
+- Replace per-row edit/archive/delete button clusters with a single accessible row-actions menu while retaining direct row opening.
+- Simplify mobile opportunity cards so their primary interaction opens details and secondary actions live in one menu.
+- Preserve table, Kanban, archive, filtering, export, keyboard, and mutation behavior.
+- Add responsive and interaction tests plus production screenshots for table, Kanban, details, and mobile states.
+
+## Capabilities
+
+### New Capabilities
+- `opportunities-workspace-hierarchy`: Defines the simplified hierarchy, progressive disclosure, responsive behavior, and accessible access to existing opportunity actions.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Primary UI components: `components/dashboard.tsx`, `components/application-table.tsx`, and shared action-menu presentation.
+- Localization: English and German action/summary labels.
+- Tests: component behavior for summary reduction and progressive action disclosure.
+- No API, database, authentication, or deployment contract changes.

--- a/openspec/changes/simplify-opportunities-workspace/proposal.md
+++ b/openspec/changes/simplify-opportunities-workspace/proposal.md
@@ -6,7 +6,7 @@ The opportunities workspace gives secondary utilities and nine summary values ne
 
 - Establish one primary page action: create a new opportunity.
 - Remove the visible command-palette button while preserving its keyboard shortcut.
-- Reduce the overview to four decision-oriented signals: total pipeline, active pipeline, new this week, and high-priority opportunities.
+- Reduce the overview to four decision-oriented signals: total active opportunities, active pipeline, new this week, and high-priority opportunities.
 - Consolidate view selection, archive access, CSV export, and bulk archival into one calm workspace toolbar with secondary actions in an overflow menu.
 - Replace per-row edit/archive/delete button clusters with a single accessible row-actions menu while retaining direct row opening.
 - Simplify mobile opportunity cards so their primary interaction opens details and secondary actions live in one menu.

--- a/openspec/changes/simplify-opportunities-workspace/specs/opportunities-workspace-hierarchy/spec.md
+++ b/openspec/changes/simplify-opportunities-workspace/specs/opportunities-workspace-hierarchy/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: A single primary page action
+The opportunities workspace SHALL present creation of a new opportunity as its only visually primary page-level action. The command palette MUST remain available through its existing keyboard shortcut without requiring a persistent page-heading button.
+
+#### Scenario: User scans the page heading
+- **WHEN** the opportunities workspace is rendered
+- **THEN** the heading exposes one emphasized action for creating a new opportunity
+- **AND** no command-palette button competes with that action
+
+#### Scenario: User invokes the command palette
+- **WHEN** the user presses Cmd+K or Ctrl+K
+- **THEN** the existing command palette opens
+
+### Requirement: Decision-oriented overview
+The opportunities workspace SHALL display no more than four default summary signals: total active opportunities, active pipeline opportunities, opportunities received this week, and high-priority opportunities. The overview MUST NOT display the full status and triage distributions by default.
+
+#### Scenario: User reviews the overview
+- **WHEN** application data has loaded
+- **THEN** exactly four summary values are presented
+- **AND** each value describes a distinct decision-oriented signal
+
+#### Scenario: High-priority opportunities exist
+- **WHEN** one or more opportunities have triage quality four or five
+- **THEN** the high-priority signal displays their combined count
+- **AND** the overview does not add a separate redundant action sentence
+
+### Requirement: Consolidated workspace utilities
+The workspace SHALL keep table/Kanban view selection directly visible and SHALL place archive access, CSV export, and rule-based bulk archival in one labeled secondary-actions menu.
+
+#### Scenario: User changes workspace view
+- **WHEN** the user selects Table or Kanban
+- **THEN** the corresponding view is displayed without opening an overflow menu
+
+#### Scenario: User needs a secondary utility
+- **WHEN** the user opens the workspace secondary-actions menu
+- **THEN** archive access, CSV export, and applicable bulk archive options are available
+- **AND** selecting an action preserves its existing behavior
+
+### Requirement: Progressive row and card actions
+Each opportunity row and mobile card SHALL provide one secondary-actions trigger instead of persistently displaying edit, archive, and delete controls. Opening the opportunity itself MUST remain a direct primary interaction.
+
+#### Scenario: User opens opportunity details
+- **WHEN** the user activates the opportunity name or card body
+- **THEN** the existing opportunity details editor opens directly
+
+#### Scenario: User opens opportunity actions
+- **WHEN** the user activates the opportunity action trigger
+- **THEN** edit, archive or unarchive, and delete actions are available as applicable
+- **AND** destructive actions are visually distinguished
+
+### Requirement: Responsive and accessible controls
+All consolidated controls SHALL remain usable on mobile and by keyboard. Menu triggers MUST expose accessible names, menus MUST close on Escape and outside interaction, and interactive targets MUST retain appropriate touch sizing.
+
+#### Scenario: Mobile workspace
+- **WHEN** the workspace is rendered at a narrow viewport
+- **THEN** the primary action, view selector, filters, and secondary-actions trigger remain usable without horizontal page overflow
+
+#### Scenario: Keyboard dismissal
+- **WHEN** a secondary-actions menu is open and the user presses Escape
+- **THEN** the menu closes and no underlying mutation is triggered

--- a/openspec/changes/simplify-opportunities-workspace/tasks.md
+++ b/openspec/changes/simplify-opportunities-workspace/tasks.md
@@ -1,0 +1,24 @@
+## 1. Shared interaction foundation
+
+- [x] 1.1 Add a reusable accessible action-menu component with outside-click and Escape dismissal
+- [x] 1.2 Add English and German labels for the reduced overview and consolidated menus
+- [x] 1.3 Add focused component tests for action-menu accessibility and progressive disclosure
+
+## 2. Workspace hierarchy
+
+- [x] 2.1 Remove the visible command button while preserving the keyboard shortcut and primary create action
+- [x] 2.2 Replace the nine-value overview and redundant high-priority sentence with four decision-oriented signals
+- [x] 2.3 Keep table/Kanban selection visible and consolidate archive, export, and bulk archival into one secondary menu
+
+## 3. Opportunity actions
+
+- [x] 3.1 Replace desktop table row action links with one accessible action menu
+- [x] 3.2 Replace mobile card action buttons with direct card opening and one accessible action menu
+- [x] 3.3 Verify edit, archive/unarchive, delete, selection, and filtering behavior remains intact
+
+## 4. Validation and evidence
+
+- [x] 4.1 Run ESLint and the Vitest suite
+- [x] 4.2 Run a production Next.js build
+- [x] 4.3 Inspect the production workspace at desktop and mobile breakpoints
+- [x] 4.4 Run strict OpenSpec validation and record all tasks complete


### PR DESCRIPTION
## Summary
- reduces the overloaded overview from nine values to four decision-oriented signals
- keeps New Opportunity as the sole primary action and consolidates archive/export utilities under More
- replaces desktop and mobile action clusters with accessible progressive-disclosure menus
- includes a strictly validated OpenSpec change

## UX validation
- production preview inspected at desktop and mobile breakpoints
- four-metric overview remains readable on mobile
- Table/Kanban controls and workspace More menu remain accessible
- row and mobile-card actions are consolidated without removing functionality

## Validation
- [x] `npm run lint` — 0 errors, 4 existing warnings
- [x] `npm test` — 121 tests passed
- [x] `npm run build`
- [x] `openspec validate simplify-opportunities-workspace --strict`
- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added accessible overflow menus for workspace and opportunity actions.
  - Grouped archive, export, bulk actions, edit, archive, and delete controls into streamlined menus.
  - Made mobile opportunity cards directly open details with keyboard support.
  - Simplified dashboard summaries to highlight total, active, new, and high-priority opportunities.
  - Added English and German labels for the new actions and statistics.

- **Tests**
  - Added accessibility and progressive-disclosure coverage for action menus.

- **Documentation**
  - Documented the updated workspace hierarchy and interaction model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->