### PR TITLE
Normalize source labels in application table

### DIFF
--- a/components/__tests__/application-table-source.test.tsx
+++ b/components/__tests__/application-table-source.test.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { NextIntlClientProvider } from "next-intl";
+import { describe, expect, it, vi } from "vitest";
+import en from "../../messages/en.json";
+import { ApplicationTable } from "../application-table";
+import type { Application } from "@/types";
+
+const application: Application = {
+  id: "app-1",
+  company: "Example",
+  role: "Engineer",
+  status: "applied",
+  appliedAt: null,
+  lastContact: null,
+  followUpAt: null,
+  notes: null,
+  jobDescription: null,
+  source: "2026-07-07 MCP scan: Himalayas + web search; canonical source pending",
+  remote: true,
+  salaryMin: null,
+  salaryMax: null,
+  rating: null,
+  jobUrl: null,
+  resumeId: null,
+  companySize: null,
+  salaryBandMentioned: false,
+  triageQuality: null,
+  triageReason: null,
+  incomingSource: null,
+  autoRejected: false,
+  autoRejectReason: null,
+  archivedAt: null,
+  createdAt: "2026-07-07T00:00:00.000Z",
+  updatedAt: "2026-07-07T00:00:00.000Z",
+};
+
+describe("ApplicationTable source column", () => {
+  it("shows the normalized category and retains raw provenance in the tooltip", () => {
+    const html = renderToStaticMarkup(
+      <NextIntlClientProvider locale="en" messages={en} timeZone="UTC">
+        <ApplicationTable
+          applications={[application]}
+          onEdit={vi.fn()}
+          onDelete={vi.fn()}
+        />
+      </NextIntlClientProvider>,
+    );
+
+    expect(html).toContain(">Himalayas<");
+    expect(html).toContain(`title="${application.source}"`);
+    expect(html).not.toContain(">2026-07-07 MCP scan:");
+  });
+});

--- a/components/application-table.tsx
+++ b/components/application-table.tsx
@@ -98,6 +98,7 @@ function ApplicationActionMenu({ app, onEdit, onDelete, onArchive, showArchived,
 function MobileApplicationCard({ app, onEdit, onDelete, onArchive, showArchived }: MobileApplicationCardProps) {
   const t = useTranslations("table");
   const ta = useTranslations("actions");
+  const tAnalytics = useTranslations("analytics");
   const locale = useLocale();
   const dateFnsLocale = locale === "de" ? de : enUS;
   const [notesExpanded, setNotesExpanded] = useState(false);
@@ -167,7 +168,12 @@ function MobileApplicationCard({ app, onEdit, onDelete, onArchive, showArchived 
         </div>
         <div>
           <div className="text-xs font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-0.5">{t("source")}</div>
-          <div className="text-gray-700 dark:text-gray-300 wrap-break-word">{app.source || "—"}</div>
+          <div
+            className="text-gray-700 dark:text-gray-300 wrap-break-word"
+            title={app.source || undefined}
+          >
+            {app.source ? tAnalytics(`source_labels.${getSourceCategory(app.source)}`) : "—"}
+          </div>
         </div>
         {app.rating && (
           <div>
@@ -237,6 +243,7 @@ interface ApplicationTableProps {
 export function ApplicationTable({ applications, onEdit, onDelete, onArchive, showArchived, initialStatusFilter, initialSourceFilter, initialGlobalFilter, selectedIds, onToggleSelect, onSelectAll, onClearSelection, focusedIndex }: ApplicationTableProps) {
   const t = useTranslations("table");
   const ta = useTranslations("actions");
+  const tAnalytics = useTranslations("analytics");
   const ts = useTranslations("status");
   const locale = useLocale();
   const dateFnsLocale = locale === "de" ? de : enUS;
@@ -370,13 +377,15 @@ export function ApplicationTable({ applications, onEdit, onDelete, onArchive, sh
     columnHelper.accessor("source", {
       header: t("source"),
       cell: (info) => {
-        const val = info.getValue();
-        return val ? (
+        const rawSource = info.getValue();
+        return rawSource ? (
           <span
             className="inline-flex max-w-36 items-center px-2 py-0.5 rounded-full text-xs font-medium bg-cyan-100 text-cyan-800 dark:bg-cyan-500/20 dark:text-cyan-300"
-            title={val}
+            title={rawSource}
           >
-            <span className="truncate">{val}</span>
+            <span className="truncate">
+              {tAnalytics(`source_labels.${getSourceCategory(rawSource)}`)}
+            </span>
           </span>
         ) : (
           <span className="text-gray-400 dark:text-gray-500">—</span>


### PR DESCRIPTION
## Summary
- display the same localized source categories in the table and mobile cards as in Analytics
- retain the complete raw source provenance in the native tooltip
- add regression coverage for verbose MCP scan metadata

## Validation
- [x] `npm test` — 142 tests passed
- [x] `npm run lint` — 0 errors (4 existing warnings)
- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [x] `git diff --check`