### PR TITLE
feat: preserve immutable application submission packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ A lead and opportunity management suite for tracking your sales pipeline. Manage
 - **Google OAuth** — secure login, multi-user with per-user admin roles
 - **Email Intelligence** — Gmail integration to auto-detect and import client communications
 - **MCP Server** — Model Context Protocol endpoint for AI agent integration (OAuth 2.1 + PKCE)
+- **Submission Packages** — immutable, idempotent snapshots of submitted answers, compensation, CVs, cover letters, and timeline events
+- **Interview Recall** — owner-scoped MCP retrieval of the job description, exact submissions, documents, and application timeline
 - **API Docs** — OpenAPI 3.1 spec with Swagger UI at `/api-docs`, LLM-friendly guide at `/llm.txt`
 - **Rate Limiting** — per-IP rate limits on all API routes with standard headers
 - **Security Hardened** — CSP, HSTS, X-Frame-Options, gitleaks pre-commit hooks, encrypted email tokens
@@ -238,6 +240,8 @@ The data layer uses a factory pattern (`lib/db/index.ts`). The `DB_PROVIDER` env
 - **`firestore`** — Firebase Admin SDK with Firestore
 
 All API routes call `getDb()` which returns a `DatabaseAdapter` interface. Swapping backends requires zero code changes.
+
+Firestore deployments must also apply the composite indexes in `firestore.indexes.json` (for example, `firebase deploy --only firestore:indexes`). PostgreSQL deployments apply the Prisma migration before starting the new application build.
 
 ### Storage Abstraction
 

--- a/app/api/applications/[id]/contacts/route.ts
+++ b/app/api/applications/[id]/contacts/route.ts
@@ -24,7 +24,7 @@ export async function POST(
     return NextResponse.json({ error: "name is required" }, { status: 400 });
   }
 
-  const contact = await getDb().createContact(applicationId, {
+  const contact = await getDb().createContact(applicationId, auth.userId, {
     name: String(name).slice(0, 255),
     email: email ? String(email).slice(0, 255) : null,
     phone: phone ? String(phone).slice(0, 50) : null,

--- a/app/api/applications/[id]/events/route.ts
+++ b/app/api/applications/[id]/events/route.ts
@@ -26,7 +26,12 @@ export async function POST(
   const auth = await requireAuth();
   if (!auth) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   const { id } = await params;
-  const body = await request.json() as Record<string, unknown>;
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json() as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
   const type = String(body.type ?? "").trim().slice(0, 100);
   if (!type) return NextResponse.json({ error: "type is required" }, { status: 400 });
   const occurredAt = body.occurredAt ? new Date(String(body.occurredAt)) : new Date();

--- a/app/api/applications/[id]/events/route.ts
+++ b/app/api/applications/[id]/events/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import { requireAuth } from "@/lib/session";
+import { validateEventMetadata } from "@/lib/applications/submission";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireAuth();
+  if (!auth) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const { id } = await params;
+  const rawLimit = Number(request.nextUrl.searchParams.get("limit") ?? 100);
+  const limit = Number.isInteger(rawLimit) ? Math.max(1, Math.min(500, rawLimit)) : 100;
+  try {
+    return NextResponse.json(await getDb().listApplicationEvents(id, auth.userId, limit));
+  } catch {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireAuth();
+  if (!auth) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const { id } = await params;
+  const body = await request.json() as Record<string, unknown>;
+  const type = String(body.type ?? "").trim().slice(0, 100);
+  if (!type) return NextResponse.json({ error: "type is required" }, { status: 400 });
+  const occurredAt = body.occurredAt ? new Date(String(body.occurredAt)) : new Date();
+  if (Number.isNaN(occurredAt.getTime())) {
+    return NextResponse.json({ error: "occurredAt must be a valid ISO timestamp" }, { status: 400 });
+  }
+  const idempotencyKey = body.idempotencyKey == null
+    ? undefined
+    : String(body.idempotencyKey).trim();
+  if (idempotencyKey && (idempotencyKey.length < 8 || idempotencyKey.length > 128)) {
+    return NextResponse.json({ error: "idempotencyKey must contain 8-128 characters" }, { status: 400 });
+  }
+  try {
+    const event = await getDb().createApplicationEvent(id, auth.userId, {
+      type,
+      occurredAt,
+      source: "rest",
+      actor: auth.user.email,
+      idempotencyKey,
+      metadata: validateEventMetadata(body.metadata),
+    });
+    return NextResponse.json(event, { status: 201 });
+  } catch (error) {
+    const code = error instanceof Error ? error.message : "event_failed";
+    const status = code === "not_found" ? 404 : code.includes("idempotency") ? 409 : 400;
+    return NextResponse.json({ error: code }, { status });
+  }
+}

--- a/app/api/applications/[id]/events/route.ts
+++ b/app/api/applications/[id]/events/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import { requireAuth } from "@/lib/session";
-import { validateEventMetadata } from "@/lib/applications/submission";
+import {
+  requireOccurredAtForIdempotency,
+  validateEventMetadata,
+} from "@/lib/applications/submission";
 
 export async function GET(
   request: NextRequest,
@@ -43,6 +46,14 @@ export async function POST(
     : String(body.idempotencyKey).trim();
   if (idempotencyKey && (idempotencyKey.length < 8 || idempotencyKey.length > 128)) {
     return NextResponse.json({ error: "idempotencyKey must contain 8-128 characters" }, { status: 400 });
+  }
+  try {
+    requireOccurredAtForIdempotency(idempotencyKey, body.occurredAt as string | undefined);
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "invalid_idempotent_event" },
+      { status: 400 },
+    );
   }
   try {
     const event = await getDb().createApplicationEvent(id, auth.userId, {

--- a/app/api/applications/[id]/route.ts
+++ b/app/api/applications/[id]/route.ts
@@ -49,9 +49,9 @@ export async function PATCH(
   const body = await request.json();
   const { company, role, status, appliedAt, lastContact, followUpAt, notes, jobDescription, source, remote, salaryMin, salaryMax, rating, jobUrl, resumeId, archivedAt, companySize, salaryBandMentioned, triageQuality, triageReason, incomingSource, autoRejected, autoRejectReason } = body;
 
-  const parsedSalaryMin = salaryMin != null ? Number(salaryMin) : null;
-  const parsedSalaryMax = salaryMax != null ? Number(salaryMax) : null;
-  const parsedRating = rating != null ? Number(rating) : null;
+  const parsedSalaryMin = salaryMin != null && salaryMin !== "" ? Number(salaryMin) : null;
+  const parsedSalaryMax = salaryMax != null && salaryMax !== "" ? Number(salaryMax) : null;
+  const parsedRating = rating != null && rating !== "" ? Number(rating) : null;
   if (
     (parsedSalaryMin !== null && (!Number.isInteger(parsedSalaryMin) || parsedSalaryMin < 0)) ||
     (parsedSalaryMax !== null && (!Number.isInteger(parsedSalaryMax) || parsedSalaryMax < 0))
@@ -76,6 +76,14 @@ export async function PATCH(
       { error: error instanceof Error ? error.message : "Invalid structured metadata" },
       { status: 400 },
     );
+  }
+
+  let expectedUpdatedAt: Date | undefined;
+  if (body.expectedUpdatedAt !== undefined) {
+    expectedUpdatedAt = new Date(String(body.expectedUpdatedAt));
+    if (Number.isNaN(expectedUpdatedAt.getTime())) {
+      return NextResponse.json({ error: "invalid_expected_updated_at" }, { status: 400 });
+    }
   }
 
   try {
@@ -132,15 +140,19 @@ export async function PATCH(
       archivedAt: archivedAt ? new Date(archivedAt) : null,
     }),
     ...structuredMetadata,
-    ...(body.expectedUpdatedAt && {
-      expectedUpdatedAt: new Date(String(body.expectedUpdatedAt)),
+    ...(expectedUpdatedAt !== undefined && {
+      expectedUpdatedAt,
     }),
     });
 
     return NextResponse.json(application);
   } catch (error) {
     const code = error instanceof Error ? error.message : "update_failed";
-    const responseStatus = code === "conflict" ? 409 : code === "not_found" ? 404 : 400;
+    const responseStatus = code === "conflict" || code === "canonical_job_url_conflict"
+      ? 409
+      : code === "not_found"
+        ? 404
+        : 400;
     return NextResponse.json({ error: code }, { status: responseStatus });
   }
 }

--- a/app/api/applications/[id]/route.ts
+++ b/app/api/applications/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import { requireAuth } from "@/lib/session";
 import { normalizeStatus, normalizeSource, COMPANY_SIZE_OPTIONS, INCOMING_SOURCE_OPTIONS } from "@/types";
+import { parseStructuredApplicationMetadata } from "@/lib/applications/metadata";
 
 const VALID_COMPANY_SIZES = COMPANY_SIZE_OPTIONS.map((o) => o.value) as string[];
 const VALID_INCOMING_SOURCES = INCOMING_SOURCE_OPTIONS as readonly string[];
@@ -48,8 +49,18 @@ export async function PATCH(
   const body = await request.json();
   const { company, role, status, appliedAt, lastContact, followUpAt, notes, jobDescription, source, remote, salaryMin, salaryMax, rating, jobUrl, resumeId, archivedAt, companySize, salaryBandMentioned, triageQuality, triageReason, incomingSource, autoRejected, autoRejectReason } = body;
 
-  const parsedSalaryMin = salaryMin != null ? parseInt(String(salaryMin), 10) : null;
-  const parsedSalaryMax = salaryMax != null ? parseInt(String(salaryMax), 10) : null;
+  const parsedSalaryMin = salaryMin != null ? Number(salaryMin) : null;
+  const parsedSalaryMax = salaryMax != null ? Number(salaryMax) : null;
+  const parsedRating = rating != null ? Number(rating) : null;
+  if (
+    (parsedSalaryMin !== null && (!Number.isInteger(parsedSalaryMin) || parsedSalaryMin < 0)) ||
+    (parsedSalaryMax !== null && (!Number.isInteger(parsedSalaryMax) || parsedSalaryMax < 0))
+  ) {
+    return NextResponse.json({ error: "salary values must be non-negative integers" }, { status: 400 });
+  }
+  if (parsedRating !== null && (!Number.isInteger(parsedRating) || parsedRating < 1 || parsedRating > 5)) {
+    return NextResponse.json({ error: "rating must be an integer from 1 to 5" }, { status: 400 });
+  }
   if (parsedSalaryMin != null && parsedSalaryMax != null && parsedSalaryMin > parsedSalaryMax) {
     return NextResponse.json(
       { error: "salaryMin must not exceed salaryMax" },
@@ -57,7 +68,18 @@ export async function PATCH(
     );
   }
 
-  const application = await getDb().updateApplication(id, auth.userId, {
+  let structuredMetadata;
+  try {
+    structuredMetadata = parseStructuredApplicationMetadata(body as Record<string, unknown>);
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Invalid structured metadata" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const application = await getDb().updateApplication(id, auth.userId, {
     ...(company !== undefined && { company: String(company).slice(0, 255) }),
     ...(role !== undefined && { role: String(role).slice(0, 255) }),
     ...(status !== undefined && { status: normalizeStatus(status) }),
@@ -81,7 +103,7 @@ export async function PATCH(
     ...(salaryMin !== undefined && { salaryMin: parsedSalaryMin }),
     ...(salaryMax !== undefined && { salaryMax: parsedSalaryMax }),
     ...(rating !== undefined && {
-      rating: rating != null ? Math.min(5, Math.max(1, parseInt(String(rating), 10))) : null,
+      rating: parsedRating,
     }),
     ...(jobUrl !== undefined && {
       jobUrl: jobUrl ? String(jobUrl).slice(0, 2000) : null,
@@ -109,9 +131,18 @@ export async function PATCH(
     ...(archivedAt !== undefined && {
       archivedAt: archivedAt ? new Date(archivedAt) : null,
     }),
-  });
+    ...structuredMetadata,
+    ...(body.expectedUpdatedAt && {
+      expectedUpdatedAt: new Date(String(body.expectedUpdatedAt)),
+    }),
+    });
 
-  return NextResponse.json(application);
+    return NextResponse.json(application);
+  } catch (error) {
+    const code = error instanceof Error ? error.message : "update_failed";
+    const responseStatus = code === "conflict" ? 409 : code === "not_found" ? 404 : 400;
+    return NextResponse.json({ error: code }, { status: responseStatus });
+  }
 }
 
 export async function DELETE(
@@ -124,7 +155,11 @@ export async function DELETE(
   }
 
   const { id } = await params;
-  await getDb().deleteApplication(id, auth.userId);
-
-  return NextResponse.json({ success: true });
+  try {
+    await getDb().deleteApplication(id, auth.userId);
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    const code = error instanceof Error ? error.message : "delete_failed";
+    return NextResponse.json({ error: code }, { status: code === "not_found" ? 404 : 400 });
+  }
 }

--- a/app/api/applications/[id]/submissions/route.ts
+++ b/app/api/applications/[id]/submissions/route.ts
@@ -1,0 +1,137 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import { requireAuth } from "@/lib/session";
+import { validateSubmissionAnswers } from "@/lib/applications/submission";
+
+const SALARY_PERIODS = new Set(["hour", "day", "month", "year"]);
+const SALARY_TYPES = new Set(["base", "total", "contract_rate"]);
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireAuth();
+  if (!auth) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const { id } = await params;
+  try {
+    const includeAnswers = request.nextUrl.searchParams.get("includeAnswers") === "true";
+    const submissions = await getDb().listApplicationSubmissions(id, auth.userId, includeAnswers);
+    return NextResponse.json(submissions);
+  } catch {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireAuth();
+  if (!auth) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const { id } = await params;
+  try {
+    const body = await request.json() as Record<string, unknown>;
+    if (
+      typeof body.idempotencyKey !== "string" ||
+      body.idempotencyKey.length < 8 ||
+      body.idempotencyKey.length > 128
+    ) {
+      return NextResponse.json({ error: "idempotencyKey must contain 8-128 characters" }, { status: 400 });
+    }
+    const submittedAt = new Date(String(body.submittedAt ?? ""));
+    if (Number.isNaN(submittedAt.getTime())) {
+      return NextResponse.json({ error: "submittedAt must be a valid ISO timestamp" }, { status: 400 });
+    }
+    const answers = validateSubmissionAnswers(
+      Array.isArray(body.answers) ? body.answers as Parameters<typeof validateSubmissionAnswers>[0] : [],
+    );
+    const salaryMin = body.candidateSalaryMin == null ? null : Number(body.candidateSalaryMin);
+    const salaryMax = body.candidateSalaryMax == null ? null : Number(body.candidateSalaryMax);
+    if (
+      salaryMin !== null &&
+      (!Number.isInteger(salaryMin) || salaryMin < 0)
+    ) {
+      return NextResponse.json({ error: "candidateSalaryMin must be a non-negative integer" }, { status: 400 });
+    }
+    if (
+      salaryMax !== null &&
+      (!Number.isInteger(salaryMax) || salaryMax < 0)
+    ) {
+      return NextResponse.json({ error: "candidateSalaryMax must be a non-negative integer" }, { status: 400 });
+    }
+    if (salaryMin !== null && salaryMax !== null && salaryMin > salaryMax) {
+      return NextResponse.json({ error: "candidateSalaryMin must not exceed candidateSalaryMax" }, { status: 400 });
+    }
+    const salaryCurrency = body.candidateSalaryCurrency == null
+      ? null
+      : String(body.candidateSalaryCurrency).trim().toUpperCase();
+    if (salaryCurrency !== null && !/^[A-Z]{3}$/.test(salaryCurrency)) {
+      return NextResponse.json({ error: "candidateSalaryCurrency must be an ISO 4217 code" }, { status: 400 });
+    }
+    const salaryPeriod = body.candidateSalaryPeriod == null
+      ? null
+      : String(body.candidateSalaryPeriod);
+    if (salaryPeriod !== null && !SALARY_PERIODS.has(salaryPeriod)) {
+      return NextResponse.json({ error: "candidateSalaryPeriod is invalid" }, { status: 400 });
+    }
+    const salaryType = body.candidateSalaryType == null
+      ? null
+      : String(body.candidateSalaryType);
+    if (salaryType !== null && !SALARY_TYPES.has(salaryType)) {
+      return NextResponse.json({ error: "candidateSalaryType is invalid" }, { status: 400 });
+    }
+    const followUpAt = body.followUpAt === undefined
+      ? undefined
+      : body.followUpAt === null ? null : new Date(String(body.followUpAt));
+    if (followUpAt instanceof Date && Number.isNaN(followUpAt.getTime())) {
+      return NextResponse.json({ error: "followUpAt must be a valid ISO timestamp" }, { status: 400 });
+    }
+    const expectedUpdatedAt = body.expectedUpdatedAt
+      ? new Date(String(body.expectedUpdatedAt))
+      : undefined;
+    if (expectedUpdatedAt && Number.isNaN(expectedUpdatedAt.getTime())) {
+      return NextResponse.json({ error: "expectedUpdatedAt must be a valid ISO timestamp" }, { status: 400 });
+    }
+    const applicationUrl = body.applicationUrl == null
+      ? null
+      : String(body.applicationUrl).trim();
+    if (applicationUrl) {
+      let parsedUrl: URL;
+      try {
+        parsedUrl = new URL(applicationUrl);
+      } catch {
+        return NextResponse.json({ error: "applicationUrl must be a valid URL" }, { status: 400 });
+      }
+      if (!new Set(["http:", "https:"]).has(parsedUrl.protocol)) {
+        return NextResponse.json({ error: "applicationUrl must use HTTP or HTTPS" }, { status: 400 });
+      }
+    }
+    const result = await getDb().recordApplicationSubmission(auth.userId, {
+      applicationId: id,
+      idempotencyKey: body.idempotencyKey,
+      submittedAt,
+      followUpAt,
+      applicationUrl: applicationUrl?.slice(0, 2000) ?? null,
+      atsName: body.atsName == null ? null : String(body.atsName).slice(0, 100),
+      requisitionId: body.requisitionId == null ? null : String(body.requisitionId).slice(0, 255),
+      language: body.language == null ? null : String(body.language).slice(0, 20),
+      answers,
+      candidateSalaryMin: salaryMin,
+      candidateSalaryMax: salaryMax,
+      candidateSalaryCurrency: salaryCurrency,
+      candidateSalaryPeriod: salaryPeriod,
+      candidateSalaryType: salaryType,
+      candidateSalaryFlexible: body.candidateSalaryFlexible === true,
+      documentIds: Array.isArray(body.documentIds) ? body.documentIds.map(String).slice(0, 20) : [],
+      expectedUpdatedAt,
+      dryRun: body.dryRun === true,
+      source: "rest",
+      actor: auth.user.email,
+    });
+    return NextResponse.json(result, { status: result.dryRun || result.replayed ? 200 : 201 });
+  } catch (error) {
+    const code = error instanceof Error ? error.message : "submission_failed";
+    const status = code === "not_found" ? 404 : code === "conflict" || code.includes("idempotency") ? 409 : 400;
+    return NextResponse.json({ error: code }, { status });
+  }
+}

--- a/app/api/applications/[id]/submissions/route.ts
+++ b/app/api/applications/[id]/submissions/route.ts
@@ -42,8 +42,11 @@ export async function POST(
     if (Number.isNaN(submittedAt.getTime())) {
       return NextResponse.json({ error: "submittedAt must be a valid ISO timestamp" }, { status: 400 });
     }
+    if (!Array.isArray(body.answers)) {
+      return NextResponse.json({ error: "answers must be an array" }, { status: 400 });
+    }
     const answers = validateSubmissionAnswers(
-      Array.isArray(body.answers) ? body.answers as Parameters<typeof validateSubmissionAnswers>[0] : [],
+      body.answers as Parameters<typeof validateSubmissionAnswers>[0],
     );
     const salaryMin = body.candidateSalaryMin == null ? null : Number(body.candidateSalaryMin);
     const salaryMax = body.candidateSalaryMax == null ? null : Number(body.candidateSalaryMax);

--- a/app/api/applications/route.ts
+++ b/app/api/applications/route.ts
@@ -93,30 +93,37 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const application = await getDb().createApplication(auth.userId, {
-    company: String(company).slice(0, 255),
-    role: String(role).slice(0, 255),
-    status: normalizeStatus(status || "inbound"),
-    appliedAt: resolveAppliedAtForCreate(status || "inbound", appliedAt),
-    lastContact: lastContact ? new Date(lastContact) : null,
-    followUpAt: followUpAt ? new Date(followUpAt) : null,
-    notes: notes ? String(notes).slice(0, 10000) : null,
-    jobDescription: jobDescription ? String(jobDescription).slice(0, 50000) : null,
-    source: normalizeSource(source),
-    remote: !!remote,
-    salaryMin: parsedSalaryMin,
-    salaryMax: parsedSalaryMax,
-    rating: parsedRating,
-    jobUrl: jobUrl ? String(jobUrl).slice(0, 2000) : null,
-    companySize: companySize && VALID_COMPANY_SIZES.includes(String(companySize)) ? String(companySize) : null,
-    salaryBandMentioned: parseBooleanField(salaryBandMentioned),
-    triageQuality: parseTriageQuality(triageQuality),
-    triageReason: triageReason ? String(triageReason).slice(0, 1000) : null,
-    incomingSource: incomingSource && VALID_INCOMING_SOURCES.includes(String(incomingSource)) ? String(incomingSource) : null,
-    autoRejected: parseBooleanField(autoRejected),
-    autoRejectReason: autoRejectReason ? String(autoRejectReason).slice(0, 1000) : null,
-    ...structuredMetadata,
-  });
+  try {
+    const application = await getDb().createApplication(auth.userId, {
+      company: String(company).slice(0, 255),
+      role: String(role).slice(0, 255),
+      status: normalizeStatus(status || "inbound"),
+      appliedAt: resolveAppliedAtForCreate(status || "inbound", appliedAt),
+      lastContact: lastContact ? new Date(lastContact) : null,
+      followUpAt: followUpAt ? new Date(followUpAt) : null,
+      notes: notes ? String(notes).slice(0, 10000) : null,
+      jobDescription: jobDescription ? String(jobDescription).slice(0, 50000) : null,
+      source: normalizeSource(source),
+      remote: !!remote,
+      salaryMin: parsedSalaryMin,
+      salaryMax: parsedSalaryMax,
+      rating: parsedRating,
+      jobUrl: jobUrl ? String(jobUrl).slice(0, 2000) : null,
+      companySize: companySize && VALID_COMPANY_SIZES.includes(String(companySize)) ? String(companySize) : null,
+      salaryBandMentioned: parseBooleanField(salaryBandMentioned),
+      triageQuality: parseTriageQuality(triageQuality),
+      triageReason: triageReason ? String(triageReason).slice(0, 1000) : null,
+      incomingSource: incomingSource && VALID_INCOMING_SOURCES.includes(String(incomingSource)) ? String(incomingSource) : null,
+      autoRejected: parseBooleanField(autoRejected),
+      autoRejectReason: autoRejectReason ? String(autoRejectReason).slice(0, 1000) : null,
+      ...structuredMetadata,
+    });
 
-  return NextResponse.json(application, { status: 201 });
+    return NextResponse.json(application, { status: 201 });
+  } catch (error) {
+    if (error instanceof Error && error.message === "canonical_job_url_conflict") {
+      return NextResponse.json({ error: "An application with this canonical job URL already exists" }, { status: 409 });
+    }
+    return NextResponse.json({ error: "Failed to create application" }, { status: 500 });
+  }
 }

--- a/app/api/applications/route.ts
+++ b/app/api/applications/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import { requireAuth } from "@/lib/session";
 import { normalizeStatus, normalizeSource, COMPANY_SIZE_OPTIONS, INCOMING_SOURCE_OPTIONS } from "@/types";
-import { resolveCreatedAtForCreate } from "@/lib/applications/defaults";
+import { resolveAppliedAtForCreate } from "@/lib/applications/defaults";
+import { parseStructuredApplicationMetadata } from "@/lib/applications/metadata";
 
 const VALID_COMPANY_SIZES = COMPANY_SIZE_OPTIONS.map((o) => o.value) as string[];
 const VALID_INCOMING_SOURCES = INCOMING_SOURCE_OPTIONS as readonly string[];
@@ -61,8 +62,19 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const parsedSalaryMin = salaryMin != null ? parseInt(String(salaryMin), 10) : null;
-  const parsedSalaryMax = salaryMax != null ? parseInt(String(salaryMax), 10) : null;
+  const parsedSalaryMin = salaryMin != null ? Number(salaryMin) : null;
+  const parsedSalaryMax = salaryMax != null ? Number(salaryMax) : null;
+  const parsedRating = rating != null ? Number(rating) : null;
+
+  if (
+    (parsedSalaryMin !== null && (!Number.isInteger(parsedSalaryMin) || parsedSalaryMin < 0)) ||
+    (parsedSalaryMax !== null && (!Number.isInteger(parsedSalaryMax) || parsedSalaryMax < 0))
+  ) {
+    return NextResponse.json({ error: "salary values must be non-negative integers" }, { status: 400 });
+  }
+  if (parsedRating !== null && (!Number.isInteger(parsedRating) || parsedRating < 1 || parsedRating > 5)) {
+    return NextResponse.json({ error: "rating must be an integer from 1 to 5" }, { status: 400 });
+  }
 
   if (parsedSalaryMin != null && parsedSalaryMax != null && parsedSalaryMin > parsedSalaryMax) {
     return NextResponse.json(
@@ -71,11 +83,21 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  let structuredMetadata;
+  try {
+    structuredMetadata = parseStructuredApplicationMetadata(body as Record<string, unknown>);
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Invalid structured metadata" },
+      { status: 400 },
+    );
+  }
+
   const application = await getDb().createApplication(auth.userId, {
     company: String(company).slice(0, 255),
     role: String(role).slice(0, 255),
-    status: normalizeStatus(status || "applied"),
-    appliedAt: resolveCreatedAtForCreate(appliedAt),
+    status: normalizeStatus(status || "inbound"),
+    appliedAt: resolveAppliedAtForCreate(status || "inbound", appliedAt),
     lastContact: lastContact ? new Date(lastContact) : null,
     followUpAt: followUpAt ? new Date(followUpAt) : null,
     notes: notes ? String(notes).slice(0, 10000) : null,
@@ -84,7 +106,7 @@ export async function POST(request: NextRequest) {
     remote: !!remote,
     salaryMin: parsedSalaryMin,
     salaryMax: parsedSalaryMax,
-    rating: rating != null ? Math.min(5, Math.max(1, parseInt(String(rating), 10))) : null,
+    rating: parsedRating,
     jobUrl: jobUrl ? String(jobUrl).slice(0, 2000) : null,
     companySize: companySize && VALID_COMPANY_SIZES.includes(String(companySize)) ? String(companySize) : null,
     salaryBandMentioned: parseBooleanField(salaryBandMentioned),
@@ -93,6 +115,7 @@ export async function POST(request: NextRequest) {
     incomingSource: incomingSource && VALID_INCOMING_SOURCES.includes(String(incomingSource)) ? String(incomingSource) : null,
     autoRejected: parseBooleanField(autoRejected),
     autoRejectReason: autoRejectReason ? String(autoRejectReason).slice(0, 1000) : null,
+    ...structuredMetadata,
   });
 
   return NextResponse.json(application, { status: 201 });

--- a/app/api/applications/route.ts
+++ b/app/api/applications/route.ts
@@ -62,9 +62,9 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const parsedSalaryMin = salaryMin != null ? Number(salaryMin) : null;
-  const parsedSalaryMax = salaryMax != null ? Number(salaryMax) : null;
-  const parsedRating = rating != null ? Number(rating) : null;
+  const parsedSalaryMin = salaryMin != null && salaryMin !== "" ? Number(salaryMin) : null;
+  const parsedSalaryMax = salaryMax != null && salaryMax !== "" ? Number(salaryMax) : null;
+  const parsedRating = rating != null && rating !== "" ? Number(rating) : null;
 
   if (
     (parsedSalaryMin !== null && (!Number.isInteger(parsedSalaryMin) || parsedSalaryMin < 0)) ||
@@ -123,6 +123,9 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     if (error instanceof Error && error.message === "canonical_job_url_conflict") {
       return NextResponse.json({ error: "An application with this canonical job URL already exists" }, { status: 409 });
+    }
+    if (error instanceof Error && error.message === "appliedAt_invalid") {
+      return NextResponse.json({ error: error.message }, { status: 400 });
     }
     return NextResponse.json({ error: "Failed to create application" }, { status: 500 });
   }

--- a/app/api/documents/[id]/route.ts
+++ b/app/api/documents/[id]/route.ts
@@ -3,6 +3,20 @@ import { getDb } from "@/lib/db";
 import { requireAuth } from "@/lib/session";
 import { deleteDocumentWithContent } from "@/lib/documents/service";
 
+function documentMutationError(error: unknown) {
+  const code = error instanceof Error ? error.message : "document_update_failed";
+  if (code === "not_found") {
+    return NextResponse.json({ error: code }, { status: 404 });
+  }
+  if (code === "submitted_document_immutable") {
+    return NextResponse.json({ error: code }, { status: 409 });
+  }
+  if (code === "invalid_applications" || code === "submitted_state_reserved") {
+    return NextResponse.json({ error: code }, { status: 400 });
+  }
+  return NextResponse.json({ error: "document_update_failed" }, { status: 500 });
+}
+
 export async function DELETE(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
@@ -64,8 +78,8 @@ export async function PATCH(
         return NextResponse.json({ error: "Not found" }, { status: 404 });
       }
       return NextResponse.json(document);
-    } catch {
-      return NextResponse.json({ error: "Not found, immutable, or access denied" }, { status: 409 });
+    } catch (error) {
+      return documentMutationError(error);
     }
   }
 
@@ -111,8 +125,8 @@ export async function PATCH(
         }),
       });
       return NextResponse.json(document);
-    } catch {
-      return NextResponse.json({ error: "Not found, immutable, or access denied" }, { status: 409 });
+    } catch (error) {
+      return documentMutationError(error);
     }
   }
 
@@ -124,7 +138,7 @@ export async function PATCH(
   try {
     const document = await getDb().updateDocumentLinks(id, auth.userId, applicationIds);
     return NextResponse.json(document);
-  } catch {
-    return NextResponse.json({ error: "Not found, immutable, or access denied" }, { status: 409 });
+  } catch (error) {
+    return documentMutationError(error);
   }
 }

--- a/app/api/documents/[id]/route.ts
+++ b/app/api/documents/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import { requireAuth } from "@/lib/session";
-import { deleteFile } from "@/lib/storage";
+import { deleteDocumentWithContent } from "@/lib/documents/service";
 
 export async function DELETE(
   _request: NextRequest,
@@ -14,12 +14,10 @@ export async function DELETE(
 
   const { id } = await params;
 
-  const document = await getDb().deleteDocument(id, auth.userId);
+  const document = await deleteDocumentWithContent(getDb(), id, auth.userId);
   if (!document) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
-
-  await deleteFile(document.filename);
 
   return new NextResponse(null, { status: 204 });
 }
@@ -35,7 +33,17 @@ export async function PATCH(
 
   const { id } = await params;
   const body = await request.json();
-  const { applicationIds, originalName } = body as { applicationIds?: string[]; originalName?: string };
+  const {
+    applicationIds,
+    originalName,
+    documentType,
+    state,
+    version,
+    contentHash,
+    source,
+    generatedAt,
+    submittedAt,
+  } = body as Record<string, unknown>;
 
   // Rename
   if (typeof originalName === "string") {
@@ -48,6 +56,53 @@ export async function PATCH(
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     }
     return NextResponse.json(document);
+  }
+
+  const metadataKeys = [
+    "documentType", "state", "version", "contentHash", "source", "generatedAt", "submittedAt",
+  ];
+  if (metadataKeys.some((key) => body[key] !== undefined)) {
+    const validStates = new Set(["draft", "current", "submitted", "superseded", "historical", "orphaned"]);
+    if (state !== undefined && (typeof state !== "string" || !validStates.has(state))) {
+      return NextResponse.json({ error: "Invalid document state" }, { status: 400 });
+    }
+    const parsedVersion = version === undefined ? undefined : Number(version);
+    if (parsedVersion !== undefined && (!Number.isInteger(parsedVersion) || parsedVersion < 1)) {
+      return NextResponse.json({ error: "version must be a positive integer" }, { status: 400 });
+    }
+    if (contentHash !== undefined && contentHash !== null && !/^[a-f0-9]{64}$/i.test(String(contentHash))) {
+      return NextResponse.json({ error: "contentHash must be a 64-character hexadecimal SHA-256 hash" }, { status: 400 });
+    }
+    const parseDocumentDate = (value: unknown) =>
+      value === undefined ? undefined : value === null ? null : new Date(String(value));
+    const parsedGeneratedAt = parseDocumentDate(generatedAt);
+    const parsedSubmittedAt = parseDocumentDate(submittedAt);
+    if (
+      (parsedGeneratedAt instanceof Date && Number.isNaN(parsedGeneratedAt.getTime()))
+      || (parsedSubmittedAt instanceof Date && Number.isNaN(parsedSubmittedAt.getTime()))
+    ) {
+      return NextResponse.json({ error: "Document timestamps must be valid ISO 8601 dates" }, { status: 400 });
+    }
+    try {
+      const document = await getDb().updateDocumentMetadata(id, auth.userId, {
+        ...(documentType !== undefined && { documentType: String(documentType).slice(0, 100) }),
+        ...(state !== undefined && { state: String(state) }),
+        ...(parsedVersion !== undefined && { version: parsedVersion }),
+        ...(contentHash !== undefined && {
+          contentHash: contentHash ? String(contentHash) : null,
+        }),
+        ...(source !== undefined && { source: source ? String(source).slice(0, 100) : null }),
+        ...(generatedAt !== undefined && {
+          generatedAt: parsedGeneratedAt,
+        }),
+        ...(submittedAt !== undefined && {
+          submittedAt: parsedSubmittedAt,
+        }),
+      });
+      return NextResponse.json(document);
+    } catch {
+      return NextResponse.json({ error: "Not found, immutable, or access denied" }, { status: 409 });
+    }
   }
 
   // Update application links

--- a/app/api/documents/[id]/route.ts
+++ b/app/api/documents/[id]/route.ts
@@ -14,12 +14,19 @@ export async function DELETE(
 
   const { id } = await params;
 
-  const document = await deleteDocumentWithContent(getDb(), id, auth.userId);
-  if (!document) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
-  }
+  try {
+    const document = await deleteDocumentWithContent(getDb(), id, auth.userId);
+    if (!document) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
 
-  return new NextResponse(null, { status: 204 });
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    if (error instanceof Error && error.message === "submitted_document_immutable") {
+      return NextResponse.json({ error: "Submitted and historical documents are immutable" }, { status: 409 });
+    }
+    return NextResponse.json({ error: "Failed to delete document" }, { status: 500 });
+  }
 }
 
 export async function PATCH(
@@ -51,11 +58,15 @@ export async function PATCH(
     if (trimmed.length === 0 || trimmed.length > 255) {
       return NextResponse.json({ error: "originalName must be 1-255 characters" }, { status: 400 });
     }
-    const document = await getDb().renameDocument(id, auth.userId, trimmed);
-    if (!document) {
-      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    try {
+      const document = await getDb().renameDocument(id, auth.userId, trimmed);
+      if (!document) {
+        return NextResponse.json({ error: "Not found" }, { status: 404 });
+      }
+      return NextResponse.json(document);
+    } catch {
+      return NextResponse.json({ error: "Not found, immutable, or access denied" }, { status: 409 });
     }
-    return NextResponse.json(document);
   }
 
   const metadataKeys = [
@@ -110,6 +121,10 @@ export async function PATCH(
     return NextResponse.json({ error: "applicationIds must be an array or originalName must be a string" }, { status: 400 });
   }
 
-  const document = await getDb().updateDocumentLinks(id, auth.userId, applicationIds);
-  return NextResponse.json(document);
+  try {
+    const document = await getDb().updateDocumentLinks(id, auth.userId, applicationIds);
+    return NextResponse.json(document);
+  } catch {
+    return NextResponse.json({ error: "Not found, immutable, or access denied" }, { status: 409 });
+  }
 }

--- a/app/api/documents/route.ts
+++ b/app/api/documents/route.ts
@@ -7,13 +7,31 @@ import {
   uploadDocument,
 } from "@/lib/documents/upload";
 
-export async function GET(_request: NextRequest) {
+export async function GET(request: NextRequest) {
   const auth = await requireAuth();
   if (!auth) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const documents = await getDb().listDocuments(auth.readScopeUserId);
+  const params = request.nextUrl.searchParams;
+  const rawPage = params.has("page") ? Number(params.get("page")) : undefined;
+  const rawPageSize = params.has("pageSize") ? Number(params.get("pageSize")) : undefined;
+  if (
+    (rawPage !== undefined && (!Number.isInteger(rawPage) || rawPage < 1)) ||
+    (rawPageSize !== undefined && (!Number.isInteger(rawPageSize) || rawPageSize < 1 || rawPageSize > 200))
+  ) {
+    return NextResponse.json({ error: "Invalid pagination parameters" }, { status: 400 });
+  }
+  const documents = await getDb().listDocumentsFiltered(auth.readScopeUserId, {
+    applicationId: params.get("applicationId") ?? undefined,
+    documentType: params.get("documentType") ?? undefined,
+    state: params.get("state") ?? undefined,
+    submissionId: params.get("submissionId") ?? undefined,
+    orphaned: params.has("orphaned") ? params.get("orphaned") === "true" : undefined,
+    fields: params.get("fields")?.split(",").map((field) => field.trim()).filter(Boolean),
+    page: rawPage,
+    pageSize: rawPageSize,
+  });
   return NextResponse.json(documents);
 }
 

--- a/app/api/mcp/authorize/route.ts
+++ b/app/api/mcp/authorize/route.ts
@@ -6,7 +6,6 @@ import { prisma } from "@/lib/prisma";
 import {
   createAuthCode,
   getPublicBaseUrl,
-  isLoopbackRedirectUri,
   isRedirectUriAllowed,
   SENSITIVE_CONSENT_VERSION,
 } from "@/lib/mcp-oauth";
@@ -150,11 +149,7 @@ export async function GET(req: NextRequest) {
       { status: 400 }
     );
   }
-  const isPublicLoopbackClient =
-    client.clientId.startsWith("mcp_") &&
-    client.tokenEndpointAuth === "none" &&
-    isLoopbackRedirectUri(redirectUri);
-  if (!isRedirectUriAllowed(client.redirectUris, redirectUri) && !isPublicLoopbackClient) {
+  if (!isRedirectUriAllowed(client.redirectUris, redirectUri)) {
     return NextResponse.json(
       { error: "invalid_request", error_description: "redirect_uri not registered for this client" },
       { status: 400 }

--- a/app/api/mcp/authorize/route.ts
+++ b/app/api/mcp/authorize/route.ts
@@ -3,7 +3,13 @@ import { headers } from "next/headers";
 import { createHmac, timingSafeEqual } from "node:crypto";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { createAuthCode, getPublicBaseUrl, isLoopbackRedirectUri, isRedirectUriAllowed } from "@/lib/mcp-oauth";
+import {
+  createAuthCode,
+  getPublicBaseUrl,
+  isLoopbackRedirectUri,
+  isRedirectUriAllowed,
+  SENSITIVE_CONSENT_VERSION,
+} from "@/lib/mcp-oauth";
 
 const COOKIE_NAME = "mcp_oauth_pending";
 const COOKIE_MAX_AGE = 600; // 10 minutes
@@ -238,6 +244,7 @@ export async function GET(req: NextRequest) {
     redirectUri,
     codeChallenge,
     scopes,
+    sensitiveConsentVersion: scopes.includes("mcp:submissions") ? SENSITIVE_CONSENT_VERSION : 0,
   });
 
   // Redirect back to Claude.ai with the auth code, clear pending cookie

--- a/app/api/mcp/authorize/route.ts
+++ b/app/api/mcp/authorize/route.ts
@@ -42,6 +42,45 @@ type OAuthPending = {
   scope: string;
 };
 
+type SubmissionConsent = {
+  clientId: string;
+  userId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  scope: string;
+  expiresAt: number;
+};
+
+function createSubmissionConsent(payload: SubmissionConsent): string {
+  const encoded = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${encoded}.${signPayload(encoded)}`;
+}
+
+function hasValidSubmissionConsent(
+  token: string | null,
+  expected: Omit<SubmissionConsent, "expiresAt">,
+): boolean {
+  if (!token) return false;
+  const consent = verifyAndParse<SubmissionConsent>(token);
+  return !!consent &&
+    consent.expiresAt >= Date.now() &&
+    consent.clientId === expected.clientId &&
+    consent.userId === expected.userId &&
+    consent.redirectUri === expected.redirectUri &&
+    consent.codeChallenge === expected.codeChallenge &&
+    consent.scope === expected.scope;
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (character) => ({
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    "\"": "&quot;",
+    "'": "&#39;",
+  })[character]!);
+}
+
 /**
  * OAuth 2.1 Authorization Endpoint for MCP.
  *
@@ -72,6 +111,14 @@ export async function GET(req: NextRequest) {
     return NextResponse.json(
       { error: "invalid_request", error_description: "Missing required parameters (client_id, redirect_uri, code_challenge)" },
       { status: 400 }
+    );
+  }
+  const scopes = scope.split(" ").filter(Boolean);
+  const supportedScopes = new Set(["mcp:tools", "mcp:submissions"]);
+  if (!scopes.includes("mcp:tools") || scopes.some((candidate) => !supportedScopes.has(candidate))) {
+    return NextResponse.json(
+      { error: "invalid_scope", error_description: "Supported scopes are mcp:tools and mcp:submissions" },
+      { status: 400 },
     );
   }
   if (responseType !== "code") {
@@ -142,8 +189,49 @@ export async function GET(req: NextRequest) {
     return response;
   }
 
-  // User is authenticated — issue authorization code
-  const scopes = scope.split(" ").filter(Boolean);
+  if (scopes.includes("mcp:submissions")) {
+    const expectedConsent = {
+      clientId,
+      userId: session.user.id,
+      redirectUri,
+      codeChallenge,
+      scope: scopes.join(" "),
+    };
+    if (!hasValidSubmissionConsent(url.searchParams.get("consent"), expectedConsent)) {
+      const approvalUrl = new URL("/api/mcp/authorize", getPublicBaseUrl(req));
+      approvalUrl.searchParams.set("client_id", clientId);
+      approvalUrl.searchParams.set("redirect_uri", redirectUri);
+      approvalUrl.searchParams.set("response_type", "code");
+      approvalUrl.searchParams.set("code_challenge", codeChallenge);
+      approvalUrl.searchParams.set("code_challenge_method", "S256");
+      approvalUrl.searchParams.set("scope", expectedConsent.scope);
+      if (state) approvalUrl.searchParams.set("state", state);
+      approvalUrl.searchParams.set("consent", createSubmissionConsent({
+        ...expectedConsent,
+        expiresAt: Date.now() + COOKIE_MAX_AGE * 1000,
+      }));
+      const clientLabel = escapeHtml(client.clientName ?? clientId);
+      const approvalHref = escapeHtml(approvalUrl.toString());
+      return new NextResponse(`<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>Authorize submission access</title></head>
+<body><main><h1>Authorize sensitive submission access?</h1>
+<p><strong>${clientLabel}</strong> is requesting access to exact application answers, compensation expectations, submitted documents, and interview recall packages.</p>
+<p>This data may contain sensitive personal information. Only continue if you trust this client.</p>
+<p><a href="${approvalHref}">Allow submission access</a></p>
+<p>You can close this page to deny access.</p></main></body></html>`, {
+        status: 200,
+        headers: {
+          "Content-Type": "text/html; charset=utf-8",
+          "Cache-Control": "no-store",
+          "Content-Security-Policy": "default-src 'none'; frame-ancestors 'none'; base-uri 'none'",
+          "X-Frame-Options": "DENY",
+          "Referrer-Policy": "no-referrer",
+        },
+      });
+    }
+  }
+
+  // User is authenticated and any sensitive scope was explicitly approved.
   const code = await createAuthCode({
     clientId,
     userId: session.user.id,

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -449,6 +449,7 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
       metadata: z.record(z.union([z.string(), z.number(), z.boolean(), z.null()])).optional(),
     },
     async (args) => {
+      if (args.type === "application_submitted" && !canAccessSubmissions) return submissionScopeError();
       try {
         const event = await getDb().createApplicationEvent(args.applicationId, auth.userId, {
           type: args.type,
@@ -474,6 +475,7 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
       limit: z.number().int().min(1).max(500).default(100),
     },
     async ({ applicationId, limit }) => {
+      if (!canAccessSubmissions) return submissionScopeError();
       try {
         const events = await getDb().listApplicationEvents(applicationId, auth.userId, limit);
         return { content: [{ type: "text", text: JSON.stringify(events, null, 2) }] };
@@ -624,6 +626,7 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
     "Return deterministic pipeline data-quality findings without modifying records.",
     {},
     async () => {
+      if (!canAccessSubmissions) return submissionScopeError();
       const db = getDb();
       const [applications, submissions, documents] = await Promise.all([
         db.listApplications(auth.userId),

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -50,6 +50,28 @@ const structuredApplicationToolFields = {
   currentStage: z.string().max(255).nullable().optional(),
 };
 
+const APPLICATION_UPDATE_ERROR_CODES = new Set([
+  "not_found",
+  "conflict",
+  "canonical_job_url_conflict",
+  "application_deleting",
+]);
+const SUBMISSION_ERROR_CODES = new Set([
+  "salary_range_invalid",
+  "not_found",
+  "conflict",
+  "application_deleting",
+  "idempotency_conflict",
+  "invalid_documents",
+  "document_already_submitted",
+  "verification_failed",
+]);
+
+function controlledErrorCode(error: unknown, allowed: Set<string>, fallback: string): string {
+  if (!(error instanceof Error)) return fallback;
+  return allowed.has(error.message) ? error.message : fallback;
+}
+
 // ── Auth helper ──────────────────────────────────────────────────────────────
 // Tries MCP OAuth access token first, then falls back to CRM API token.
 
@@ -234,35 +256,35 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
       ...structuredApplicationToolFields,
     },
     async ({ id, ...data }) => {
-      const update: Record<string, unknown> = {};
-      if (data.company !== undefined) update.company = data.company.slice(0, 255);
-      if (data.role !== undefined) update.role = data.role.slice(0, 255);
-      if (data.status !== undefined) update.status = normalizeStatus(data.status);
-      if (data.appliedAt !== undefined)
-        update.appliedAt = data.appliedAt ? new Date(data.appliedAt) : null;
-      if (data.lastContact !== undefined)
-        update.lastContact = data.lastContact ? new Date(data.lastContact) : null;
-      if (data.followUpAt !== undefined)
-        update.followUpAt = data.followUpAt ? new Date(data.followUpAt) : null;
-      if (data.notes !== undefined) update.notes = data.notes?.slice(0, 10000) ?? null;
-      if (data.jobDescription !== undefined)
-        update.jobDescription = data.jobDescription?.slice(0, 50000) ?? null;
-      if (data.source !== undefined) update.source = data.source?.slice(0, 100) ?? null;
-      if (data.remote !== undefined) update.remote = data.remote;
-      if (data.salaryMin !== undefined) update.salaryMin = data.salaryMin;
-      if (data.salaryMax !== undefined) update.salaryMax = data.salaryMax;
-      if (data.rating !== undefined) update.rating = data.rating;
-      if (data.jobUrl !== undefined) update.jobUrl = data.jobUrl?.slice(0, 2000) ?? null;
-      if (data.resumeId !== undefined) update.resumeId = data.resumeId ?? null;
-      Object.assign(
-        update,
-        parseStructuredApplicationMetadata(data as unknown as Record<string, unknown>),
-      );
-      if (data.expectedUpdatedAt !== undefined) {
-        update.expectedUpdatedAt = new Date(data.expectedUpdatedAt);
-      }
-
       try {
+        const update: Record<string, unknown> = {};
+        if (data.company !== undefined) update.company = data.company.slice(0, 255);
+        if (data.role !== undefined) update.role = data.role.slice(0, 255);
+        if (data.status !== undefined) update.status = normalizeStatus(data.status);
+        if (data.appliedAt !== undefined)
+          update.appliedAt = data.appliedAt ? new Date(data.appliedAt) : null;
+        if (data.lastContact !== undefined)
+          update.lastContact = data.lastContact ? new Date(data.lastContact) : null;
+        if (data.followUpAt !== undefined)
+          update.followUpAt = data.followUpAt ? new Date(data.followUpAt) : null;
+        if (data.notes !== undefined) update.notes = data.notes?.slice(0, 10000) ?? null;
+        if (data.jobDescription !== undefined)
+          update.jobDescription = data.jobDescription?.slice(0, 50000) ?? null;
+        if (data.source !== undefined) update.source = data.source?.slice(0, 100) ?? null;
+        if (data.remote !== undefined) update.remote = data.remote;
+        if (data.salaryMin !== undefined) update.salaryMin = data.salaryMin;
+        if (data.salaryMax !== undefined) update.salaryMax = data.salaryMax;
+        if (data.rating !== undefined) update.rating = data.rating;
+        if (data.jobUrl !== undefined) update.jobUrl = data.jobUrl?.slice(0, 2000) ?? null;
+        if (data.resumeId !== undefined) update.resumeId = data.resumeId ?? null;
+        Object.assign(
+          update,
+          parseStructuredApplicationMetadata(data as unknown as Record<string, unknown>),
+        );
+        if (data.expectedUpdatedAt !== undefined) {
+          update.expectedUpdatedAt = new Date(data.expectedUpdatedAt);
+        }
+
         if (data.dryRun) {
           const current = await getDb().getApplication(id, auth.userId);
           if (!current) throw new Error("not_found");
@@ -283,9 +305,14 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
         return {
           content: [{ type: "text", text: JSON.stringify(app, null, 2) }],
         };
-      } catch {
+      } catch (error) {
+        const code = controlledErrorCode(
+          error,
+          APPLICATION_UPDATE_ERROR_CODES,
+          "application_update_failed",
+        );
         return {
-          content: [{ type: "text", text: "Application not found or access denied" }],
+          content: [{ type: "text", text: JSON.stringify({ error: { code } }) }],
           isError: true,
         };
       }
@@ -374,7 +401,7 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
         });
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       } catch (error) {
-        const code = error instanceof Error ? error.message : "submission_failed";
+        const code = controlledErrorCode(error, SUBMISSION_ERROR_CODES, "submission_failed");
         return { content: [{ type: "text", text: JSON.stringify({ error: { code } }) }], isError: true };
       }
     },

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -17,6 +17,10 @@ import { parseStructuredApplicationMetadata } from "@/lib/applications/metadata"
 import { verifyMcpAccessToken } from "@/lib/mcp-oauth";
 import { generateAndStoreCv } from "@/lib/cv/generate";
 import { downloadDocumentContent } from "@/lib/documents/download";
+import {
+  isSubmissionDocument,
+  requiresSubmissionScopeForDocumentMutation,
+} from "@/lib/documents/access";
 import { uploadDocumentContent, MAX_DOCUMENT_BASE64_SIZE } from "@/lib/documents/upload";
 import { deleteDocumentWithContent } from "@/lib/documents/service";
 import type { SessionAuthResult, SessionUser } from "@/lib/session";
@@ -112,8 +116,7 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
     content: [{ type: "text" as const, text: JSON.stringify({ error: { code: "insufficient_scope", required: "mcp:submissions" } }) }],
     isError: true,
   });
-  const isSubmissionDocument = (document: { submissionId?: string | null; state?: string | null }) =>
-    Boolean(document.submissionId) || document.state === "submitted" || document.state === "historical";
+
 
   // ── Applications ────────────────────────────────────────────────────────
 
@@ -973,7 +976,13 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
     },
     async ({ id, applicationIds }) => {
       try {
+        const existing = await getDb().getDocument(id, auth.userId);
+        if (!existing) throw new Error("not_found");
+        if (!canAccessSubmissions && requiresSubmissionScopeForDocumentMutation(existing)) {
+          return submissionScopeError();
+        }
         const doc = await getDb().updateDocumentLinks(id, auth.userId, applicationIds);
+        if (!canAccessSubmissions && isSubmissionDocument(doc)) return submissionScopeError();
         return {
           content: [{ type: "text", text: JSON.stringify(doc, null, 2) }],
         };
@@ -1001,6 +1010,14 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
     },
     async ({ id, generatedAt, submittedAt, ...metadata }) => {
       try {
+        const existing = await getDb().getDocument(id, auth.userId);
+        if (!existing) throw new Error("not_found");
+        if (
+          !canAccessSubmissions
+          && (
+            requiresSubmissionScopeForDocumentMutation(existing, metadata.state)
+          )
+        ) return submissionScopeError();
         const document = await getDb().updateDocumentMetadata(id, auth.userId, {
           ...metadata,
           ...(generatedAt !== undefined && {
@@ -1010,6 +1027,7 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
             submittedAt: submittedAt ? new Date(submittedAt) : null,
           }),
         });
+        if (!canAccessSubmissions && isSubmissionDocument(document)) return submissionScopeError();
         return { content: [{ type: "text", text: JSON.stringify(document, null, 2) }] };
       } catch {
         return {

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -10,6 +10,7 @@ import { resolveAppliedAtForCreate } from "@/lib/applications/defaults";
 import {
   canonicalizeJobUrl,
   computeApplicationHealth,
+  requireOccurredAtForIdempotency,
   validateEventMetadata,
   validateSubmissionAnswers,
 } from "@/lib/applications/submission";
@@ -440,7 +441,7 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
     {
       applicationId: z.string().min(1),
       note: z.string().trim().min(1).max(5000),
-      occurredAt: z.string().datetime().optional(),
+      occurredAt: z.string().datetime().describe("Stable event timestamp required for idempotent retries"),
       idempotencyKey: z.string().min(8).max(128),
       expectedUpdatedAt: z.string().datetime().optional(),
     },
@@ -454,7 +455,7 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
             type: "note_added",
             idempotencyKey: args.idempotencyKey,
             expectedUpdatedAt: args.expectedUpdatedAt ? new Date(args.expectedUpdatedAt) : undefined,
-            occurredAt: args.occurredAt ? new Date(args.occurredAt) : new Date(),
+            occurredAt: new Date(args.occurredAt),
             source: "mcp",
             actor: auth.user.email,
             metadata: {},
@@ -481,6 +482,7 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
     async (args) => {
       if (args.type === "application_submitted" && !canAccessSubmissions) return submissionScopeError();
       try {
+        requireOccurredAtForIdempotency(args.idempotencyKey, args.occurredAt);
         const event = await getDb().createApplicationEvent(args.applicationId, auth.userId, {
           type: args.type,
           idempotencyKey: args.idempotencyKey,

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -6,13 +6,45 @@ import { getDb } from "@/lib/db";
 import { hashApiToken } from "@/lib/token";
 import { prisma } from "@/lib/prisma";
 import { normalizeStatus } from "@/types";
-import { resolveCreatedAtForCreate } from "@/lib/applications/defaults";
+import { resolveAppliedAtForCreate } from "@/lib/applications/defaults";
+import {
+  canonicalizeJobUrl,
+  computeApplicationHealth,
+  validateEventMetadata,
+  validateSubmissionAnswers,
+} from "@/lib/applications/submission";
+import { parseStructuredApplicationMetadata } from "@/lib/applications/metadata";
 import { verifyMcpAccessToken } from "@/lib/mcp-oauth";
 import { generateAndStoreCv } from "@/lib/cv/generate";
 import { downloadDocumentContent } from "@/lib/documents/download";
-import { uploadDocumentContent } from "@/lib/documents/upload";
+import { uploadDocumentContent, MAX_DOCUMENT_BASE64_SIZE } from "@/lib/documents/upload";
+import { deleteDocumentWithContent } from "@/lib/documents/service";
 import type { SessionAuthResult, SessionUser } from "@/lib/session";
 import type { UpsertCvProfileInput } from "@/lib/db/types";
+
+const structuredApplicationToolFields = {
+  workMode: z.enum(["remote", "hybrid", "onsite", "flexible"]).nullable().optional(),
+  eligibleCountries: z.array(z.string().length(2)).max(50).optional(),
+  primaryLocations: z.array(z.string().max(200)).max(50).optional(),
+  officeDaysMin: z.number().int().min(0).max(7).nullable().optional(),
+  travelPercent: z.number().int().min(0).max(100).nullable().optional(),
+  visaSponsorship: z.boolean().nullable().optional(),
+  rightToWorkRequired: z.boolean().nullable().optional(),
+  timezoneOverlap: z.string().max(255).nullable().optional(),
+  salaryCurrency: z.string().length(3).nullable().optional(),
+  salaryPeriod: z.enum(["year", "month", "day", "hour"]).nullable().optional(),
+  salaryType: z.enum(["base", "total", "contract_rate"]).nullable().optional(),
+  atsName: z.string().max(100).nullable().optional(),
+  requisitionId: z.string().max(255).nullable().optional(),
+  jobCapturedAt: z.string().datetime().nullable().optional(),
+  jobVerifiedAt: z.string().datetime().nullable().optional(),
+  jobPostedAt: z.string().datetime().nullable().optional(),
+  jobClosedAt: z.string().datetime().nullable().optional(),
+  jobContentHash: z.string().max(64).nullable().optional(),
+  jobLiveness: z.enum(["unknown", "live", "closed", "expired"]).nullable().optional(),
+  jobSummary: z.string().max(10_000).nullable().optional(),
+  currentStage: z.string().max(255).nullable().optional(),
+};
 
 // ── Auth helper ──────────────────────────────────────────────────────────────
 // Tries MCP OAuth access token first, then falls back to CRM API token.
@@ -56,6 +88,8 @@ async function authenticateFromRequest(
     userId: user.id,
     readScopeUserId: user.isAdmin ? null : user.id,
     user: sessionUser,
+    authType: "api_token",
+    scopes: ["mcp:tools", "mcp:submissions"],
   };
 }
 
@@ -71,6 +105,15 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
         "All operations are scoped to the authenticated user.",
     }
   );
+
+  const canAccessSubmissions =
+    auth.authType !== "mcp_oauth" || auth.scopes?.includes("mcp:submissions") === true;
+  const submissionScopeError = () => ({
+    content: [{ type: "text" as const, text: JSON.stringify({ error: { code: "insufficient_scope", required: "mcp:submissions" } }) }],
+    isError: true,
+  });
+  const isSubmissionDocument = (document: { submissionId?: string | null; state?: string | null }) =>
+    Boolean(document.submissionId) || document.state === "submitted" || document.state === "historical";
 
   // ── Applications ────────────────────────────────────────────────────────
 
@@ -113,11 +156,13 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
       status: z
         .enum(["inbound", "applied", "interview", "offer", "rejected"])
         .optional()
-        .describe("Application status (default: applied)"),
+        .describe("Application status (default: inbound)"),
       appliedAt: z
         .string()
         .optional()
         .describe("Date applied (ISO 8601)"),
+      lastContact: z.string().datetime().nullable().optional().describe("Last contact timestamp"),
+      followUpAt: z.string().datetime().nullable().optional().describe("Follow-up timestamp"),
       notes: z.string().optional().describe("Free-text notes"),
       jobDescription: z
         .string()
@@ -127,26 +172,30 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
       remote: z.boolean().optional().describe("Remote position?"),
       salaryMin: z.number().optional().describe("Minimum salary"),
       salaryMax: z.number().optional().describe("Maximum salary"),
+      rating: z.number().int().min(1).max(5).nullable().optional().describe("Fit rating 1-5"),
       jobUrl: z.string().optional().describe("URL to job listing or opportunity page"),
       resumeId: z.string().nullable().optional().describe("Reactive Resume resume ID"),
+      ...structuredApplicationToolFields,
     },
     async (args) => {
+      const metadata = parseStructuredApplicationMetadata(args as unknown as Record<string, unknown>);
       const app = await getDb().createApplication(auth.userId, {
         company: args.company.slice(0, 255),
         role: args.role.slice(0, 255),
-        status: normalizeStatus(args.status || "applied"),
-        appliedAt: resolveCreatedAtForCreate(args.appliedAt),
-        lastContact: null,
-        followUpAt: null,
+        status: normalizeStatus(args.status || "inbound"),
+        appliedAt: resolveAppliedAtForCreate(args.status || "inbound", args.appliedAt),
+        lastContact: args.lastContact ? new Date(args.lastContact) : null,
+        followUpAt: args.followUpAt ? new Date(args.followUpAt) : null,
         notes: args.notes?.slice(0, 10000) ?? null,
         jobDescription: args.jobDescription?.slice(0, 50000) ?? null,
         source: args.source?.slice(0, 100) ?? null,
         remote: args.remote ?? false,
         salaryMin: args.salaryMin ?? null,
         salaryMax: args.salaryMax ?? null,
-        rating: null,
+        rating: args.rating ?? null,
         jobUrl: args.jobUrl?.slice(0, 2000) ?? null,
         resumeId: args.resumeId ?? null,
+        ...metadata,
       });
       return {
         content: [{ type: "text", text: JSON.stringify(app, null, 2) }],
@@ -177,6 +226,9 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
       rating: z.number().min(1).max(5).nullable().optional().describe("Rating 1-5"),
       jobUrl: z.string().nullable().optional().describe("URL to job listing or opportunity page"),
       resumeId: z.string().nullable().optional().describe("Reactive Resume resume ID"),
+      expectedUpdatedAt: z.string().datetime().optional().describe("Optimistic concurrency timestamp"),
+      dryRun: z.boolean().default(false).describe("Validate and preview without writing"),
+      ...structuredApplicationToolFields,
     },
     async ({ id, ...data }) => {
       const update: Record<string, unknown> = {};
@@ -199,8 +251,31 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
       if (data.rating !== undefined) update.rating = data.rating;
       if (data.jobUrl !== undefined) update.jobUrl = data.jobUrl?.slice(0, 2000) ?? null;
       if (data.resumeId !== undefined) update.resumeId = data.resumeId ?? null;
+      Object.assign(
+        update,
+        parseStructuredApplicationMetadata(data as unknown as Record<string, unknown>),
+      );
+      if (data.expectedUpdatedAt !== undefined) {
+        update.expectedUpdatedAt = new Date(data.expectedUpdatedAt);
+      }
 
       try {
+        if (data.dryRun) {
+          const current = await getDb().getApplication(id, auth.userId);
+          if (!current) throw new Error("not_found");
+          if (
+            data.expectedUpdatedAt &&
+            current.updatedAt.getTime() !== new Date(data.expectedUpdatedAt).getTime()
+          ) throw new Error("conflict");
+          const previewUpdate = { ...update };
+          delete previewUpdate.expectedUpdatedAt;
+          return {
+            content: [{
+              type: "text",
+              text: JSON.stringify({ dryRun: true, application: { ...current, ...previewUpdate } }, null, 2),
+            }],
+          };
+        }
         const app = await getDb().updateApplication(id, auth.userId, update);
         return {
           content: [{ type: "text", text: JSON.stringify(app, null, 2) }],
@@ -216,9 +291,10 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
 
   server.tool(
     "delete_application",
-    "Delete an application and its contacts",
+    "Delete an application and its contacts, submissions, and timeline events",
     { id: z.string().describe("Application ID") },
     async ({ id }) => {
+      if (!canAccessSubmissions) return submissionScopeError();
       try {
         await getDb().deleteApplication(id, auth.userId);
         return { content: [{ type: "text", text: "Application deleted" }] };
@@ -229,6 +305,346 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
         };
       }
     }
+  );
+
+  server.tool(
+    "record_application_submission",
+    "Atomically preserve the exact submitted answers and document versions, set the application to applied, set appliedAt/follow-up, append a timeline event, and verify the stored package. Idempotency key required.",
+    {
+      applicationId: z.string().min(1).describe("Application ID"),
+      submittedAt: z.string().datetime().describe("Exact submission time as ISO 8601"),
+      followUpAt: z.string().datetime().nullable().optional().describe("Optional follow-up time"),
+      idempotencyKey: z.string().min(8).max(128).describe("Stable retry key for this submission"),
+      applicationUrl: z.string().url().max(2000).nullable().optional(),
+      atsName: z.string().max(100).nullable().optional(),
+      requisitionId: z.string().max(255).nullable().optional(),
+      language: z.string().max(20).nullable().optional(),
+      answers: z.array(z.object({
+        key: z.string().max(255).optional(),
+        question: z.string().min(1).max(2000),
+        answer: z.string().max(20000),
+        kind: z.enum(["text", "boolean", "number", "choice", "salary", "other"]).optional(),
+        sensitive: z.boolean().optional(),
+      })).max(50).default([]),
+      candidateSalaryMin: z.number().int().nonnegative().nullable().optional(),
+      candidateSalaryMax: z.number().int().nonnegative().nullable().optional(),
+      candidateSalaryCurrency: z.string().length(3).nullable().optional(),
+      candidateSalaryPeriod: z.enum(["hour", "day", "month", "year"]).nullable().optional(),
+      candidateSalaryType: z.enum(["base", "total", "contract_rate"]).nullable().optional(),
+      candidateSalaryFlexible: z.boolean().optional(),
+      documentIds: z.array(z.string().min(1)).max(20).default([]),
+      expectedUpdatedAt: z.string().datetime().optional().describe("Optimistic concurrency timestamp"),
+      dryRun: z.boolean().default(false),
+    },
+    async (args) => {
+      if (!canAccessSubmissions) return submissionScopeError();
+      try {
+        if (
+          args.candidateSalaryMin != null &&
+          args.candidateSalaryMax != null &&
+          args.candidateSalaryMin > args.candidateSalaryMax
+        ) throw new Error("salary_range_invalid");
+        const answers = validateSubmissionAnswers(args.answers);
+        const result = await getDb().recordApplicationSubmission(auth.userId, {
+          applicationId: args.applicationId,
+          submittedAt: new Date(args.submittedAt),
+          followUpAt: args.followUpAt === undefined
+            ? undefined
+            : args.followUpAt === null ? null : new Date(args.followUpAt),
+          idempotencyKey: args.idempotencyKey,
+          applicationUrl: args.applicationUrl,
+          atsName: args.atsName,
+          requisitionId: args.requisitionId,
+          language: args.language,
+          answers,
+          candidateSalaryMin: args.candidateSalaryMin,
+          candidateSalaryMax: args.candidateSalaryMax,
+          candidateSalaryCurrency: args.candidateSalaryCurrency?.toUpperCase() ?? args.candidateSalaryCurrency,
+          candidateSalaryPeriod: args.candidateSalaryPeriod,
+          candidateSalaryType: args.candidateSalaryType,
+          candidateSalaryFlexible: args.candidateSalaryFlexible,
+          documentIds: args.documentIds,
+          expectedUpdatedAt: args.expectedUpdatedAt ? new Date(args.expectedUpdatedAt) : undefined,
+          dryRun: args.dryRun,
+          source: "mcp",
+          actor: auth.user.email,
+        });
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      } catch (error) {
+        const code = error instanceof Error ? error.message : "submission_failed";
+        return { content: [{ type: "text", text: JSON.stringify({ error: { code } }) }], isError: true };
+      }
+    },
+  );
+
+  server.tool(
+    "list_application_submissions",
+    "List submission summaries for one application. Answers are excluded by default because they may contain sensitive personal data.",
+    { applicationId: z.string().min(1) },
+    async ({ applicationId }) => {
+      if (!canAccessSubmissions) return submissionScopeError();
+      try {
+        const submissions = await getDb().listApplicationSubmissions(applicationId, auth.userId, false);
+        return { content: [{ type: "text", text: JSON.stringify(submissions, null, 2) }] };
+      } catch {
+        return { content: [{ type: "text", text: "Application not found or access denied" }], isError: true };
+      }
+    },
+  );
+
+  server.tool(
+    "get_application_submission",
+    "Get one owner-scoped submission including its exact answers and submitted documents. Treat the response as sensitive.",
+    { id: z.string().min(1).describe("Submission ID") },
+    async ({ id }) => {
+      if (!canAccessSubmissions) return submissionScopeError();
+      const submission = await getDb().getApplicationSubmission(id, auth.userId);
+      if (!submission) return { content: [{ type: "text", text: "Submission not found" }], isError: true };
+      return { content: [{ type: "text", text: JSON.stringify(submission, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "append_application_note",
+    "Append a note without a read-modify-write race and add an immutable note_added timeline event.",
+    {
+      applicationId: z.string().min(1),
+      note: z.string().trim().min(1).max(5000),
+      occurredAt: z.string().datetime().optional(),
+      idempotencyKey: z.string().min(8).max(128),
+      expectedUpdatedAt: z.string().datetime().optional(),
+    },
+    async (args) => {
+      try {
+        const result = await getDb().appendApplicationNote(
+          args.applicationId,
+          auth.userId,
+          args.note,
+          {
+            type: "note_added",
+            idempotencyKey: args.idempotencyKey,
+            expectedUpdatedAt: args.expectedUpdatedAt ? new Date(args.expectedUpdatedAt) : undefined,
+            occurredAt: args.occurredAt ? new Date(args.occurredAt) : new Date(),
+            source: "mcp",
+            actor: auth.user.email,
+            metadata: {},
+          },
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      } catch (error) {
+        const code = error instanceof Error ? error.message : "append_failed";
+        return { content: [{ type: "text", text: JSON.stringify({ error: { code } }) }], isError: true };
+      }
+    },
+  );
+
+  server.tool(
+    "record_application_event",
+    "Append an immutable owner-scoped application timeline event.",
+    {
+      applicationId: z.string().min(1),
+      type: z.string().trim().min(1).max(100),
+      idempotencyKey: z.string().min(8).max(128).optional(),
+      occurredAt: z.string().datetime().optional(),
+      metadata: z.record(z.union([z.string(), z.number(), z.boolean(), z.null()])).optional(),
+    },
+    async (args) => {
+      try {
+        const event = await getDb().createApplicationEvent(args.applicationId, auth.userId, {
+          type: args.type,
+          idempotencyKey: args.idempotencyKey,
+          occurredAt: args.occurredAt ? new Date(args.occurredAt) : new Date(),
+          source: "mcp",
+          actor: auth.user.email,
+          metadata: validateEventMetadata(args.metadata),
+        });
+        return { content: [{ type: "text", text: JSON.stringify(event, null, 2) }] };
+      } catch (error) {
+        const code = error instanceof Error ? error.message : "event_failed";
+        return { content: [{ type: "text", text: JSON.stringify({ error: { code } }) }], isError: true };
+      }
+    },
+  );
+
+  server.tool(
+    "list_application_events",
+    "List immutable timeline events for an application, newest first.",
+    {
+      applicationId: z.string().min(1),
+      limit: z.number().int().min(1).max(500).default(100),
+    },
+    async ({ applicationId, limit }) => {
+      try {
+        const events = await getDb().listApplicationEvents(applicationId, auth.userId, limit);
+        return { content: [{ type: "text", text: JSON.stringify(events, null, 2) }] };
+      } catch {
+        return { content: [{ type: "text", text: "Application not found or access denied" }], isError: true };
+      }
+    },
+  );
+
+  server.tool(
+    "get_interview_recall_package",
+    "Return the job description, exact submitted answers, timeline, and submitted documents for interview preparation. Owner-scoped sensitive response.",
+    { applicationId: z.string().min(1) },
+    async ({ applicationId }) => {
+      if (!canAccessSubmissions) return submissionScopeError();
+      const db = getDb();
+      const application = await db.getApplication(applicationId, auth.userId);
+      if (!application) return { content: [{ type: "text", text: "Application not found" }], isError: true };
+      const [submissions, events, documents] = await Promise.all([
+        db.listApplicationSubmissions(applicationId, auth.userId, true),
+        db.listApplicationEvents(applicationId, auth.userId, 500),
+        db.listDocumentsByApplication(applicationId, auth.userId),
+      ]);
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({ application, submissions, events, documents }, null, 2),
+        }],
+      };
+    },
+  );
+
+  server.tool(
+    "find_application_by_job_url",
+    "Find an exact owner-scoped duplicate using a canonicalized job URL.",
+    { jobUrl: z.string().url().max(2000) },
+    async ({ jobUrl }) => {
+      const canonicalJobUrl = canonicalizeJobUrl(jobUrl);
+      if (!canonicalJobUrl) return { content: [{ type: "text", text: "Invalid URL" }], isError: true };
+      const application = await getDb().findApplicationByCanonicalJobUrl(auth.userId, canonicalJobUrl);
+      return { content: [{ type: "text", text: JSON.stringify({ canonicalJobUrl, application }, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "upsert_application_by_job_url",
+    "Create or update one opportunity using an exact canonical job URL, avoiding duplicate records.",
+    {
+      company: z.string().min(1).max(255),
+      role: z.string().min(1).max(255),
+      jobUrl: z.string().url().max(2000),
+      status: z.enum(["inbound", "applied", "interview", "offer", "rejected"]).optional(),
+      notes: z.string().max(10_000).nullable().optional(),
+      jobDescription: z.string().max(50_000).nullable().optional(),
+      source: z.string().max(100).nullable().optional(),
+      remote: z.boolean().optional(),
+      salaryMin: z.number().int().nullable().optional(),
+      salaryMax: z.number().int().nullable().optional(),
+      rating: z.number().int().min(1).max(5).nullable().optional(),
+      resumeId: z.string().max(255).nullable().optional(),
+      dryRun: z.boolean().default(false),
+      ...structuredApplicationToolFields,
+    },
+    async (args) => {
+      try {
+        const canonicalJobUrl = canonicalizeJobUrl(args.jobUrl);
+        if (!canonicalJobUrl) throw new Error("job_url_invalid");
+        if (args.salaryMin != null && args.salaryMax != null && args.salaryMin > args.salaryMax) {
+          throw new Error("salary_range_invalid");
+        }
+        const db = getDb();
+        const existing = await db.findApplicationByCanonicalJobUrl(auth.userId, canonicalJobUrl);
+        const metadata = parseStructuredApplicationMetadata(args as unknown as Record<string, unknown>);
+        const updateExisting = (applicationId: string) => db.updateApplication(applicationId, auth.userId, {
+          company: args.company,
+          role: args.role,
+          ...(args.status !== undefined && { status: args.status }),
+          ...(args.notes !== undefined && { notes: args.notes }),
+          ...(args.jobDescription !== undefined && { jobDescription: args.jobDescription }),
+          ...(args.source !== undefined && { source: args.source }),
+          ...(args.remote !== undefined && { remote: args.remote }),
+          ...(args.salaryMin !== undefined && { salaryMin: args.salaryMin }),
+          ...(args.salaryMax !== undefined && { salaryMax: args.salaryMax }),
+          ...(args.rating !== undefined && { rating: args.rating }),
+          ...(args.resumeId !== undefined && { resumeId: args.resumeId }),
+          jobUrl: args.jobUrl,
+          canonicalJobUrl,
+          ...metadata,
+        });
+        if (args.dryRun) {
+          return {
+            content: [{
+              type: "text",
+              text: JSON.stringify({
+                dryRun: true,
+                operation: existing ? "update" : "create",
+                canonicalJobUrl,
+                existingId: existing?.id ?? null,
+              }, null, 2),
+            }],
+          };
+        }
+        if (existing) {
+          const application = await updateExisting(existing.id);
+          return { content: [{ type: "text", text: JSON.stringify({ operation: "updated", application }, null, 2) }] };
+        }
+        const status = args.status ?? "inbound";
+        let operation = "created";
+        let application;
+        try {
+          application = await db.createApplication(auth.userId, {
+          company: args.company,
+          role: args.role,
+          status,
+          appliedAt: resolveAppliedAtForCreate(status, undefined),
+          lastContact: null,
+          followUpAt: null,
+          notes: args.notes ?? null,
+          jobDescription: args.jobDescription ?? null,
+          source: args.source ?? null,
+          remote: args.remote ?? false,
+          salaryMin: args.salaryMin ?? null,
+          salaryMax: args.salaryMax ?? null,
+          rating: args.rating ?? null,
+          jobUrl: args.jobUrl,
+          canonicalJobUrl,
+          resumeId: args.resumeId ?? null,
+          ...metadata,
+          });
+        } catch (error) {
+          const code = error instanceof Error ? error.message : "";
+          if (code !== "canonical_job_url_conflict") throw error;
+          const concurrent = await db.findApplicationByCanonicalJobUrl(auth.userId, canonicalJobUrl);
+          if (!concurrent) throw error;
+          application = await updateExisting(concurrent.id);
+          operation = "updated";
+        }
+        return { content: [{ type: "text", text: JSON.stringify({ operation, application }, null, 2) }] };
+      } catch (error) {
+        const code = error instanceof Error ? error.message : "upsert_failed";
+        return { content: [{ type: "text", text: JSON.stringify({ error: { code } }) }], isError: true };
+      }
+    },
+  );
+
+  server.tool(
+    "pipeline_healthcheck",
+    "Return deterministic pipeline data-quality findings without modifying records.",
+    {},
+    async () => {
+      const db = getDb();
+      const [applications, submissions, documents] = await Promise.all([
+        db.listApplications(auth.userId),
+        db.listUserSubmissions(auth.userId),
+        db.listDocuments(auth.userId),
+      ]);
+      const findings = computeApplicationHealth({
+        applications,
+        submissions,
+        documents: documents.map((document) => ({
+          id: document.id,
+          applicationIds: document.applications?.map((application) => application.id) ?? [],
+        })),
+      });
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({ healthy: findings.length === 0, findingCount: findings.length, findings }, null, 2),
+        }],
+      };
+    },
   );
 
   // ── Batch & filtered operations ───────────────────────────────────────
@@ -259,6 +675,7 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
             rating: z.number().min(1).max(5).nullable().optional().describe("Rating 1-5"),
             jobUrl: z.string().nullable().optional().describe("URL to job listing"),
             resumeId: z.string().nullable().optional().describe("Reactive Resume resume ID"),
+            ...structuredApplicationToolFields,
           })
         )
         .min(1)
@@ -284,6 +701,7 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
           rating: item.rating,
           jobUrl: item.jobUrl !== undefined ? (item.jobUrl?.slice(0, 2000) ?? null) : undefined,
           resumeId: item.resumeId !== undefined ? (item.resumeId ?? null) : undefined,
+          ...parseStructuredApplicationMetadata(item as unknown as Record<string, unknown>),
         }));
 
         const result = await getDb().batchUpsertApplications(auth.userId, sanitized);
@@ -310,6 +728,7 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
         .describe("Array of application IDs to delete (max 50)"),
     },
     async ({ ids }) => {
+      if (!canAccessSubmissions) return submissionScopeError();
       try {
         const result = await getDb().batchDeleteApplications(ids, auth.userId);
         return {
@@ -395,7 +814,7 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
           isError: true,
         };
       }
-      const contact = await getDb().createContact(applicationId, {
+      const contact = await getDb().createContact(applicationId, auth.userId, {
         name: data.name.slice(0, 255),
         email: data.email?.slice(0, 255) ?? null,
         phone: data.phone?.slice(0, 50) ?? null,
@@ -473,14 +892,26 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
 
   server.tool(
     "list_documents",
-    "List all uploaded documents",
-    {},
-    async () => {
-      const docs = await getDb().listDocuments(auth.readScopeUserId);
+    "List uploaded documents with optional application, lifecycle, submission, orphan, pagination, and field-selection filters.",
+    {
+      applicationId: z.string().optional(),
+      documentType: z.string().max(100).optional(),
+      state: z.enum(["draft", "current", "submitted", "superseded", "historical", "orphaned"]).optional(),
+      submissionId: z.string().optional(),
+      orphaned: z.boolean().optional(),
+      fields: z.array(z.string()).max(30).optional(),
+      page: z.number().int().min(1).optional(),
+      pageSize: z.number().int().min(1).max(200).optional(),
+    },
+    async (args) => {
+      const docs = await getDb().listDocumentsFiltered(auth.readScopeUserId, {
+        ...args,
+        excludeSubmissionArtifacts: !canAccessSubmissions,
+      });
       return {
         content: [{ type: "text", text: JSON.stringify(docs, null, 2) }],
       };
-    }
+    },
   );
 
   server.tool(
@@ -495,6 +926,7 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
           isError: true,
         };
       }
+      if (!canAccessSubmissions && isSubmissionDocument(doc)) return submissionScopeError();
       return {
         content: [{ type: "text", text: JSON.stringify(doc, null, 2) }],
       };
@@ -509,7 +941,7 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
       mimeType: z
         .enum(["application/pdf", "image/jpeg", "image/png", "image/webp"])
         .describe("MIME type of the uploaded file"),
-      contentBase64: z.string().min(1).describe("Raw file bytes encoded as standard base64"),
+      contentBase64: z.string().min(1).max(MAX_DOCUMENT_BASE64_SIZE).describe("Raw file bytes encoded as standard base64"),
       applicationIds: z.array(z.string()).optional().describe("Application IDs to link"),
     },
     async (args) => uploadDocumentContent(args, auth.userId),
@@ -519,7 +951,14 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
     "download_document_content",
     "Download the binary content of a document. For files <=1MB the content is returned inline as base64. For larger files, a short-lived signed URL is returned instead when object storage is available (falls back to inline base64 otherwise).",
     { id: z.string().describe("Document ID") },
-    async ({ id }) => downloadDocumentContent(id, auth.readScopeUserId),
+    async ({ id }) => {
+      const document = await getDb().getDocument(id, auth.readScopeUserId);
+      if (!document) {
+        return { content: [{ type: "text", text: "Document not found" }], isError: true };
+      }
+      if (!canAccessSubmissions && isSubmissionDocument(document)) return submissionScopeError();
+      return downloadDocumentContent(id, auth.readScopeUserId);
+    },
   );
 
   server.tool(
@@ -545,12 +984,46 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
   );
 
   server.tool(
+    "update_document_metadata",
+    "Classify an owned document and update lifecycle metadata. Submitted document content remains immutable.",
+    {
+      id: z.string().describe("Document ID"),
+      documentType: z.string().max(100).optional(),
+      state: z.enum(["draft", "current", "submitted", "superseded", "historical", "orphaned"]).optional(),
+      version: z.number().int().min(1).optional(),
+      contentHash: z.string().regex(/^[a-f0-9]{64}$/i).nullable().optional(),
+      source: z.string().max(100).nullable().optional(),
+      generatedAt: z.string().datetime().nullable().optional(),
+      submittedAt: z.string().datetime().nullable().optional(),
+    },
+    async ({ id, generatedAt, submittedAt, ...metadata }) => {
+      try {
+        const document = await getDb().updateDocumentMetadata(id, auth.userId, {
+          ...metadata,
+          ...(generatedAt !== undefined && {
+            generatedAt: generatedAt ? new Date(generatedAt) : null,
+          }),
+          ...(submittedAt !== undefined && {
+            submittedAt: submittedAt ? new Date(submittedAt) : null,
+          }),
+        });
+        return { content: [{ type: "text", text: JSON.stringify(document, null, 2) }] };
+      } catch {
+        return {
+          content: [{ type: "text", text: "Document not found or access denied" }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
     "delete_document",
     "Delete a document",
     { id: z.string().describe("Document ID") },
     async ({ id }) => {
       try {
-        const result = await getDb().deleteDocument(id, auth.userId);
+        const result = await deleteDocumentWithContent(getDb(), id, auth.userId);
         if (!result) {
           return {
             content: [{ type: "text", text: "Document not found or access denied" }],

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,63 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "applications",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "applicationSubmissions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "applicationId", "order": "ASCENDING" },
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "submittedAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "applicationSubmissions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "submittedAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "applicationEvents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "applicationId", "order": "ASCENDING" },
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "occurredAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "documents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "uploadedAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "documents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "applicationIds", "arrayConfig": "CONTAINS" }
+      ]
+    },
+    {
+      "collectionGroup": "documents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "submissionId", "order": "ASCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/lib/__tests__/mcp-oauth.test.ts
+++ b/lib/__tests__/mcp-oauth.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { isLoopbackRedirectUri, isRedirectUriAllowed } from "../mcp-oauth";
+import {
+  effectiveMcpScopes,
+  isLoopbackRedirectUri,
+  isRedirectUriAllowed,
+  SENSITIVE_CONSENT_VERSION,
+} from "../mcp-oauth";
 
 describe("MCP OAuth redirect validation", () => {
   it("accepts exact registered redirect URIs", () => {
@@ -37,5 +42,18 @@ describe("MCP OAuth redirect validation", () => {
         "http://127.0.0.1:47987/callback"
       )
     ).toBe(false);
+  });
+});
+
+describe("MCP OAuth sensitive consent versioning", () => {
+  it("does not activate a legacy mcp:submissions scope string", () => {
+    expect(effectiveMcpScopes(["mcp:tools", "mcp:submissions"], 0)).toEqual(["mcp:tools"]);
+  });
+
+  it("preserves mcp:submissions only after versioned consent", () => {
+    expect(effectiveMcpScopes(
+      ["mcp:tools", "mcp:submissions"],
+      SENSITIVE_CONSENT_VERSION,
+    )).toEqual(["mcp:tools", "mcp:submissions"]);
   });
 });

--- a/lib/applications/__tests__/defaults.test.ts
+++ b/lib/applications/__tests__/defaults.test.ts
@@ -23,6 +23,13 @@ describe("opportunity creation defaults", () => {
     );
   });
 
+  it("rejects invalid explicit appliedAt values", () => {
+    expect(() => resolveAppliedAtForCreate("applied", "not-a-date", now))
+      .toThrow("appliedAt_invalid");
+    expect(() => resolveAppliedAtForCreate("applied", new Date("invalid"), now))
+      .toThrow("appliedAt_invalid");
+  });
+
   it("formats a date for date inputs", () => {
     expect(toDateInputValue(new Date("2026-06-30T12:34:56.000Z"))).toBe("2026-06-30");
   });

--- a/lib/applications/__tests__/defaults.test.ts
+++ b/lib/applications/__tests__/defaults.test.ts
@@ -1,17 +1,24 @@
 import { describe, expect, it } from "vitest";
-import { resolveCreatedAtForCreate, toDateInputValue } from "../defaults";
+import { resolveAppliedAtForCreate, toDateInputValue } from "../defaults";
 
 describe("opportunity creation defaults", () => {
-  it("auto-fills the created-at/applied-at date when creation omits it", () => {
-    const now = new Date("2026-06-30T08:00:00.000Z");
+  const now = new Date("2026-06-30T08:00:00.000Z");
 
-    expect(resolveCreatedAtForCreate(undefined, now)).toEqual(now);
-    expect(resolveCreatedAtForCreate(null, now)).toEqual(now);
-    expect(resolveCreatedAtForCreate("", now)).toEqual(now);
+  it("keeps appliedAt empty for a new inbound lead", () => {
+    expect(resolveAppliedAtForCreate("inbound", undefined, now)).toBeNull();
+    expect(resolveAppliedAtForCreate("inbound", null, now)).toBeNull();
+    expect(resolveAppliedAtForCreate("inbound", "", now)).toBeNull();
   });
 
-  it("preserves an explicit created-at/applied-at value", () => {
-    expect(resolveCreatedAtForCreate("2026-05-04", new Date("2026-06-30"))).toEqual(
+  it("auto-fills appliedAt only for an explicitly applied-or-later status", () => {
+    expect(resolveAppliedAtForCreate("applied", undefined, now)).toEqual(now);
+    expect(resolveAppliedAtForCreate("interview", undefined, now)).toEqual(now);
+    expect(resolveAppliedAtForCreate("offer", undefined, now)).toEqual(now);
+    expect(resolveAppliedAtForCreate("rejected", undefined, now)).toEqual(now);
+  });
+
+  it("preserves an explicit appliedAt value", () => {
+    expect(resolveAppliedAtForCreate("inbound", "2026-05-04", now)).toEqual(
       new Date("2026-05-04"),
     );
   });

--- a/lib/applications/__tests__/metadata.test.ts
+++ b/lib/applications/__tests__/metadata.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { parseStructuredApplicationMetadata } from "../metadata";
+
+describe("parseStructuredApplicationMetadata", () => {
+  it("normalizes structured metadata and derives a canonical job URL", () => {
+    expect(
+      parseStructuredApplicationMetadata({
+        jobUrl: "https://Jobs.Example.com/roles/1/?utm_source=mail",
+        workMode: "remote",
+        eligibleCountries: ["es", "DE", "es"],
+        salaryCurrency: "eur",
+        salaryPeriod: "year",
+        officeDaysMin: 0,
+        jobCapturedAt: "2026-07-13T08:00:00.000Z",
+      }),
+    ).toMatchObject({
+      canonicalJobUrl: "https://jobs.example.com/roles/1",
+      workMode: "remote",
+      eligibleCountries: ["ES", "DE"],
+      salaryCurrency: "EUR",
+      salaryPeriod: "year",
+      officeDaysMin: 0,
+      jobCapturedAt: new Date("2026-07-13T08:00:00.000Z"),
+    });
+  });
+
+  it("rejects invalid enums, ranges, countries, dates, currency, hashes, and URLs", () => {
+    expect(() => parseStructuredApplicationMetadata({ workMode: "sometimes" })).toThrow(/workMode/);
+    expect(() => parseStructuredApplicationMetadata({ travelPercent: 101 })).toThrow(/travelPercent/);
+    expect(() => parseStructuredApplicationMetadata({ eligibleCountries: ["Spain"] })).toThrow(/eligibleCountries/);
+    expect(() => parseStructuredApplicationMetadata({ jobCapturedAt: "not-a-date" })).toThrow(/jobCapturedAt/);
+    expect(() => parseStructuredApplicationMetadata({ salaryCurrency: "EU" })).toThrow(/salaryCurrency/);
+    expect(() => parseStructuredApplicationMetadata({ jobContentHash: "not-a-sha256" })).toThrow(/jobContentHash/);
+    expect(() => parseStructuredApplicationMetadata({ jobUrl: "javascript:alert(1)" })).toThrow(/http or https/);
+  });
+});

--- a/lib/applications/__tests__/metadata.test.ts
+++ b/lib/applications/__tests__/metadata.test.ts
@@ -33,4 +33,14 @@ describe("parseStructuredApplicationMetadata", () => {
     expect(() => parseStructuredApplicationMetadata({ jobContentHash: "not-a-sha256" })).toThrow(/jobContentHash/);
     expect(() => parseStructuredApplicationMetadata({ jobUrl: "javascript:alert(1)" })).toThrow(/http or https/);
   });
+
+  it("preserves explicit nulls so PATCH can clear normalized fields", () => {
+    expect(parseStructuredApplicationMetadata({
+      salaryCurrency: null,
+      jobContentHash: null,
+    })).toMatchObject({
+      salaryCurrency: null,
+      jobContentHash: null,
+    });
+  });
 });

--- a/lib/applications/__tests__/submission.test.ts
+++ b/lib/applications/__tests__/submission.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   canonicalizeJobUrl,
   computeApplicationHealth,
+  requireOccurredAtForIdempotency,
   validateSubmissionAnswers,
 } from "../submission";
 
@@ -57,6 +58,16 @@ describe("validateSubmissionAnswers", () => {
       answer: "x".repeat(20_000),
     }));
     expect(() => validateSubmissionAnswers(answers)).toThrowError(/750000-byte/);
+  });
+});
+
+describe("requireOccurredAtForIdempotency", () => {
+  it("requires a stable timestamp when an idempotency key is supplied", () => {
+    expect(() => requireOccurredAtForIdempotency("retry-key", undefined))
+      .toThrow("occurred_at_required_for_idempotency");
+    expect(() => requireOccurredAtForIdempotency("retry-key", "2026-07-13T20:00:00Z"))
+      .not.toThrow();
+    expect(() => requireOccurredAtForIdempotency(undefined, undefined)).not.toThrow();
   });
 });
 

--- a/lib/applications/__tests__/submission.test.ts
+++ b/lib/applications/__tests__/submission.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  canonicalizeJobUrl,
+  computeApplicationHealth,
+  validateSubmissionAnswers,
+} from "../submission";
+
+describe("canonicalizeJobUrl", () => {
+  it("normalizes scheme/host, removes fragments, tracking parameters, and trailing slash", () => {
+    expect(
+      canonicalizeJobUrl("HTTPS://Jobs.Example.com/roles/123/?utm_source=mail&ref=alert#apply"),
+    ).toBe("https://jobs.example.com/roles/123");
+  });
+
+  it("keeps identity-bearing query parameters in stable order", () => {
+    expect(canonicalizeJobUrl("https://example.com/job?b=2&id=7&a=1")).toBe(
+      "https://example.com/job?a=1&b=2&id=7",
+    );
+  });
+
+  it("rejects non-http URLs", () => {
+    expect(() => canonicalizeJobUrl("file:///etc/passwd")).toThrowError(/http/i);
+  });
+});
+
+describe("validateSubmissionAnswers", () => {
+  it("trims valid answers and preserves structured metadata", () => {
+    expect(
+      validateSubmissionAnswers([
+        { key: "why", question: " Why us? ", answer: " Because. ", kind: "text", sensitive: false },
+      ]),
+    ).toEqual([
+      { key: "why", question: "Why us?", answer: " Because. ", kind: "text", sensitive: false },
+    ]);
+  });
+
+  it("rejects empty questions and excessive answer counts", () => {
+    expect(() => validateSubmissionAnswers([{ question: " ", answer: "x" }])).toThrowError(
+      /question/i,
+    );
+    expect(() =>
+      validateSubmissionAnswers(
+        Array.from({ length: 51 }, (_, i) => ({ question: `Q${i}`, answer: "x" })),
+      ),
+    ).toThrowError(/50/);
+  });
+
+  it("rejects oversized answers", () => {
+    expect(() =>
+      validateSubmissionAnswers([{ question: "Q", answer: "x".repeat(20_001) }]),
+    ).toThrowError(/20000/);
+  });
+
+  it("rejects answer packages that exceed the Firestore-safe aggregate size", () => {
+    const answers = Array.from({ length: 40 }, (_, index) => ({
+      question: `Question ${index}`,
+      answer: "x".repeat(20_000),
+    }));
+    expect(() => validateSubmissionAnswers(answers)).toThrowError(/750000-byte/);
+  });
+});
+
+describe("computeApplicationHealth", () => {
+  const now = new Date("2026-07-13T10:00:00.000Z");
+
+  it("finds applied applications without a structured submission", () => {
+    const findings = computeApplicationHealth({
+      applications: [{ id: "1", status: "applied", appliedAt: now, followUpAt: null }],
+      submissions: [],
+      documents: [],
+      now,
+    });
+    expect(findings.map((finding) => finding.code)).toEqual(
+      expect.arrayContaining(["applied_without_submission", "missing_next_action"]),
+    );
+  });
+
+  it("finds incomplete submission packages and orphan documents", () => {
+    const findings = computeApplicationHealth({
+      applications: [{ id: "1", status: "applied", appliedAt: now, followUpAt: now }],
+      submissions: [{ id: "s1", applicationId: "1", answers: [], documentIds: [] }],
+      documents: [{ id: "d1", applicationIds: [], state: "current" }],
+      now,
+    });
+    expect(findings.map((finding) => finding.code)).toEqual(
+      expect.arrayContaining(["submission_without_answers", "submission_without_materials", "orphan_document"]),
+    );
+  });
+
+  it("does not classify rejected linked material as orphaned", () => {
+    const findings = computeApplicationHealth({
+      applications: [{ id: "1", status: "rejected", appliedAt: now, followUpAt: null }],
+      submissions: [],
+      documents: [{ id: "d1", applicationIds: ["1"], state: "historical" }],
+      now,
+    });
+    expect(findings).toEqual([]);
+  });
+});

--- a/lib/applications/defaults.ts
+++ b/lib/applications/defaults.ts
@@ -2,11 +2,19 @@ export function toDateInputValue(date: Date = new Date()): string {
   return date.toISOString().split("T")[0];
 }
 
-export function resolveCreatedAtForCreate(
+const APPLIED_OR_LATER = new Set(["applied", "interview", "offer", "rejected"]);
+
+/**
+ * Resolve the application date without falsely turning a newly discovered lead
+ * into a submitted application. An explicit value is always preserved; an
+ * omitted value is only defaulted for an explicitly applied-or-later status.
+ */
+export function resolveAppliedAtForCreate(
+  status: string,
   value: Date | string | null | undefined,
   now: Date = new Date(),
-): Date {
+): Date | null {
   if (value instanceof Date) return value;
-  if (value === undefined || value === null || value === "") return now;
-  return new Date(value);
+  if (value !== undefined && value !== null && value !== "") return new Date(value);
+  return APPLIED_OR_LATER.has(status) ? now : null;
 }

--- a/lib/applications/defaults.ts
+++ b/lib/applications/defaults.ts
@@ -14,7 +14,14 @@ export function resolveAppliedAtForCreate(
   value: Date | string | null | undefined,
   now: Date = new Date(),
 ): Date | null {
-  if (value instanceof Date) return value;
-  if (value !== undefined && value !== null && value !== "") return new Date(value);
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) throw new Error("appliedAt_invalid");
+    return value;
+  }
+  if (value !== undefined && value !== null && value !== "") {
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) throw new Error("appliedAt_invalid");
+    return parsed;
+  }
   return APPLIED_OR_LATER.has(status) ? now : null;
 }

--- a/lib/applications/metadata.ts
+++ b/lib/applications/metadata.ts
@@ -1,0 +1,134 @@
+import { canonicalizeJobUrl } from "./submission";
+import type { StructuredApplicationMetadataInput } from "@/lib/db/types";
+
+const WORK_MODES = new Set(["remote", "hybrid", "onsite", "flexible"]);
+const SALARY_PERIODS = new Set(["year", "month", "day", "hour"]);
+const SALARY_TYPES = new Set(["base", "total", "contract_rate"]);
+const JOB_LIVENESS = new Set(["unknown", "live", "closed", "expired"]);
+
+function optionalString(value: unknown, max: number): string | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null || value === "") return null;
+  return String(value).trim().slice(0, max) || null;
+}
+
+function optionalEnum(
+  value: unknown,
+  allowed: Set<string>,
+  field: string,
+): string | null | undefined {
+  const parsed = optionalString(value, 100);
+  if (parsed == null) return parsed;
+  if (!allowed.has(parsed)) throw new Error(`${field}_invalid`);
+  return parsed;
+}
+
+function optionalInteger(
+  value: unknown,
+  field: string,
+  min: number,
+  max: number,
+): number | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null || value === "") return null;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < min || parsed > max) {
+    throw new Error(`${field}_invalid`);
+  }
+  return parsed;
+}
+
+function optionalBoolean(value: unknown): boolean | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null || value === "") return null;
+  if (value === true || value === "true") return true;
+  if (value === false || value === "false") return false;
+  throw new Error("boolean_invalid");
+}
+
+function optionalDate(value: unknown, field: string): Date | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null || value === "") return null;
+  const date = value instanceof Date ? value : new Date(String(value));
+  if (Number.isNaN(date.getTime())) throw new Error(`${field}_invalid`);
+  return date;
+}
+
+function optionalStringArray(
+  value: unknown,
+  field: string,
+  maxItems: number,
+  itemMax: number,
+): string[] | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!Array.isArray(value) || value.length > maxItems) throw new Error(`${field}_invalid`);
+  return Array.from(
+    new Set(value.map((item) => String(item).trim().slice(0, itemMax)).filter(Boolean)),
+  );
+}
+
+export function parseStructuredApplicationMetadata(
+  input: Record<string, unknown>,
+): StructuredApplicationMetadataInput {
+  if (
+    input.eligibleCountries !== undefined &&
+    input.eligibleCountries !== null &&
+    (!Array.isArray(input.eligibleCountries) ||
+      input.eligibleCountries.some((country) => !/^[A-Za-z]{2}$/.test(String(country).trim())))
+  ) {
+    throw new Error("eligibleCountries_invalid");
+  }
+  const eligibleCountries = optionalStringArray(input.eligibleCountries, "eligibleCountries", 50, 2)
+    ?.map((country) => country.toUpperCase());
+  if (eligibleCountries?.some((country) => !/^[A-Z]{2}$/.test(country))) {
+    throw new Error("eligibleCountries_invalid");
+  }
+
+  const salaryCurrency = optionalString(input.salaryCurrency, 3)?.toUpperCase();
+  if (salaryCurrency != null && !/^[A-Z]{3}$/.test(salaryCurrency)) {
+    throw new Error("salaryCurrency_invalid");
+  }
+  const jobContentHash = optionalString(input.jobContentHash, 64)?.toLowerCase();
+  if (jobContentHash != null && !/^[a-f0-9]{64}$/.test(jobContentHash)) {
+    throw new Error("jobContentHash_invalid");
+  }
+
+  const result: StructuredApplicationMetadataInput = {
+    workMode: optionalEnum(input.workMode, WORK_MODES, "workMode"),
+    eligibleCountries,
+    primaryLocations: optionalStringArray(input.primaryLocations, "primaryLocations", 50, 200),
+    officeDaysMin: optionalInteger(input.officeDaysMin, "officeDaysMin", 0, 7),
+    travelPercent: optionalInteger(input.travelPercent, "travelPercent", 0, 100),
+    visaSponsorship: optionalBoolean(input.visaSponsorship),
+    rightToWorkRequired: optionalBoolean(input.rightToWorkRequired),
+    timezoneOverlap: optionalString(input.timezoneOverlap, 255),
+    salaryCurrency,
+    salaryPeriod: optionalEnum(input.salaryPeriod, SALARY_PERIODS, "salaryPeriod"),
+    salaryType: optionalEnum(input.salaryType, SALARY_TYPES, "salaryType"),
+    atsName: optionalString(input.atsName, 100),
+    requisitionId: optionalString(input.requisitionId, 255),
+    jobCapturedAt: optionalDate(input.jobCapturedAt, "jobCapturedAt"),
+    jobVerifiedAt: optionalDate(input.jobVerifiedAt, "jobVerifiedAt"),
+    jobPostedAt: optionalDate(input.jobPostedAt, "jobPostedAt"),
+    jobClosedAt: optionalDate(input.jobClosedAt, "jobClosedAt"),
+    jobContentHash,
+    jobLiveness: optionalEnum(input.jobLiveness, JOB_LIVENESS, "jobLiveness"),
+    jobSummary: optionalString(input.jobSummary, 10_000),
+    currentStage: optionalString(input.currentStage, 255),
+  };
+
+  const rawJobUrl = input.jobUrl !== undefined ? input.jobUrl : input.canonicalJobUrl;
+  if (rawJobUrl !== undefined) {
+    if (rawJobUrl === null || rawJobUrl === "") {
+      result.canonicalJobUrl = null;
+    } else {
+      const canonicalJobUrl = canonicalizeJobUrl(String(rawJobUrl));
+      if (!canonicalJobUrl) throw new Error("jobUrl_invalid");
+      result.canonicalJobUrl = canonicalJobUrl;
+    }
+  }
+
+  return Object.fromEntries(
+    Object.entries(result).filter(([, value]) => value !== undefined),
+  ) as StructuredApplicationMetadataInput;
+}

--- a/lib/applications/metadata.ts
+++ b/lib/applications/metadata.ts
@@ -84,11 +84,13 @@ export function parseStructuredApplicationMetadata(
     throw new Error("eligibleCountries_invalid");
   }
 
-  const salaryCurrency = optionalString(input.salaryCurrency, 3)?.toUpperCase();
+  const rawSalaryCurrency = optionalString(input.salaryCurrency, 3);
+  const salaryCurrency = rawSalaryCurrency == null ? rawSalaryCurrency : rawSalaryCurrency.toUpperCase();
   if (salaryCurrency != null && !/^[A-Z]{3}$/.test(salaryCurrency)) {
     throw new Error("salaryCurrency_invalid");
   }
-  const jobContentHash = optionalString(input.jobContentHash, 64)?.toLowerCase();
+  const rawJobContentHash = optionalString(input.jobContentHash, 64);
+  const jobContentHash = rawJobContentHash == null ? rawJobContentHash : rawJobContentHash.toLowerCase();
   if (jobContentHash != null && !/^[a-f0-9]{64}$/.test(jobContentHash)) {
     throw new Error("jobContentHash_invalid");
   }

--- a/lib/applications/submission.ts
+++ b/lib/applications/submission.ts
@@ -146,6 +146,15 @@ export function validateEventMetadata(value: unknown): Record<string, unknown> {
   return metadata;
 }
 
+export function requireOccurredAtForIdempotency(
+  idempotencyKey: string | null | undefined,
+  occurredAt: string | Date | null | undefined,
+): void {
+  if (idempotencyKey && !occurredAt) {
+    throw new Error("occurred_at_required_for_idempotency");
+  }
+}
+
 function asDate(value: Date | string | null): Date | null {
   if (!value) return null;
   const date = value instanceof Date ? value : new Date(value);

--- a/lib/applications/submission.ts
+++ b/lib/applications/submission.ts
@@ -1,0 +1,255 @@
+import { createHash } from "node:crypto";
+
+export interface SubmissionAnswerInput {
+  key?: string;
+  question: string;
+  answer: string;
+  kind?: "text" | "boolean" | "number" | "choice" | "salary" | "other";
+  sensitive?: boolean;
+}
+
+export interface HealthApplication {
+  id: string;
+  status: string;
+  appliedAt: Date | string | null;
+  followUpAt: Date | string | null;
+}
+
+export interface HealthSubmission {
+  id: string;
+  applicationId: string;
+  answers: unknown[];
+  documentIds: string[];
+}
+
+export interface HealthDocument {
+  id: string;
+  applicationIds: string[];
+  state?: string;
+}
+
+export interface ApplicationHealthFinding {
+  code:
+    | "applied_without_date"
+    | "date_without_applied_status"
+    | "applied_without_submission"
+    | "missing_next_action"
+    | "overdue_follow_up"
+    | "submission_without_answers"
+    | "submission_without_materials"
+    | "orphan_document";
+  severity: "info" | "warning" | "error";
+  applicationId?: string;
+  submissionId?: string;
+  documentId?: string;
+  message: string;
+  remediation: string;
+}
+
+const TRACKING_PARAMS = new Set([
+  "ref",
+  "source",
+  "campaign",
+  "mc_cid",
+  "mc_eid",
+  "gclid",
+  "fbclid",
+]);
+
+function stableSerialize(value: unknown): string {
+  if (value instanceof Date) return JSON.stringify(value.toISOString());
+  if (Array.isArray(value)) return `[${value.map(stableSerialize).join(",")}]`;
+  if (value && typeof value === "object") {
+    const object = value as Record<string, unknown>;
+    return `{${Object.keys(object)
+      .filter((key) => object[key] !== undefined)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableSerialize(object[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function submissionRequestHash(value: unknown): string {
+  return createHash("sha256").update(stableSerialize(value)).digest("hex");
+}
+
+export function canonicalizeJobUrl(raw: string | null | undefined): string | null {
+  if (!raw?.trim()) return null;
+  const url = new URL(raw.trim());
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("Job URL must use http or https");
+  }
+  if (url.username || url.password) {
+    throw new Error("Job URL must not contain credentials");
+  }
+  url.protocol = url.protocol.toLowerCase();
+  url.hostname = url.hostname.toLowerCase();
+  url.hash = "";
+  const keys: string[] = [];
+  url.searchParams.forEach((_value, key) => keys.push(key));
+  for (const key of keys) {
+    if (key.toLowerCase().startsWith("utm_") || TRACKING_PARAMS.has(key.toLowerCase())) {
+      url.searchParams.delete(key);
+    }
+  }
+  url.searchParams.sort();
+  if (url.pathname.length > 1) url.pathname = url.pathname.replace(/\/+$/, "");
+  return url.toString().replace(/\?$/, "").replace(/\/$/, url.pathname === "/" ? "/" : "");
+}
+
+export function validateSubmissionAnswers(
+  answers: SubmissionAnswerInput[],
+): SubmissionAnswerInput[] {
+  if (!Array.isArray(answers)) throw new Error("answers must be an array");
+  if (answers.length > 50) throw new Error("A submission supports at most 50 answers");
+  const validated = answers.map((raw, index) => {
+    const question = String(raw.question ?? "").trim();
+    const answer = String(raw.answer ?? "");
+    if (!question) throw new Error(`Answer ${index + 1} requires a question`);
+    if (question.length > 2000) throw new Error("Questions must be at most 2000 characters");
+    if (answer.length > 20_000) throw new Error("Answers must be at most 20000 characters");
+    const key = raw.key?.trim();
+    if (key && key.length > 100) throw new Error("Answer keys must be at most 100 characters");
+    const kind = raw.kind;
+    if (kind !== undefined && !["text", "boolean", "number", "choice", "salary", "other"].includes(kind)) {
+      throw new Error(`Answer ${index + 1} has an invalid kind`);
+    }
+    if (raw.sensitive !== undefined && typeof raw.sensitive !== "boolean") {
+      throw new Error(`Answer ${index + 1} sensitive must be a boolean`);
+    }
+    return {
+      ...(key ? { key } : {}),
+      question,
+      answer,
+      ...(kind ? { kind } : {}),
+      ...(raw.sensitive !== undefined ? { sensitive: raw.sensitive } : {}),
+    };
+  });
+  if (Buffer.byteLength(JSON.stringify(validated), "utf8") > 750_000) {
+    throw new Error("Submission answers exceed the 750000-byte storage limit");
+  }
+  return validated;
+}
+
+export function validateEventMetadata(value: unknown): Record<string, unknown> {
+  if (value === undefined || value === null) return {};
+  if (typeof value !== "object" || Array.isArray(value)) throw new Error("event_metadata_invalid");
+  const metadata = value as Record<string, unknown>;
+  const entries = Object.entries(metadata);
+  if (entries.length > 100 || entries.some(([key]) => !key || key.length > 100)) {
+    throw new Error("event_metadata_invalid");
+  }
+  if (Buffer.byteLength(JSON.stringify(metadata), "utf8") > 32_000) {
+    throw new Error("event_metadata_too_large");
+  }
+  return metadata;
+}
+
+function asDate(value: Date | string | null): Date | null {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function computeApplicationHealth(input: {
+  applications: HealthApplication[];
+  submissions: HealthSubmission[];
+  documents: HealthDocument[];
+  now?: Date;
+}): ApplicationHealthFinding[] {
+  const now = input.now ?? new Date();
+  const findings: ApplicationHealthFinding[] = [];
+  const submissionsByApplication = new Map<string, HealthSubmission[]>();
+  for (const submission of input.submissions) {
+    const existing = submissionsByApplication.get(submission.applicationId) ?? [];
+    existing.push(submission);
+    submissionsByApplication.set(submission.applicationId, existing);
+    if (submission.answers.length === 0) {
+      findings.push({
+        code: "submission_without_answers",
+        severity: "warning",
+        applicationId: submission.applicationId,
+        submissionId: submission.id,
+        message: "The submission does not preserve any application answers.",
+        remediation: "Record the exact submitted answers or explicitly confirm the form had none.",
+      });
+    }
+    if (submission.documentIds.length === 0) {
+      findings.push({
+        code: "submission_without_materials",
+        severity: "error",
+        applicationId: submission.applicationId,
+        submissionId: submission.id,
+        message: "The submission has no preserved submitted materials.",
+        remediation: "Link the exact submitted CV and other uploaded files.",
+      });
+    }
+  }
+
+  for (const application of input.applications) {
+    const appliedAt = asDate(application.appliedAt);
+    const followUpAt = asDate(application.followUpAt);
+    const isApplied = ["applied", "interview", "offer", "rejected"].includes(application.status);
+    if (isApplied && !appliedAt) {
+      findings.push({
+        code: "applied_without_date",
+        severity: "error",
+        applicationId: application.id,
+        message: "The application is applied-or-later but has no appliedAt timestamp.",
+        remediation: "Record the confirmed submission timestamp.",
+      });
+    }
+    if (!isApplied && appliedAt) {
+      findings.push({
+        code: "date_without_applied_status",
+        severity: "warning",
+        applicationId: application.id,
+        message: "The lead has an appliedAt timestamp but is not in an applied-or-later status.",
+        remediation: "Correct the status or clear the application timestamp.",
+      });
+    }
+    if (["applied", "interview", "offer"].includes(application.status)) {
+      if ((submissionsByApplication.get(application.id) ?? []).length === 0) {
+        findings.push({
+          code: "applied_without_submission",
+          severity: "error",
+          applicationId: application.id,
+          message: "No structured submission package is stored for this active application.",
+          remediation: "Record the submitted answers and exact submitted materials.",
+        });
+      }
+      if (!followUpAt) {
+        findings.push({
+          code: "missing_next_action",
+          severity: "warning",
+          applicationId: application.id,
+          message: "The active application has no follow-up date.",
+          remediation: "Set the next follow-up or interview action.",
+        });
+      } else if (followUpAt.getTime() < now.getTime()) {
+        findings.push({
+          code: "overdue_follow_up",
+          severity: "warning",
+          applicationId: application.id,
+          message: "The follow-up date is overdue.",
+          remediation: "Complete or reschedule the follow-up.",
+        });
+      }
+    }
+  }
+
+  for (const document of input.documents) {
+    if (document.applicationIds.length === 0) {
+      findings.push({
+        code: "orphan_document",
+        severity: "info",
+        documentId: document.id,
+        message: "The document is not linked to an application.",
+        remediation: "Link, classify as intentionally orphaned, archive, or delete after review.",
+      });
+    }
+  }
+
+  return findings;
+}

--- a/lib/cv/generate.ts
+++ b/lib/cv/generate.ts
@@ -4,6 +4,7 @@ import { renderToBuffer } from "@react-pdf/renderer";
 import { CvDocument } from "./pdf-template";
 import { uploadFile } from "@/lib/storage";
 import { deleteDocumentWithContent } from "@/lib/documents/service";
+import { isSubmissionDocument } from "@/lib/documents/access";
 import type { DatabaseAdapter } from "@/lib/db/adapter";
 import type { CvProfileRecord, CvPatchRecord, DocumentRecord } from "@/lib/db/types";
 
@@ -82,7 +83,7 @@ export async function generateAndStoreCv(opts: {
   // Delete previous CV document if tracked on the patch
   if (patch.documentId) {
     const previous = await db.getDocument(patch.documentId, userId);
-    if (previous && !previous.submissionId) {
+    if (previous && !isSubmissionDocument(previous)) {
       await deleteDocumentWithContent(db, patch.documentId, userId);
     }
   }

--- a/lib/cv/generate.ts
+++ b/lib/cv/generate.ts
@@ -2,7 +2,8 @@ import React from "react";
 import { randomUUID } from "crypto";
 import { renderToBuffer } from "@react-pdf/renderer";
 import { CvDocument } from "./pdf-template";
-import { uploadFile, deleteFile, fileExists } from "@/lib/storage";
+import { uploadFile } from "@/lib/storage";
+import { deleteDocumentWithContent } from "@/lib/documents/service";
 import type { DatabaseAdapter } from "@/lib/db/adapter";
 import type { CvProfileRecord, CvPatchRecord, DocumentRecord } from "@/lib/db/types";
 
@@ -80,12 +81,9 @@ export async function generateAndStoreCv(opts: {
 
   // Delete previous CV document if tracked on the patch
   if (patch.documentId) {
-    const oldDoc = await db.getDocument(patch.documentId, userId);
-    if (oldDoc) {
-      if (await fileExists(oldDoc.filename)) {
-        await deleteFile(oldDoc.filename);
-      }
-      await db.deleteDocument(oldDoc.id, userId);
+    const previous = await db.getDocument(patch.documentId, userId);
+    if (previous && !previous.submissionId) {
+      await deleteDocumentWithContent(db, patch.documentId, userId);
     }
   }
 

--- a/lib/db/__tests__/firestore-adapter.test.ts
+++ b/lib/db/__tests__/firestore-adapter.test.ts
@@ -7,6 +7,9 @@ const { mockGetAll, stores, mockTimestamp } = vi.hoisted(() => {
     applications: new Map<string, Record<string, unknown>>(),
     documents: new Map<string, Record<string, unknown>>(),
     contacts: new Map<string, Record<string, unknown>>(),
+    applicationSubmissions: new Map<string, Record<string, unknown>>(),
+    applicationEvents: new Map<string, Record<string, unknown>>(),
+    applicationCanonicalUrls: new Map<string, Record<string, unknown>>(),
   };
 
   const mockGetAll = vi.fn();
@@ -21,16 +24,24 @@ interface MockSnap {
   id: string;
   exists: boolean;
   data: () => Record<string, unknown> | undefined;
-  ref: { id: string };
+  ref: MockDocRef;
 }
 
-function makeDocRef(store: Map<string, Record<string, unknown>>, id: string) {
-  return {
+interface MockDocRef {
+  id: string;
+  __store: Map<string, Record<string, unknown>>;
+  get: () => Promise<MockSnap>;
+  update: (data: Record<string, unknown>) => Promise<void>;
+  delete: () => Promise<void>;
+}
+
+function makeDocRef(store: Map<string, Record<string, unknown>>, id: string): MockDocRef {
+  const ref: MockDocRef = {
     id,
-    ref: { id },
+    __store: store,
     async get(): Promise<MockSnap> {
       const data = store.get(id);
-      return { id, exists: !!data, data: () => data, ref: { id } };
+      return { id, exists: !!data, data: () => data, ref };
     },
     async update(d: Record<string, unknown>) {
       const existing = store.get(id);
@@ -38,29 +49,65 @@ function makeDocRef(store: Map<string, Record<string, unknown>>, id: string) {
     },
     async delete() { store.delete(id); },
   };
+  return ref;
+}
+
+function makeQuery(
+  store: Map<string, Record<string, unknown>>,
+  filters: Array<{ field: string; value: unknown }> = [],
+  sort?: { field: string; direction: "asc" | "desc" },
+  max?: number,
+) {
+  return {
+    where(field: string, operator: string, value: unknown) {
+      if (operator !== "==") throw new Error(`Unsupported mock operator: ${operator}`);
+      return makeQuery(store, [...filters, { field, value }], sort, max);
+    },
+    orderBy(field: string, direction: "asc" | "desc" = "asc") {
+      return makeQuery(store, filters, { field, direction }, max);
+    },
+    limit(value: number) {
+      return makeQuery(store, filters, sort, value);
+    },
+    async get() {
+      let entries = Array.from(store.entries()).filter(([, data]) =>
+        filters.every(({ field, value }) => data[field] === value),
+      );
+      if (sort) {
+        entries.sort(([, left], [, right]) => {
+          const a = left[sort.field] as { toDate?: () => Date } | Date | number | string | undefined;
+          const b = right[sort.field] as { toDate?: () => Date } | Date | number | string | undefined;
+          const normalize = (item: typeof a) => {
+            if (item && typeof item === "object" && "toDate" in item && item.toDate) return item.toDate().getTime();
+            if (item instanceof Date) return item.getTime();
+            return item ?? "";
+          };
+          const result = normalize(a) < normalize(b) ? -1 : normalize(a) > normalize(b) ? 1 : 0;
+          return sort.direction === "desc" ? -result : result;
+        });
+      }
+      if (max !== undefined) entries = entries.slice(0, max);
+      return {
+        empty: entries.length === 0,
+        docs: entries.map(([id, data]) => ({
+          id,
+          exists: true,
+          data: () => data,
+          ref: makeDocRef(store, id),
+        })),
+      };
+    },
+  };
 }
 
 function makeCollection(store: Map<string, Record<string, unknown>>) {
   return {
-    doc: (id: string) => makeDocRef(store, id),
+    ...makeQuery(store),
+    doc: (id?: string) => makeDocRef(store, id ?? `auto-${store.size + 1}`),
     async add(data: Record<string, unknown>) {
       const id = `generated-${store.size + 1}`;
       store.set(id, data);
-      return {
-        id,
-        async get(): Promise<MockSnap> {
-          return { id, exists: true, data: () => store.get(id)!, ref: { id } };
-        },
-      };
-    },
-    orderBy() {
-      return {
-        where() { return { async get() { return { docs: [] }; } }; },
-        async get() { return { docs: [] }; },
-      };
-    },
-    where() {
-      return { async get() { return { docs: [] }; } };
+      return makeDocRef(store, id);
     },
   };
 }
@@ -80,6 +127,34 @@ vi.mock("firebase-admin/firestore", () => ({
       return s ? makeCollection(s) : makeCollection(new Map());
     },
     getAll: mockGetAll,
+    async runTransaction<T>(callback: (transaction: {
+      get: (reference: { get: () => Promise<unknown> }) => Promise<unknown>;
+      create: (ref: MockDocRef, data: Record<string, unknown>) => void;
+      set: (ref: MockDocRef, data: Record<string, unknown>) => void;
+      update: (ref: MockDocRef, data: Record<string, unknown>) => void;
+      delete: (ref: MockDocRef) => void;
+    }) => Promise<T>): Promise<T> {
+      const writes: Array<() => void> = [];
+      const result = await callback({
+        get: (ref) => ref.get(),
+        create: (ref, data) => {
+          if (ref.__store.has(ref.id)) throw new Error("already_exists");
+          writes.push(() => ref.__store.set(ref.id, data));
+        },
+        set: (ref, data) => {
+          writes.push(() => ref.__store.set(ref.id, data));
+        },
+        update: (ref, data) => {
+          if (!ref.__store.has(ref.id)) throw new Error("not_found");
+          writes.push(() => ref.__store.set(ref.id, { ...ref.__store.get(ref.id)!, ...data }));
+        },
+        delete: (ref) => {
+          writes.push(() => ref.__store.delete(ref.id));
+        },
+      });
+      writes.forEach((write) => write());
+      return result;
+    },
     batch: () => ({ delete: vi.fn(), commit: vi.fn() }),
   }),
   Timestamp: {
@@ -124,13 +199,13 @@ function seedApps(apps: Array<{ id: string; userId: string; company: string; rol
         id: r.id,
         exists: !!data,
         data: () => data,
-        ref: { id: r.id },
+        ref: makeDocRef(stores.applications, r.id),
       };
     }),
   );
 }
 
-function seedDocs(docs: Array<{ id: string; userId: string; filename: string; originalName: string; size: number; mimeType: string; applicationIds: string[] }>) {
+function seedDocs(docs: Array<{ id: string; userId: string; filename: string; originalName: string; size: number; mimeType: string; applicationIds: string[]; submissionId?: string | null }>) {
   stores.documents.clear();
   for (const d of docs) {
     stores.documents.set(d.id, {
@@ -140,12 +215,271 @@ function seedDocs(docs: Array<{ id: string; userId: string; filename: string; or
       size: d.size,
       mimeType: d.mimeType,
       applicationIds: d.applicationIds,
+      submissionId: d.submissionId ?? null,
       uploadedAt: mockTimestamp,
     });
   }
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────────
+
+describe("FirestoreAdapter — application metadata", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stores.applications.clear();
+    stores.documents.clear();
+    stores.contacts.clear();
+    stores.applicationCanonicalUrls.clear();
+  });
+
+  it("persists structured opportunity metadata and keeps inbound unapplied", async () => {
+    const adapter = new FirestoreAdapter();
+    const result = await adapter.createApplication("user-1", {
+      company: "Acme",
+      role: "Senior Platform Engineer",
+      status: "inbound",
+      appliedAt: null,
+      lastContact: null,
+      followUpAt: null,
+      notes: null,
+      jobDescription: "Build a platform",
+      source: "company-site",
+      remote: true,
+      salaryMin: 80_000,
+      salaryMax: 100_000,
+      rating: 5,
+      jobUrl: "https://example.com/jobs/1",
+      resumeId: null,
+      canonicalJobUrl: "https://example.com/jobs/1",
+      workMode: "remote",
+      eligibleCountries: ["ES", "AT"],
+      primaryLocations: ["Europe"],
+      salaryCurrency: "EUR",
+      salaryPeriod: "year",
+      salaryType: "base",
+      atsName: "greenhouse",
+      requisitionId: "REQ-1",
+      jobLiveness: "live",
+    });
+
+    expect(result.status).toBe("inbound");
+    expect(result.appliedAt).toBeNull();
+    expect(result.eligibleCountries).toEqual(["ES", "AT"]);
+    expect(result.salaryCurrency).toBe("EUR");
+    expect(result.requisitionId).toBe("REQ-1");
+  });
+
+  it("atomically rejects duplicate canonical job URLs", async () => {
+    const adapter = new FirestoreAdapter();
+    const input = {
+      company: "Acme",
+      role: "Platform Engineer",
+      status: "inbound" as const,
+      appliedAt: null,
+      lastContact: null,
+      followUpAt: null,
+      notes: null,
+      jobDescription: null,
+      source: "company-site",
+      remote: true,
+      salaryMin: null,
+      salaryMax: null,
+      rating: null,
+      jobUrl: "https://example.com/jobs/1",
+      resumeId: null,
+      canonicalJobUrl: "https://example.com/jobs/1",
+    };
+
+    await adapter.createApplication("user-1", input);
+    await expect(adapter.createApplication("user-1", input)).rejects.toThrow("canonical_job_url_conflict");
+    expect(stores.applications.size).toBe(1);
+    expect(stores.applicationCanonicalUrls.size).toBe(1);
+  });
+  it("routes batch creates through canonical URL uniqueness", async () => {
+    const adapter = new FirestoreAdapter();
+    const item = {
+      company: "Acme",
+      role: "Platform Engineer",
+      status: "inbound" as const,
+      canonicalJobUrl: "https://example.com/jobs/1",
+    };
+
+    const result = await adapter.batchUpsertApplications("user-1", [item, item]);
+    expect(result.succeeded).toBe(1);
+    expect(result.failed).toBe(1);
+    expect(stores.applications.size).toBe(1);
+    expect(stores.applicationCanonicalUrls.size).toBe(1);
+  });
+
+  it("routes batch updates through deletion and canonical-index guards", async () => {
+    const adapter = new FirestoreAdapter();
+    const application = await adapter.createApplication("user-1", {
+      company: "Acme",
+      role: "Platform Engineer",
+      status: "inbound",
+      appliedAt: null,
+      lastContact: null,
+      followUpAt: null,
+      notes: null,
+      jobDescription: null,
+      source: null,
+      remote: true,
+      salaryMin: null,
+      salaryMax: null,
+      rating: null,
+      jobUrl: "https://example.com/jobs/1",
+      resumeId: null,
+      canonicalJobUrl: "https://example.com/jobs/1",
+    });
+    stores.applications.get(application.id)!.deletionState = "in_progress";
+
+    const result = await adapter.batchUpsertApplications("user-1", [{
+      id: application.id,
+      canonicalJobUrl: "https://example.com/jobs/2",
+    }]);
+    expect(result.failed).toBe(1);
+    expect(stores.applicationCanonicalUrls.size).toBe(1);
+    expect(Array.from(stores.applicationCanonicalUrls.values())[0].canonicalJobUrl)
+      .toBe("https://example.com/jobs/1");
+  });
+});
+
+describe("FirestoreAdapter — submission transaction", () => {
+  const userId = "user-1";
+  const submittedAt = new Date("2026-07-13T07:13:17Z");
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.values(stores).forEach((store) => store.clear());
+    mockGetAll.mockImplementation(async (...refs: MockDocRef[]) =>
+      Promise.all(refs.map((ref) => ref.get())),
+    );
+    stores.applications.set("app-1", {
+      userId,
+      company: "Pleo",
+      role: "Senior GenAI Platform Engineer",
+      status: "inbound",
+      appliedAt: null,
+      notes: null,
+      updatedAt: mockTimestamp,
+      createdAt: mockTimestamp,
+    });
+    stores.documents.set("doc-1", {
+      userId,
+      filename: "cv.pdf",
+      originalName: "cv.pdf",
+      size: 100,
+      mimeType: "application/pdf",
+      documentType: "resume",
+      state: "current",
+      version: 1,
+      applicationIds: ["app-1"],
+      submissionId: null,
+      uploadedAt: mockTimestamp,
+    });
+  });
+
+  function input(answer = "Exact submitted answer") {
+    return {
+      applicationId: "app-1",
+      idempotencyKey: "pleo-submit-2026-07-13",
+      submittedAt,
+      followUpAt: new Date("2026-07-17T07:00:00Z"),
+      answers: [{ question: "Why Pleo?", answer }],
+      candidateSalaryMin: 75_000,
+      candidateSalaryMax: 75_000,
+      candidateSalaryCurrency: "EUR",
+      candidateSalaryPeriod: "year",
+      candidateSalaryType: "base",
+      candidateSalaryFlexible: true,
+      documentIds: ["doc-1"],
+      source: "test",
+      actor: "user@example.com",
+    };
+  }
+
+  it("atomically records, verifies, and idempotently replays a package", async () => {
+    const adapter = new FirestoreAdapter();
+    const created = await adapter.recordApplicationSubmission(userId, input());
+
+    expect(created.replayed).toBe(false);
+    expect(created.verified).toBe(true);
+    expect(created.application.status).toBe("applied");
+    expect(created.submission.answers).toEqual([{ question: "Why Pleo?", answer: "Exact submitted answer" }]);
+    expect(created.documents[0].state).toBe("submitted");
+    expect(stores.applicationSubmissions).toHaveLength(1);
+    expect(stores.applicationEvents).toHaveLength(1);
+
+    const replay = await adapter.recordApplicationSubmission(userId, input());
+    expect(replay.replayed).toBe(true);
+    expect(stores.applicationSubmissions).toHaveLength(1);
+    expect(stores.applicationEvents).toHaveLength(1);
+  });
+
+  it("rejects the same idempotency key with a different payload", async () => {
+    const adapter = new FirestoreAdapter();
+    await adapter.recordApplicationSubmission(userId, input());
+
+    await expect(
+      adapter.recordApplicationSubmission(userId, input("Changed answer")),
+    ).rejects.toThrow("idempotency_conflict");
+  });
+
+  it("validates dry-run without mutating application, document, or package stores", async () => {
+    const adapter = new FirestoreAdapter();
+    const result = await adapter.recordApplicationSubmission(userId, { ...input(), dryRun: true });
+
+    expect(result.dryRun).toBe(true);
+    expect(stores.applications.get("app-1")!.status).toBe("inbound");
+    expect(stores.documents.get("doc-1")!.state).toBe("current");
+    expect(stores.applicationSubmissions).toHaveLength(0);
+    expect(stores.applicationEvents).toHaveLength(0);
+  });
+
+  it("rejects cross-user submission attempts without partial writes", async () => {
+    const adapter = new FirestoreAdapter();
+    await expect(
+      adapter.recordApplicationSubmission("other-user", input()),
+    ).rejects.toThrow("not_found");
+    expect(stores.applicationSubmissions).toHaveLength(0);
+    expect(stores.applicationEvents).toHaveLength(0);
+  });
+
+  it("rejects writes while application deletion is in progress", async () => {
+    const adapter = new FirestoreAdapter();
+    stores.applications.get("app-1")!.deletionState = "in_progress";
+
+    await expect(adapter.recordApplicationSubmission(userId, input())).rejects.toThrow("application_deleting");
+    expect(stores.applicationSubmissions).toHaveLength(0);
+    expect(stores.applicationEvents).toHaveLength(0);
+  });
+
+  it("rolls back the entire package when a referenced document is invalid", async () => {
+    const adapter = new FirestoreAdapter();
+    await expect(
+      adapter.recordApplicationSubmission(userId, {
+        ...input(),
+        documentIds: ["doc-1", "missing-doc"],
+      }),
+    ).rejects.toThrow("invalid_documents");
+    expect(stores.applications.get("app-1")!.status).toBe("inbound");
+    expect(stores.documents.get("doc-1")!.state).toBe("current");
+    expect(stores.applicationSubmissions).toHaveLength(0);
+    expect(stores.applicationEvents).toHaveLength(0);
+  });
+
+  it("rejects stale optimistic-concurrency timestamps without writes", async () => {
+    const adapter = new FirestoreAdapter();
+    await expect(
+      adapter.recordApplicationSubmission(userId, {
+        ...input(),
+        expectedUpdatedAt: new Date("2026-01-01T00:00:00Z"),
+      }),
+    ).rejects.toThrow("conflict");
+    expect(stores.applications.get("app-1")!.status).toBe("inbound");
+    expect(stores.applicationSubmissions).toHaveLength(0);
+  });
+});
 
 describe("FirestoreAdapter — document operations", () => {
   let adapter: FirestoreAdapter;
@@ -159,8 +493,22 @@ describe("FirestoreAdapter — document operations", () => {
     adapter = new FirestoreAdapter();
   });
 
+  it("excludes submitted and historical artifacts for base MCP scope", async () => {
+    seedDocs([
+      { id: "current", userId, filename: "a.pdf", originalName: "a.pdf", size: 1, mimeType: "application/pdf", applicationIds: [] },
+      { id: "submitted", userId, filename: "b.pdf", originalName: "b.pdf", size: 1, mimeType: "application/pdf", applicationIds: [], submissionId: "submission-1" },
+      { id: "historical", userId, filename: "c.pdf", originalName: "c.pdf", size: 1, mimeType: "application/pdf", applicationIds: [] },
+    ]);
+    stores.documents.get("current")!.state = "current";
+    stores.documents.get("submitted")!.state = "submitted";
+    stores.documents.get("historical")!.state = "historical";
+
+    const documents = await adapter.listDocumentsFiltered(userId, { excludeSubmissionArtifacts: true });
+    expect(documents.map((document) => document.id)).toEqual(["current"]);
+  });
+
   describe("createDocument", () => {
-    it("uses getAll (batch) instead of individual get() calls", async () => {
+    it("verifies linked applications transactionally", async () => {
       seedApps([
         { id: "app-1", userId, company: "Acme", role: "Dev" },
         { id: "app-2", userId, company: "Globex", role: "SRE" },
@@ -174,28 +522,40 @@ describe("FirestoreAdapter — document operations", () => {
         applicationIds: ["app-1", "app-2"],
       });
 
-      expect(mockGetAll).toHaveBeenCalledTimes(1);
+      expect(mockGetAll).not.toHaveBeenCalled();
       expect(result.applications).toHaveLength(2);
       expect(result.applications![0].company).toBe("Acme");
       expect(result.applications![1].company).toBe("Globex");
     });
 
-    it("filters out apps not owned by the user", async () => {
+    it("rejects apps not owned by the user without creating a document", async () => {
       seedApps([
         { id: "app-1", userId, company: "Acme", role: "Dev" },
         { id: "app-2", userId: "other-user", company: "Evil Corp", role: "Spy" },
       ]);
 
-      const result = await adapter.createDocument(userId, {
+      await expect(adapter.createDocument(userId, {
         filename: "doc.pdf",
         originalName: "doc.pdf",
         size: 512,
         mimeType: "application/pdf",
         applicationIds: ["app-1", "app-2"],
-      });
+      })).rejects.toThrow("invalid_applications");
+      expect(stores.documents.size).toBe(0);
+    });
 
-      expect(result.applications).toHaveLength(1);
-      expect(result.applications![0].company).toBe("Acme");
+    it("rejects links to applications being deleted", async () => {
+      seedApps([{ id: "app-1", userId, company: "Acme", role: "Dev" }]);
+      stores.applications.get("app-1")!.deletionState = "in_progress";
+
+      await expect(adapter.createDocument(userId, {
+        filename: "doc.pdf",
+        originalName: "doc.pdf",
+        size: 512,
+        mimeType: "application/pdf",
+        applicationIds: ["app-1"],
+      })).rejects.toThrow("invalid_applications");
+      expect(stores.documents.size).toBe(0);
     });
 
     it("handles empty applicationIds without calling getAll", async () => {
@@ -211,21 +571,19 @@ describe("FirestoreAdapter — document operations", () => {
       expect(result.applications).toHaveLength(0);
     });
 
-    it("filters out non-existent app IDs", async () => {
+    it("rejects non-existent app IDs without creating a document", async () => {
       seedApps([
         { id: "app-1", userId, company: "Acme", role: "Dev" },
       ]);
 
-      const result = await adapter.createDocument(userId, {
+      await expect(adapter.createDocument(userId, {
         filename: "test.pdf",
         originalName: "test.pdf",
         size: 100,
         mimeType: "application/pdf",
         applicationIds: ["app-1", "app-nonexistent"],
-      });
-
-      expect(result.applications).toHaveLength(1);
-      expect(result.applications![0].id).toBe("app-1");
+      })).rejects.toThrow("invalid_applications");
+      expect(stores.documents.size).toBe(0);
     });
   });
 
@@ -254,7 +612,19 @@ describe("FirestoreAdapter — document operations", () => {
 
       await expect(
         adapter.updateDocumentLinks("doc-1", userId, ["app-1"]),
-      ).rejects.toThrow("Not found");
+      ).rejects.toThrow("not_found");
+    });
+
+    it("rejects relinking an exact submitted document version", async () => {
+      seedDocs([{
+        id: "doc-1", userId, filename: "f.pdf", originalName: "f.pdf",
+        size: 100, mimeType: "application/pdf", applicationIds: ["app-1"],
+        submissionId: "submission-1",
+      }]);
+
+      await expect(
+        adapter.updateDocumentLinks("doc-1", userId, []),
+      ).rejects.toThrow("submitted_document_immutable");
     });
   });
 
@@ -285,23 +655,74 @@ describe("FirestoreAdapter — document operations", () => {
       const result = await adapter.renameDocument("doc-1", userId, "nope.pdf");
       expect(result).toBeNull();
     });
+
+    it("rejects renaming an exact submitted document version", async () => {
+      seedDocs([{
+        id: "doc-1", userId, filename: "f.pdf", originalName: "f.pdf",
+        size: 100, mimeType: "application/pdf", applicationIds: [],
+        submissionId: "submission-1",
+      }]);
+
+      await expect(
+        adapter.renameDocument("doc-1", userId, "changed.pdf"),
+      ).rejects.toThrow("submitted_document_immutable");
+    });
   });
 
-  describe("batch chunking", () => {
-    it("chunks into batches of 30 for large app lists", async () => {
+  describe("submitted document lifecycle", () => {
+    it("allows only the submitted-to-historical state transition", async () => {
+      seedDocs([{
+        id: "doc-1", userId, filename: "f.pdf", originalName: "f.pdf",
+        size: 100, mimeType: "application/pdf", applicationIds: [],
+        submissionId: "submission-1",
+      }]);
+
+      const historical = await adapter.updateDocumentMetadata("doc-1", userId, {
+        state: "historical",
+      });
+      expect(historical.state).toBe("historical");
+
+      await expect(
+        adapter.updateDocumentMetadata("doc-1", userId, { version: 2 }),
+      ).rejects.toThrow("submitted_document_immutable");
+    });
+
+    it("keeps historical submitted artifacts immutable after their submission record is removed", async () => {
+      seedDocs([{
+        id: "doc-1", userId, filename: "f.pdf", originalName: "f.pdf",
+        size: 100, mimeType: "application/pdf", applicationIds: [], submissionId: null,
+      }]);
+      stores.documents.get("doc-1")!.state = "historical";
+
+      await expect(adapter.renameDocument("doc-1", userId, "renamed.pdf"))
+        .rejects.toThrow("submitted_document_immutable");
+      await expect(adapter.updateDocumentLinks("doc-1", userId, []))
+        .rejects.toThrow("submitted_document_immutable");
+      await expect(adapter.deleteDocument("doc-1", userId))
+        .rejects.toThrow("submitted_document_immutable");
+      await expect(adapter.updateDocumentMetadata("doc-1", userId, { source: "changed" }))
+        .rejects.toThrow("submitted_document_immutable");
+    });
+
+    it("rejects deleting an exact submitted document version", async () => {
+      seedDocs([{
+        id: "doc-1", userId, filename: "f.pdf", originalName: "f.pdf",
+        size: 100, mimeType: "application/pdf", applicationIds: [],
+        submissionId: "submission-1",
+      }]);
+
+      await expect(adapter.deleteDocument("doc-1", userId)).rejects.toThrow(
+        "submitted_document_immutable",
+      );
+    });
+  });
+
+  describe("large application link sets", () => {
+    it("verifies 35 linked applications in one transaction", async () => {
       const apps = Array.from({ length: 35 }, (_, i) => ({
         id: `app-${i}`, userId, company: `Co-${i}`, role: "Eng",
       }));
       seedApps(apps);
-
-      let callCount = 0;
-      mockGetAll.mockImplementation(async (...refs: Array<{ id: string }>) => {
-        callCount++;
-        return refs.map((r) => {
-          const data = stores.applications.get(r.id);
-          return { id: r.id, exists: !!data, data: () => data, ref: { id: r.id } };
-        });
-      });
 
       const result = await adapter.createDocument(userId, {
         filename: "big.pdf",
@@ -311,8 +732,7 @@ describe("FirestoreAdapter — document operations", () => {
         applicationIds: apps.map((a) => a.id),
       });
 
-      // 35 apps → 2 chunks (30 + 5)
-      expect(callCount).toBe(2);
+      expect(mockGetAll).not.toHaveBeenCalled();
       expect(result.applications).toHaveLength(35);
     });
   });

--- a/lib/db/__tests__/firestore-adapter.test.ts
+++ b/lib/db/__tests__/firestore-adapter.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ── Hoisted mocks (available inside vi.mock factories) ──────────────────────
 
-const { mockGetAll, stores, mockTimestamp } = vi.hoisted(() => {
+const { mockGetAll, stores, mockTimestamp, batchState } = vi.hoisted(() => {
   const stores = {
     applications: new Map<string, Record<string, unknown>>(),
     documents: new Map<string, Record<string, unknown>>(),
@@ -14,8 +14,9 @@ const { mockGetAll, stores, mockTimestamp } = vi.hoisted(() => {
 
   const mockGetAll = vi.fn();
   const mockTimestamp = { toDate: () => new Date("2025-01-01") };
+  const batchState = { commitCount: 0, failOnCommit: null as number | null };
 
-  return { mockGetAll, stores, mockTimestamp };
+  return { mockGetAll, stores, mockTimestamp, batchState };
 });
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -54,14 +55,16 @@ function makeDocRef(store: Map<string, Record<string, unknown>>, id: string): Mo
 
 function makeQuery(
   store: Map<string, Record<string, unknown>>,
-  filters: Array<{ field: string; value: unknown }> = [],
+  filters: Array<{ field: string; operator: string; value: unknown }> = [],
   sort?: { field: string; direction: "asc" | "desc" },
   max?: number,
 ) {
   return {
     where(field: string, operator: string, value: unknown) {
-      if (operator !== "==") throw new Error(`Unsupported mock operator: ${operator}`);
-      return makeQuery(store, [...filters, { field, value }], sort, max);
+      if (!["==", "array-contains", "in"].includes(operator)) {
+        throw new Error(`Unsupported mock operator: ${operator}`);
+      }
+      return makeQuery(store, [...filters, { field, operator, value }], sort, max);
     },
     orderBy(field: string, direction: "asc" | "desc" = "asc") {
       return makeQuery(store, filters, { field, direction }, max);
@@ -71,7 +74,11 @@ function makeQuery(
     },
     async get() {
       let entries = Array.from(store.entries()).filter(([, data]) =>
-        filters.every(({ field, value }) => data[field] === value),
+        filters.every(({ field, operator, value }) => {
+          if (operator === "==") return data[field] === value;
+          if (operator === "array-contains") return Array.isArray(data[field]) && data[field].includes(value);
+          return Array.isArray(value) && value.includes(data[field]);
+        }),
       );
       if (sort) {
         entries.sort(([, left], [, right]) => {
@@ -155,7 +162,22 @@ vi.mock("firebase-admin/firestore", () => ({
       writes.forEach((write) => write());
       return result;
     },
-    batch: () => ({ delete: vi.fn(), commit: vi.fn() }),
+    batch: () => {
+      const writes: Array<() => void> = [];
+      return {
+        delete: (ref: MockDocRef) => writes.push(() => ref.__store.delete(ref.id)),
+        update: (ref: MockDocRef, data: Record<string, unknown>) => writes.push(() => {
+          const current = ref.__store.get(ref.id);
+          if (!current) throw new Error("not_found");
+          ref.__store.set(ref.id, { ...current, ...data });
+        }),
+        commit: async () => {
+          batchState.commitCount += 1;
+          if (batchState.failOnCommit === batchState.commitCount) throw new Error("injected_batch_failure");
+          writes.forEach((write) => write());
+        },
+      };
+    },
   }),
   Timestamp: {
     now: () => mockTimestamp,
@@ -222,6 +244,11 @@ function seedDocs(docs: Array<{ id: string; userId: string; filename: string; or
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  batchState.commitCount = 0;
+  batchState.failOnCommit = null;
+});
 
 describe("FirestoreAdapter — application metadata", () => {
   beforeEach(() => {
@@ -341,6 +368,59 @@ describe("FirestoreAdapter — application metadata", () => {
     expect(stores.applicationCanonicalUrls.size).toBe(1);
     expect(Array.from(stores.applicationCanonicalUrls.values())[0].canonicalJobUrl)
       .toBe("https://example.com/jobs/1");
+  });
+});
+
+describe("FirestoreAdapter — retryable application deletion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.values(stores).forEach((store) => store.clear());
+  });
+
+  it("preserves all submitted documents before deleting submissions and recovers after a later batch fails", async () => {
+    const adapter = new FirestoreAdapter();
+    stores.applications.set("app-1", {
+      userId: "user-1", company: "Acme", role: "Engineer", canonicalJobUrl: null,
+    });
+    stores.applicationSubmissions.set("submission-1", {
+      userId: "user-1", applicationId: "app-1",
+    });
+    for (let index = 0; index < 451; index += 1) {
+      stores.documents.set(`doc-${index}`, {
+        userId: "user-1",
+        filename: `doc-${index}.pdf`,
+        originalName: `doc-${index}.pdf`,
+        size: 1,
+        mimeType: "application/pdf",
+        applicationIds: ["app-1"],
+        submissionId: "submission-1",
+        state: "submitted",
+        uploadedAt: mockTimestamp,
+      });
+    }
+    batchState.failOnCommit = 2;
+
+    await expect(adapter.deleteApplication("app-1", "user-1"))
+      .rejects.toThrow("injected_batch_failure");
+    expect(stores.applicationSubmissions.has("submission-1")).toBe(true);
+    expect(stores.documents.get("doc-0")).toMatchObject({
+      applicationIds: [], submissionId: null, state: "historical",
+    });
+    expect(stores.documents.get("doc-450")).toMatchObject({
+      applicationIds: ["app-1"], submissionId: "submission-1", state: "submitted",
+    });
+
+    batchState.failOnCommit = null;
+    await adapter.deleteApplication("app-1", "user-1");
+
+    expect(stores.applications.has("app-1")).toBe(false);
+    expect(stores.applicationSubmissions.has("submission-1")).toBe(false);
+    expect(Array.from(stores.documents.values()).every((document) =>
+      Array.isArray(document.applicationIds)
+      && document.applicationIds.length === 0
+      && document.submissionId === null
+      && document.state === "historical"
+    )).toBe(true);
   });
 });
 

--- a/lib/db/__tests__/firestore-adapter.test.ts
+++ b/lib/db/__tests__/firestore-adapter.test.ts
@@ -496,6 +496,17 @@ describe("FirestoreAdapter — submission transaction", () => {
     expect(stores.applicationEvents).toHaveLength(1);
   });
 
+  it("rejects reuse of a historical submission artifact without partial writes", async () => {
+    const adapter = new FirestoreAdapter();
+    stores.documents.get("doc-1")!.state = "historical";
+
+    await expect(adapter.recordApplicationSubmission(userId, input()))
+      .rejects.toThrow("document_already_submitted");
+    expect(stores.applicationSubmissions).toHaveLength(0);
+    expect(stores.applicationEvents).toHaveLength(0);
+    expect(stores.documents.get("doc-1")).toMatchObject({ state: "historical", submissionId: null });
+  });
+
   it("rejects the same idempotency key with a different payload", async () => {
     const adapter = new FirestoreAdapter();
     await adapter.recordApplicationSubmission(userId, input());
@@ -756,12 +767,16 @@ describe("FirestoreAdapter — document operations", () => {
         size: 100, mimeType: "application/pdf", applicationIds: [],
         submissionId: "submission-1",
       }]);
+      stores.documents.get("doc-1")!.state = "submitted";
 
       const historical = await adapter.updateDocumentMetadata("doc-1", userId, {
         state: "historical",
       });
       expect(historical.state).toBe("historical");
 
+      await expect(
+        adapter.updateDocumentMetadata("doc-1", userId, { state: "submitted" }),
+      ).rejects.toThrow("submitted_document_immutable");
       await expect(
         adapter.updateDocumentMetadata("doc-1", userId, { version: 2 }),
       ).rejects.toThrow("submitted_document_immutable");
@@ -781,6 +796,8 @@ describe("FirestoreAdapter — document operations", () => {
       await expect(adapter.deleteDocument("doc-1", userId))
         .rejects.toThrow("submitted_document_immutable");
       await expect(adapter.updateDocumentMetadata("doc-1", userId, { source: "changed" }))
+        .rejects.toThrow("submitted_document_immutable");
+      await expect(adapter.updateDocumentMetadata("doc-1", userId, { state: "submitted" }))
         .rejects.toThrow("submitted_document_immutable");
     });
 

--- a/lib/db/__tests__/firestore-adapter.test.ts
+++ b/lib/db/__tests__/firestore-adapter.test.ts
@@ -547,13 +547,13 @@ describe("FirestoreAdapter — submission transaction", () => {
     expect(created.application.status).toBe("applied");
     expect(created.submission.answers).toEqual([{ question: "Why Pleo?", answer: "Exact submitted answer" }]);
     expect(created.documents[0].state).toBe("submitted");
-    expect(stores.applicationSubmissions).toHaveLength(1);
-    expect(stores.applicationEvents).toHaveLength(1);
+    expect(stores.applicationSubmissions.size).toBe(1);
+    expect(stores.applicationEvents.size).toBe(1);
 
     const replay = await adapter.recordApplicationSubmission(userId, input());
     expect(replay.replayed).toBe(true);
-    expect(stores.applicationSubmissions).toHaveLength(1);
-    expect(stores.applicationEvents).toHaveLength(1);
+    expect(stores.applicationSubmissions.size).toBe(1);
+    expect(stores.applicationEvents.size).toBe(1);
   });
 
   it("rejects reuse of a historical submission artifact without partial writes", async () => {
@@ -562,8 +562,8 @@ describe("FirestoreAdapter — submission transaction", () => {
 
     await expect(adapter.recordApplicationSubmission(userId, input()))
       .rejects.toThrow("document_already_submitted");
-    expect(stores.applicationSubmissions).toHaveLength(0);
-    expect(stores.applicationEvents).toHaveLength(0);
+    expect(stores.applicationSubmissions.size).toBe(0);
+    expect(stores.applicationEvents.size).toBe(0);
     expect(stores.documents.get("doc-1")).toMatchObject({ state: "historical", submissionId: null });
   });
 
@@ -583,8 +583,8 @@ describe("FirestoreAdapter — submission transaction", () => {
     expect(result.dryRun).toBe(true);
     expect(stores.applications.get("app-1")!.status).toBe("inbound");
     expect(stores.documents.get("doc-1")!.state).toBe("current");
-    expect(stores.applicationSubmissions).toHaveLength(0);
-    expect(stores.applicationEvents).toHaveLength(0);
+    expect(stores.applicationSubmissions.size).toBe(0);
+    expect(stores.applicationEvents.size).toBe(0);
   });
 
   it("rejects cross-user submission attempts without partial writes", async () => {
@@ -592,8 +592,8 @@ describe("FirestoreAdapter — submission transaction", () => {
     await expect(
       adapter.recordApplicationSubmission("other-user", input()),
     ).rejects.toThrow("not_found");
-    expect(stores.applicationSubmissions).toHaveLength(0);
-    expect(stores.applicationEvents).toHaveLength(0);
+    expect(stores.applicationSubmissions.size).toBe(0);
+    expect(stores.applicationEvents.size).toBe(0);
   });
 
   it("rejects writes while application deletion is in progress", async () => {
@@ -601,8 +601,8 @@ describe("FirestoreAdapter — submission transaction", () => {
     stores.applications.get("app-1")!.deletionState = "in_progress";
 
     await expect(adapter.recordApplicationSubmission(userId, input())).rejects.toThrow("application_deleting");
-    expect(stores.applicationSubmissions).toHaveLength(0);
-    expect(stores.applicationEvents).toHaveLength(0);
+    expect(stores.applicationSubmissions.size).toBe(0);
+    expect(stores.applicationEvents.size).toBe(0);
   });
 
   it("rolls back the entire package when a referenced document is invalid", async () => {
@@ -615,8 +615,8 @@ describe("FirestoreAdapter — submission transaction", () => {
     ).rejects.toThrow("invalid_documents");
     expect(stores.applications.get("app-1")!.status).toBe("inbound");
     expect(stores.documents.get("doc-1")!.state).toBe("current");
-    expect(stores.applicationSubmissions).toHaveLength(0);
-    expect(stores.applicationEvents).toHaveLength(0);
+    expect(stores.applicationSubmissions.size).toBe(0);
+    expect(stores.applicationEvents.size).toBe(0);
   });
 
   it("rejects stale optimistic-concurrency timestamps without writes", async () => {
@@ -628,7 +628,7 @@ describe("FirestoreAdapter — submission transaction", () => {
       }),
     ).rejects.toThrow("conflict");
     expect(stores.applications.get("app-1")!.status).toBe("inbound");
-    expect(stores.applicationSubmissions).toHaveLength(0);
+    expect(stores.applicationSubmissions.size).toBe(0);
   });
 });
 

--- a/lib/db/__tests__/firestore-adapter.test.ts
+++ b/lib/db/__tests__/firestore-adapter.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ── Hoisted mocks (available inside vi.mock factories) ──────────────────────
 
-const { mockGetAll, stores, mockTimestamp, batchState } = vi.hoisted(() => {
+const { mockGetAll, stores, mockTimestamp, batchState, applyUpdate } = vi.hoisted(() => {
   const stores = {
     applications: new Map<string, Record<string, unknown>>(),
     documents: new Map<string, Record<string, unknown>>(),
@@ -14,9 +14,29 @@ const { mockGetAll, stores, mockTimestamp, batchState } = vi.hoisted(() => {
 
   const mockGetAll = vi.fn();
   const mockTimestamp = { toDate: () => new Date("2025-01-01") };
-  const batchState = { commitCount: 0, failOnCommit: null as number | null };
+  const batchState = {
+    commitCount: 0,
+    failOnCommit: null as number | null,
+    beforeCommit: null as (() => void) | null,
+  };
+  const applyUpdate = (
+    current: Record<string, unknown>,
+    update: Record<string, unknown>,
+  ): Record<string, unknown> => {
+    const next = { ...current };
+    for (const [key, value] of Object.entries(update)) {
+      if (value && typeof value === "object" && "__arrayRemove" in value) {
+        const removed = (value as { __arrayRemove: unknown[] }).__arrayRemove;
+        const existing = Array.isArray(next[key]) ? next[key] : [];
+        next[key] = existing.filter((item) => !removed.includes(item));
+      } else {
+        next[key] = value;
+      }
+    }
+    return next;
+  };
 
-  return { mockGetAll, stores, mockTimestamp, batchState };
+  return { mockGetAll, stores, mockTimestamp, batchState, applyUpdate };
 });
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -46,7 +66,7 @@ function makeDocRef(store: Map<string, Record<string, unknown>>, id: string): Mo
     },
     async update(d: Record<string, unknown>) {
       const existing = store.get(id);
-      if (existing) store.set(id, { ...existing, ...d });
+      if (existing) store.set(id, applyUpdate(existing, d));
     },
     async delete() { store.delete(id); },
   };
@@ -153,7 +173,7 @@ vi.mock("firebase-admin/firestore", () => ({
         },
         update: (ref, data) => {
           if (!ref.__store.has(ref.id)) throw new Error("not_found");
-          writes.push(() => ref.__store.set(ref.id, { ...ref.__store.get(ref.id)!, ...data }));
+          writes.push(() => ref.__store.set(ref.id, applyUpdate(ref.__store.get(ref.id)!, data)));
         },
         delete: (ref) => {
           writes.push(() => ref.__store.delete(ref.id));
@@ -169,11 +189,14 @@ vi.mock("firebase-admin/firestore", () => ({
         update: (ref: MockDocRef, data: Record<string, unknown>) => writes.push(() => {
           const current = ref.__store.get(ref.id);
           if (!current) throw new Error("not_found");
-          ref.__store.set(ref.id, { ...current, ...data });
+          ref.__store.set(ref.id, applyUpdate(current, data));
         }),
         commit: async () => {
           batchState.commitCount += 1;
           if (batchState.failOnCommit === batchState.commitCount) throw new Error("injected_batch_failure");
+          const beforeCommit = batchState.beforeCommit;
+          batchState.beforeCommit = null;
+          beforeCommit?.();
           writes.forEach((write) => write());
         },
       };
@@ -183,7 +206,10 @@ vi.mock("firebase-admin/firestore", () => ({
     now: () => mockTimestamp,
     fromDate: (d: Date) => ({ toDate: () => d }),
   },
-  FieldValue: { serverTimestamp: () => mockTimestamp },
+  FieldValue: {
+    serverTimestamp: () => mockTimestamp,
+    arrayRemove: (...values: unknown[]) => ({ __arrayRemove: values }),
+  },
 }));
 
 vi.mock("@/lib/prisma", () => ({
@@ -248,6 +274,7 @@ function seedDocs(docs: Array<{ id: string; userId: string; filename: string; or
 beforeEach(() => {
   batchState.commitCount = 0;
   batchState.failOnCommit = null;
+  batchState.beforeCommit = null;
 });
 
 describe("FirestoreAdapter — application metadata", () => {
@@ -375,6 +402,39 @@ describe("FirestoreAdapter — retryable application deletion", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     Object.values(stores).forEach((store) => store.clear());
+  });
+
+  it("removes only the deleted application link without overwriting a concurrent document mutation", async () => {
+    const adapter = new FirestoreAdapter();
+    stores.applications.set("app-1", {
+      userId: "user-1", company: "Acme", role: "Engineer", canonicalJobUrl: null,
+    });
+    stores.documents.set("doc-1", {
+      userId: "user-1",
+      filename: "doc.pdf",
+      originalName: "doc.pdf",
+      size: 1,
+      mimeType: "application/pdf",
+      applicationIds: ["app-1", "app-2"],
+      submissionId: null,
+      state: "current",
+      uploadedAt: mockTimestamp,
+    });
+    batchState.beforeCommit = () => {
+      stores.documents.set("doc-1", {
+        ...stores.documents.get("doc-1")!,
+        applicationIds: ["app-1", "app-2", "app-3"],
+        state: "superseded",
+      });
+    };
+
+    await adapter.deleteApplication("app-1", "user-1");
+
+    expect(stores.documents.get("doc-1")).toMatchObject({
+      applicationIds: ["app-2", "app-3"],
+      submissionId: null,
+      state: "superseded",
+    });
   });
 
   it("preserves all submitted documents before deleting submissions and recovers after a later batch fails", async () => {

--- a/lib/db/adapter.ts
+++ b/lib/db/adapter.ts
@@ -23,6 +23,13 @@ import type {
   UpsertCvProfileInput,
   CvPatchRecord,
   UpsertCvPatchInput,
+  ApplicationSubmissionRecord,
+  ApplicationEventRecord,
+  RecordSubmissionInput,
+  RecordSubmissionResult,
+  CreateApplicationEventInput,
+  ListDocumentsFilter,
+  UpdateDocumentMetadataInput,
 } from "./types";
 
 export interface DatabaseAdapter {
@@ -35,6 +42,18 @@ export interface DatabaseAdapter {
   createApplication(userId: string, data: CreateApplicationInput): Promise<ApplicationRecord>;
   updateApplication(id: string, userId: string, data: UpdateApplicationInput): Promise<ApplicationRecord>;
   deleteApplication(id: string, userId: string): Promise<void>;
+  /** Find an exact canonical URL match owned by the user. */
+  findApplicationByCanonicalJobUrl(userId: string, canonicalJobUrl: string): Promise<ApplicationRecord | null>;
+  /** Append notes without a caller-side read/replace race and record an event. */
+  appendApplicationNote(id: string, userId: string, note: string, event: CreateApplicationEventInput): Promise<{ application: ApplicationRecord; event: ApplicationEventRecord }>;
+
+  // ── Submissions & timeline ───────────────────────────────────────────────
+  recordApplicationSubmission(userId: string, input: RecordSubmissionInput): Promise<RecordSubmissionResult>;
+  listApplicationSubmissions(applicationId: string, userId: string, includeAnswers?: boolean): Promise<ApplicationSubmissionRecord[]>;
+  listUserSubmissions(userId: string): Promise<ApplicationSubmissionRecord[]>;
+  getApplicationSubmission(id: string, userId: string): Promise<ApplicationSubmissionRecord | null>;
+  createApplicationEvent(applicationId: string, userId: string, input: CreateApplicationEventInput): Promise<ApplicationEventRecord>;
+  listApplicationEvents(applicationId: string, userId: string, limit?: number): Promise<ApplicationEventRecord[]>;
 
   /** List applications with optional filters and field selection. */
   listApplicationsFiltered(userId: string | null, filter: ListApplicationsFilter): Promise<Partial<ApplicationRecord>[]>;
@@ -46,16 +65,18 @@ export interface DatabaseAdapter {
   // ── Contacts ─────────────────────────────────────────────────────────────
   /** Verify an application exists and belongs to userId. */
   verifyApplicationOwner(id: string, userId: string): Promise<boolean>;
-  createContact(applicationId: string, data: CreateContactInput): Promise<ContactRecord>;
+  createContact(applicationId: string, userId: string, data: CreateContactInput): Promise<ContactRecord>;
   updateContact(id: string, applicationId: string, userId: string, data: UpdateContactInput): Promise<ContactRecord>;
   deleteContact(id: string, applicationId: string, userId: string): Promise<void>;
 
   // ── Documents ────────────────────────────────────────────────────────────
   listDocuments(userId: string | null): Promise<DocumentRecord[]>;
+  listDocumentsFiltered(userId: string | null, filter: ListDocumentsFilter): Promise<Partial<DocumentRecord>[]>;
   /** List documents linked to a specific application. */
   listDocumentsByApplication(applicationId: string, userId: string): Promise<DocumentRecord[]>;
   getDocument(id: string, userId: string | null): Promise<DocumentRecord | null>;
   createDocument(userId: string, data: CreateDocumentInput): Promise<DocumentRecord>;
+  updateDocumentMetadata(id: string, userId: string, data: UpdateDocumentMetadataInput): Promise<DocumentRecord>;
   /** Replace the set of linked application IDs on a document. */
   updateDocumentLinks(id: string, userId: string, applicationIds: string[]): Promise<DocumentRecord>;
   /** Rename the user-facing original name of a document. */

--- a/lib/db/firestore-adapter.ts
+++ b/lib/db/firestore-adapter.ts
@@ -451,10 +451,11 @@ export class FirestoreAdapter implements DatabaseAdapter {
         type: "update" as const,
         ref: document.ref,
         data: {
-          applicationIds: ((data.applicationIds as string[] | undefined) ?? [])
-            .filter((applicationId) => applicationId !== id),
-          submissionId: belongsToDeletedSubmission ? null : submissionId,
-          state: belongsToDeletedSubmission ? "historical" : (data.state ?? "current"),
+          applicationIds: FieldValue.arrayRemove(id),
+          ...(belongsToDeletedSubmission && {
+            submissionId: null,
+            state: "historical",
+          }),
         },
       };
     });

--- a/lib/db/firestore-adapter.ts
+++ b/lib/db/firestore-adapter.ts
@@ -606,7 +606,11 @@ export class FirestoreAdapter implements DatabaseAdapter {
       for (const documentId of uniqueDocumentIds) {
         const snapshot = await transaction.get(this.docs.doc(documentId));
         if (!snapshot.exists || snapshot.data()!.userId !== userId) throw new Error("invalid_documents");
-        if (snapshot.data()!.submissionId) throw new Error("document_already_submitted");
+        if (
+          snapshot.data()!.submissionId
+          || snapshot.data()!.state === "submitted"
+          || snapshot.data()!.state === "historical"
+        ) throw new Error("document_already_submitted");
         documentSnapshots.push(snapshot);
       }
 
@@ -1192,7 +1196,9 @@ export class FirestoreAdapter implements DatabaseAdapter {
       const stateOnly = keys.every((key) => key === "state");
       const immutable = submissionId || existing.data()!.state === "submitted" || existing.data()!.state === "historical";
       if (immutable) {
-        if (!stateOnly || (data.state !== "submitted" && data.state !== "historical")) {
+        const allowedState = data.state === existing.data()!.state
+          || (existing.data()!.state === "submitted" && data.state === "historical");
+        if (!stateOnly || !allowedState) {
           throw new Error("submitted_document_immutable");
         }
       } else if (data.state === "submitted") {

--- a/lib/db/firestore-adapter.ts
+++ b/lib/db/firestore-adapter.ts
@@ -2,8 +2,8 @@ import { getFirestore, Timestamp, FieldValue } from "firebase-admin/firestore";
 import { getApps, initializeApp, applicationDefault } from "firebase-admin/app";
 import { prisma } from "@/lib/prisma";
 import { normalizeStatus } from "@/types";
-import { sanitizeTriageFields } from "./sanitize";
-import { resolveCreatedAtForCreate } from "@/lib/applications/defaults";
+import { resolveAppliedAtForCreate } from "@/lib/applications/defaults";
+import { submissionRequestHash } from "@/lib/applications/submission";
 import type { DatabaseAdapter } from "./adapter";
 import type {
   ApplicationRecord,
@@ -30,6 +30,13 @@ import type {
   UpsertCvProfileInput,
   CvPatchRecord,
   UpsertCvPatchInput,
+  ApplicationSubmissionRecord,
+  ApplicationEventRecord,
+  RecordSubmissionInput,
+  RecordSubmissionResult,
+  CreateApplicationEventInput,
+  ListDocumentsFilter,
+  UpdateDocumentMetadataInput,
 } from "./types";
 
 // ── Firestore init ──────────────────────────────────────────────────────────
@@ -69,6 +76,7 @@ function mapApp(id: string, data: FirebaseFirestore.DocumentData): ApplicationRe
     salaryMax: data.salaryMax ?? null,
     rating: data.rating ?? null,
     jobUrl: data.jobUrl ?? null,
+    canonicalJobUrl: data.canonicalJobUrl ?? null,
     resumeId: data.resumeId ?? null,
     companySize: data.companySize ?? null,
     salaryBandMentioned: data.salaryBandMentioned ?? false,
@@ -78,9 +86,30 @@ function mapApp(id: string, data: FirebaseFirestore.DocumentData): ApplicationRe
     autoRejected: data.autoRejected ?? false,
     autoRejectReason: data.autoRejectReason ?? null,
     archivedAt: toDate(data.archivedAt) ?? null,
+    workMode: data.workMode ?? null,
+    eligibleCountries: Array.isArray(data.eligibleCountries) ? data.eligibleCountries : [],
+    primaryLocations: Array.isArray(data.primaryLocations) ? data.primaryLocations : [],
+    officeDaysMin: data.officeDaysMin ?? null,
+    travelPercent: data.travelPercent ?? null,
+    visaSponsorship: data.visaSponsorship ?? null,
+    rightToWorkRequired: data.rightToWorkRequired ?? null,
+    timezoneOverlap: data.timezoneOverlap ?? null,
+    salaryCurrency: data.salaryCurrency ?? null,
+    salaryPeriod: data.salaryPeriod ?? null,
+    salaryType: data.salaryType ?? null,
+    atsName: data.atsName ?? null,
+    requisitionId: data.requisitionId ?? null,
+    jobCapturedAt: toDate(data.jobCapturedAt),
+    jobVerifiedAt: toDate(data.jobVerifiedAt),
+    jobPostedAt: toDate(data.jobPostedAt),
+    jobClosedAt: toDate(data.jobClosedAt),
+    jobContentHash: data.jobContentHash ?? null,
+    jobLiveness: data.jobLiveness ?? null,
+    jobSummary: data.jobSummary ?? null,
+    currentStage: data.currentStage ?? null,
     createdAt: toDate(data.createdAt) ?? new Date(),
     updatedAt: toDate(data.updatedAt) ?? new Date(),
-    contacts: data._contacts, // populated separately when needed
+    contacts: data._contacts,
   };
 }
 
@@ -105,9 +134,85 @@ function mapDoc(id: string, data: FirebaseFirestore.DocumentData): DocumentRecor
     originalName: data.originalName,
     size: data.size,
     mimeType: data.mimeType,
+    documentType: data.documentType ?? "other",
+    state: data.state ?? "current",
+    version: data.version ?? 1,
+    contentHash: data.contentHash ?? null,
+    source: data.source ?? null,
+    generatedAt: toDate(data.generatedAt),
+    submittedAt: toDate(data.submittedAt),
+    submissionId: data.submissionId ?? null,
     uploadedAt: toDate(data.uploadedAt) ?? new Date(),
-    applications: data._applications, // populated separately when needed
+    applications: data._applications,
   };
+}
+
+function mapSubmission(
+  id: string,
+  data: FirebaseFirestore.DocumentData,
+  includeAnswers = true,
+): ApplicationSubmissionRecord {
+  return {
+    id,
+    userId: data.userId,
+    applicationId: data.applicationId,
+    idempotencyKey: data.idempotencyKey,
+    requestHash: data.requestHash,
+    submittedAt: toDate(data.submittedAt) ?? new Date(),
+    applicationUrl: data.applicationUrl ?? null,
+    atsName: data.atsName ?? null,
+    requisitionId: data.requisitionId ?? null,
+    language: data.language ?? null,
+    answers: includeAnswers && Array.isArray(data.answers) ? data.answers : [],
+    candidateSalaryMin: data.candidateSalaryMin ?? null,
+    candidateSalaryMax: data.candidateSalaryMax ?? null,
+    candidateSalaryCurrency: data.candidateSalaryCurrency ?? null,
+    candidateSalaryPeriod: data.candidateSalaryPeriod ?? null,
+    candidateSalaryType: data.candidateSalaryType ?? null,
+    candidateSalaryFlexible: data.candidateSalaryFlexible ?? false,
+    documentIds: Array.isArray(data.documentIds) ? data.documentIds : [],
+    createdAt: toDate(data.createdAt) ?? new Date(),
+    documents: data._documents,
+  };
+}
+
+function mapEvent(id: string, data: FirebaseFirestore.DocumentData): ApplicationEventRecord {
+  return {
+    id,
+    userId: data.userId,
+    applicationId: data.applicationId,
+    type: data.type,
+    idempotencyKey: data.idempotencyKey ?? null,
+    occurredAt: toDate(data.occurredAt) ?? new Date(),
+    source: data.source ?? null,
+    actor: data.actor ?? null,
+    metadata: data.metadata ?? null,
+    createdAt: toDate(data.createdAt) ?? new Date(),
+  };
+}
+
+const STRUCTURED_METADATA_FIELDS = [
+  "canonicalJobUrl", "workMode", "eligibleCountries", "primaryLocations",
+  "officeDaysMin", "travelPercent", "visaSponsorship", "rightToWorkRequired",
+  "timezoneOverlap", "salaryCurrency", "salaryPeriod", "salaryType", "atsName",
+  "requisitionId", "jobContentHash", "jobLiveness", "jobSummary", "currentStage",
+] as const;
+
+const STRUCTURED_DATE_FIELDS = [
+  "jobCapturedAt", "jobVerifiedAt", "jobPostedAt", "jobClosedAt",
+] as const;
+
+function structuredMetadataForFirestore(data: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const field of STRUCTURED_METADATA_FIELDS) {
+    if (data[field] !== undefined) result[field] = data[field];
+  }
+  for (const field of STRUCTURED_DATE_FIELDS) {
+    if (data[field] !== undefined) {
+      result[field] = toTimestamp(data[field] as Date | null | undefined);
+    }
+  }
+  return result;
 }
 
 // ── Implementation ──────────────────────────────────────────────────────────
@@ -117,6 +222,13 @@ export class FirestoreAdapter implements DatabaseAdapter {
   private get apps() { return this.db.collection("applications"); }
   private get contacts() { return this.db.collection("contacts"); }
   private get docs() { return this.db.collection("documents"); }
+  private get submissions() { return this.db.collection("applicationSubmissions"); }
+  private get events() { return this.db.collection("applicationEvents"); }
+  private get canonicalUrls() { return this.db.collection("applicationCanonicalUrls"); }
+
+  private canonicalUrlRef(userId: string, canonicalJobUrl: string) {
+    return this.canonicalUrls.doc(submissionRequestHash({ userId, canonicalJobUrl }));
+  }
 
   // ── Applications ────────────────────────────────────────────────────────
 
@@ -183,21 +295,24 @@ export class FirestoreAdapter implements DatabaseAdapter {
 
   async createApplication(userId: string, data: CreateApplicationInput): Promise<ApplicationRecord> {
     const now = Timestamp.now();
-    const ref = await this.apps.add({
+    const reference = this.apps.doc();
+    const payload = {
       userId,
       company: data.company,
       role: data.role,
       status: normalizeStatus(data.status),
-      appliedAt: toTimestamp(resolveCreatedAtForCreate(data.appliedAt)),
+      appliedAt: toTimestamp(resolveAppliedAtForCreate(data.status, data.appliedAt)),
       lastContact: toTimestamp(data.lastContact),
       followUpAt: toTimestamp(data.followUpAt),
       notes: data.notes,
       jobDescription: data.jobDescription,
+      source: data.source,
       remote: data.remote ?? false,
       salaryMin: data.salaryMin ?? null,
       salaryMax: data.salaryMax ?? null,
       rating: data.rating ?? null,
       jobUrl: data.jobUrl ?? null,
+      resumeId: data.resumeId ?? null,
       companySize: data.companySize ?? null,
       salaryBandMentioned: data.salaryBandMentioned ?? false,
       triageQuality: data.triageQuality ?? null,
@@ -205,22 +320,31 @@ export class FirestoreAdapter implements DatabaseAdapter {
       incomingSource: data.incomingSource ?? null,
       autoRejected: data.autoRejected ?? false,
       autoRejectReason: data.autoRejectReason ?? null,
+      ...structuredMetadataForFirestore(data as unknown as Record<string, unknown>),
       createdAt: now,
       updatedAt: now,
+    };
+    await this.db.runTransaction(async (transaction) => {
+      if (data.canonicalJobUrl) {
+        const indexReference = this.canonicalUrlRef(userId, data.canonicalJobUrl);
+        const duplicate = await transaction.get(indexReference);
+        if (duplicate.exists) throw new Error("canonical_job_url_conflict");
+        transaction.create(indexReference, {
+          userId,
+          canonicalJobUrl: data.canonicalJobUrl,
+          applicationId: reference.id,
+          createdAt: now,
+        });
+      }
+      transaction.create(reference, payload);
     });
-    const snap = await ref.get();
-    const app = mapApp(ref.id, snap.data()!);
+    const app = mapApp(reference.id, payload);
     app.contacts = [];
     return app;
   }
 
   async updateApplication(id: string, userId: string, data: UpdateApplicationInput): Promise<ApplicationRecord> {
     const ref = this.apps.doc(id);
-    const existing = await ref.get();
-    if (!existing.exists || existing.data()!.userId !== userId) {
-      throw new Error("Not found");
-    }
-
     const update: Record<string, unknown> = { updatedAt: FieldValue.serverTimestamp() };
     if (data.company !== undefined) update.company = data.company;
     if (data.role !== undefined) update.role = data.role;
@@ -230,11 +354,13 @@ export class FirestoreAdapter implements DatabaseAdapter {
     if (data.followUpAt !== undefined) update.followUpAt = toTimestamp(data.followUpAt);
     if (data.notes !== undefined) update.notes = data.notes;
     if (data.jobDescription !== undefined) update.jobDescription = data.jobDescription;
+    if (data.source !== undefined) update.source = data.source;
     if (data.remote !== undefined) update.remote = data.remote;
     if (data.salaryMin !== undefined) update.salaryMin = data.salaryMin;
     if (data.salaryMax !== undefined) update.salaryMax = data.salaryMax;
     if (data.rating !== undefined) update.rating = data.rating;
     if (data.jobUrl !== undefined) update.jobUrl = data.jobUrl;
+    if (data.resumeId !== undefined) update.resumeId = data.resumeId;
     if (data.companySize !== undefined) update.companySize = data.companySize;
     if (data.salaryBandMentioned !== undefined) update.salaryBandMentioned = data.salaryBandMentioned;
     if (data.triageQuality !== undefined) update.triageQuality = data.triageQuality;
@@ -242,23 +368,475 @@ export class FirestoreAdapter implements DatabaseAdapter {
     if (data.incomingSource !== undefined) update.incomingSource = data.incomingSource;
     if (data.autoRejected !== undefined) update.autoRejected = data.autoRejected;
     if (data.autoRejectReason !== undefined) update.autoRejectReason = data.autoRejectReason;
+    if (data.archivedAt !== undefined) update.archivedAt = toTimestamp(data.archivedAt);
+    Object.assign(update, structuredMetadataForFirestore(data as unknown as Record<string, unknown>));
 
-    await ref.update(update);
+    await this.db.runTransaction(async (transaction) => {
+      const existing = await transaction.get(ref);
+      if (!existing.exists || existing.data()!.userId !== userId) throw new Error("not_found");
+      if (existing.data()!.deletionState === "in_progress") throw new Error("application_deleting");
+      const currentCanonicalJobUrl = existing.data()!.canonicalJobUrl as string | null | undefined;
+      let nextCanonicalIndex: FirebaseFirestore.DocumentReference | null = null;
+      let nextCanonicalIndexExists = false;
+      if (data.canonicalJobUrl) {
+        nextCanonicalIndex = this.canonicalUrlRef(userId, data.canonicalJobUrl);
+        const duplicate = await transaction.get(nextCanonicalIndex);
+        if (duplicate.exists && duplicate.data()!.applicationId !== id) {
+          throw new Error("canonical_job_url_conflict");
+        }
+        nextCanonicalIndexExists = duplicate.exists;
+      }
+      if (data.expectedUpdatedAt) {
+        const currentUpdatedAt = toDate(existing.data()!.updatedAt);
+        if (!currentUpdatedAt || currentUpdatedAt.getTime() !== data.expectedUpdatedAt.getTime()) {
+          throw new Error("conflict");
+        }
+      }
+      if (data.canonicalJobUrl !== undefined) {
+        if (currentCanonicalJobUrl && currentCanonicalJobUrl !== data.canonicalJobUrl) {
+          transaction.delete(this.canonicalUrlRef(userId, currentCanonicalJobUrl));
+        }
+        if (nextCanonicalIndex && !nextCanonicalIndexExists) {
+          transaction.set(nextCanonicalIndex, {
+            userId,
+            canonicalJobUrl: data.canonicalJobUrl,
+            applicationId: id,
+            createdAt: Timestamp.now(),
+          });
+        }
+      }
+      transaction.update(ref, update);
+    });
     return (await this.getApplication(id, userId))!;
   }
 
-  async deleteApplication(id: string, userId: string): Promise<void> {
+  private async deleteApplicationCascade(id: string, userId: string): Promise<void> {
     const ref = this.apps.doc(id);
-    const existing = await ref.get();
-    if (!existing.exists || existing.data()!.userId !== userId) {
-      throw new Error("Not found");
+    await this.db.runTransaction(async (transaction) => {
+      const existing = await transaction.get(ref);
+      if (!existing.exists || existing.data()!.userId !== userId) throw new Error("not_found");
+      transaction.update(ref, {
+        deletionState: "in_progress",
+        deletionStartedAt: FieldValue.serverTimestamp(),
+      });
+    });
+
+    const [contactSnap, submissionSnap, eventSnap, linkedDocumentSnap] = await Promise.all([
+      this.contacts.where("applicationId", "==", id).get(),
+      this.submissions.where("applicationId", "==", id).where("userId", "==", userId).get(),
+      this.events.where("applicationId", "==", id).where("userId", "==", userId).get(),
+      this.docs.where("userId", "==", userId).where("applicationIds", "array-contains", id).get(),
+    ]);
+    const submissionIds = submissionSnap.docs.map((document) => document.id);
+    const deletedSubmissionIds = new Set(submissionIds);
+    const documents = new Map<string, FirebaseFirestore.QueryDocumentSnapshot>();
+    linkedDocumentSnap.docs.forEach((document) => documents.set(document.id, document));
+    for (let offset = 0; offset < submissionIds.length; offset += 30) {
+      const snapshot = await this.docs
+        .where("userId", "==", userId)
+        .where("submissionId", "in", submissionIds.slice(offset, offset + 30))
+        .get();
+      snapshot.docs.forEach((document) => documents.set(document.id, document));
     }
-    // Cascade: delete contacts
-    const contactSnap = await this.contacts.where("applicationId", "==", id).get();
-    const batch = this.db.batch();
-    contactSnap.docs.forEach((d) => batch.delete(d.ref));
-    batch.delete(ref);
-    await batch.commit();
+
+    const operations: Array<
+      | { type: "delete"; ref: FirebaseFirestore.DocumentReference }
+      | { type: "update"; ref: FirebaseFirestore.DocumentReference; data: Record<string, unknown> }
+    > = [
+      ...contactSnap.docs.map((document) => ({ type: "delete" as const, ref: document.ref })),
+      ...submissionSnap.docs.map((document) => ({ type: "delete" as const, ref: document.ref })),
+      ...eventSnap.docs.map((document) => ({ type: "delete" as const, ref: document.ref })),
+      ...Array.from(documents.values()).map((document) => {
+        const data = document.data();
+        const submissionId = typeof data.submissionId === "string" ? data.submissionId : null;
+        const belongsToDeletedSubmission = submissionId !== null && deletedSubmissionIds.has(submissionId);
+        return {
+          type: "update" as const,
+          ref: document.ref,
+          data: {
+            applicationIds: ((data.applicationIds as string[] | undefined) ?? [])
+              .filter((applicationId) => applicationId !== id),
+            submissionId: belongsToDeletedSubmission ? null : submissionId,
+            state: belongsToDeletedSubmission ? "historical" : (data.state ?? "current"),
+          },
+        };
+      }),
+    ];
+    for (let offset = 0; offset < operations.length; offset += 450) {
+      const batch = this.db.batch();
+      for (const operation of operations.slice(offset, offset + 450)) {
+        if (operation.type === "delete") batch.delete(operation.ref);
+        else batch.update(operation.ref, operation.data);
+      }
+      await batch.commit();
+    }
+    await this.db.runTransaction(async (transaction) => {
+      const current = await transaction.get(ref);
+      if (!current.exists) return;
+      if (current.data()!.userId !== userId || current.data()!.deletionState !== "in_progress") {
+        throw new Error("application_delete_conflict");
+      }
+      const canonicalJobUrl = current.data()!.canonicalJobUrl as string | null | undefined;
+      if (canonicalJobUrl) transaction.delete(this.canonicalUrlRef(userId, canonicalJobUrl));
+      transaction.delete(ref);
+    });
+  }
+
+  async deleteApplication(id: string, userId: string): Promise<void> {
+    await this.deleteApplicationCascade(id, userId);
+  }
+
+  async findApplicationByCanonicalJobUrl(
+    userId: string,
+    canonicalJobUrl: string,
+  ): Promise<ApplicationRecord | null> {
+    const snapshot = await this.apps
+      .where("userId", "==", userId)
+      .where("canonicalJobUrl", "==", canonicalJobUrl)
+      .limit(1)
+      .get();
+    if (snapshot.empty) return null;
+    const document = snapshot.docs[0];
+    return mapApp(document.id, document.data());
+  }
+
+  async appendApplicationNote(
+    id: string,
+    userId: string,
+    note: string,
+    eventInput: CreateApplicationEventInput,
+  ): Promise<{ application: ApplicationRecord; event: ApplicationEventRecord }> {
+    const requestHash = submissionRequestHash({ applicationId: id, note, type: eventInput.type });
+    const eventId = submissionRequestHash({
+      userId,
+      key: eventInput.idempotencyKey ?? requestHash,
+    }).slice(0, 40);
+    const result = await this.db.runTransaction(async (transaction) => {
+      const appRef = this.apps.doc(id);
+      const eventRef = this.events.doc(eventId);
+      const [appSnapshot, eventSnapshot] = await Promise.all([
+        transaction.get(appRef),
+        transaction.get(eventRef),
+      ]);
+      if (!appSnapshot.exists || appSnapshot.data()!.userId !== userId) throw new Error("not_found");
+      if (appSnapshot.data()!.deletionState === "in_progress") throw new Error("application_deleting");
+      if (eventSnapshot.exists) {
+        if (eventSnapshot.data()!.requestHash !== requestHash) throw new Error("idempotency_conflict");
+        return { appData: appSnapshot.data()!, eventData: eventSnapshot.data()! };
+      }
+      if (eventInput.expectedUpdatedAt) {
+        const currentUpdatedAt = toDate(appSnapshot.data()!.updatedAt);
+        if (!currentUpdatedAt || currentUpdatedAt.getTime() !== eventInput.expectedUpdatedAt.getTime()) {
+          throw new Error("conflict");
+        }
+      }
+      const existingNotes = appSnapshot.data()!.notes as string | null | undefined;
+      const notes = existingNotes ? `${existingNotes}\n\n${note}` : note;
+      if (notes.length > 50_000) throw new Error("notes_too_large");
+      const now = Timestamp.now();
+      const eventData = {
+        userId,
+        applicationId: id,
+        type: eventInput.type,
+        idempotencyKey: eventInput.idempotencyKey ?? null,
+        requestHash,
+        occurredAt: toTimestamp(eventInput.occurredAt),
+        source: eventInput.source ?? null,
+        actor: eventInput.actor ?? null,
+        metadata: {
+          ...(eventInput.metadata ?? {}),
+          requestHash,
+        },
+        createdAt: now,
+      };
+      transaction.update(appRef, { notes, updatedAt: now });
+      transaction.create(eventRef, eventData);
+      return { appData: { ...appSnapshot.data()!, notes, updatedAt: now }, eventData };
+    });
+    return {
+      application: mapApp(id, result.appData),
+      event: mapEvent(eventId, result.eventData),
+    };
+  }
+
+  async recordApplicationSubmission(
+    userId: string,
+    input: RecordSubmissionInput,
+  ): Promise<RecordSubmissionResult> {
+    const hashable: Record<string, unknown> = { ...input };
+    delete hashable.idempotencyKey;
+    delete hashable.dryRun;
+    delete hashable.expectedUpdatedAt;
+    delete hashable.source;
+    delete hashable.actor;
+    const requestHash = submissionRequestHash(hashable);
+    const submissionId = submissionRequestHash({ userId, key: input.idempotencyKey }).slice(0, 40);
+    const eventId = `submission-${submissionId}`;
+
+    const outcome = await this.db.runTransaction(async (transaction) => {
+      const submissionRef = this.submissions.doc(submissionId);
+      const existingSubmission = await transaction.get(submissionRef);
+      if (existingSubmission.exists) {
+        const existingData = existingSubmission.data()!;
+        if (existingData.userId !== userId || existingData.requestHash !== requestHash) {
+          throw new Error("idempotency_conflict");
+        }
+        return { replayed: true, dryRun: false };
+      }
+
+      const appRef = this.apps.doc(input.applicationId);
+      const appSnapshot = await transaction.get(appRef);
+      if (!appSnapshot.exists || appSnapshot.data()!.userId !== userId) throw new Error("not_found");
+      const appData = appSnapshot.data()!;
+      if (appData.deletionState === "in_progress") throw new Error("application_deleting");
+      if (input.expectedUpdatedAt) {
+        const updatedAt = toDate(appData.updatedAt);
+        if (!updatedAt || updatedAt.getTime() !== input.expectedUpdatedAt.getTime()) {
+          throw new Error("conflict");
+        }
+      }
+
+      const uniqueDocumentIds = Array.from(new Set(input.documentIds));
+      const documentSnapshots: FirebaseFirestore.DocumentSnapshot[] = [];
+      for (const documentId of uniqueDocumentIds) {
+        const snapshot = await transaction.get(this.docs.doc(documentId));
+        if (!snapshot.exists || snapshot.data()!.userId !== userId) throw new Error("invalid_documents");
+        if (snapshot.data()!.submissionId) throw new Error("document_already_submitted");
+        documentSnapshots.push(snapshot);
+      }
+
+      const now = Timestamp.now();
+      const submissionData = {
+        userId,
+        applicationId: input.applicationId,
+        idempotencyKey: input.idempotencyKey,
+        requestHash,
+        submittedAt: toTimestamp(input.submittedAt),
+        applicationUrl: input.applicationUrl ?? null,
+        atsName: input.atsName ?? null,
+        requisitionId: input.requisitionId ?? null,
+        language: input.language ?? null,
+        answers: input.answers,
+        candidateSalaryMin: input.candidateSalaryMin ?? null,
+        candidateSalaryMax: input.candidateSalaryMax ?? null,
+        candidateSalaryCurrency: input.candidateSalaryCurrency ?? null,
+        candidateSalaryPeriod: input.candidateSalaryPeriod ?? null,
+        candidateSalaryType: input.candidateSalaryType ?? null,
+        candidateSalaryFlexible: input.candidateSalaryFlexible ?? false,
+        documentIds: uniqueDocumentIds,
+        createdAt: now,
+      };
+      if (input.dryRun) {
+        return { replayed: false, dryRun: true, appData, submissionData, documentSnapshots };
+      }
+
+      const eventData = {
+        userId,
+        applicationId: input.applicationId,
+        type: "application_submitted",
+        occurredAt: toTimestamp(input.submittedAt),
+        source: input.source ?? "mcp",
+        actor: input.actor ?? null,
+        metadata: {
+          submissionId,
+          documentIds: uniqueDocumentIds,
+          answerCount: input.answers.length,
+        },
+        createdAt: now,
+      };
+      transaction.create(submissionRef, submissionData);
+      transaction.create(this.events.doc(eventId), eventData);
+      transaction.update(appRef, {
+        status: "applied",
+        appliedAt: toTimestamp(input.submittedAt),
+        ...(input.followUpAt !== undefined ? { followUpAt: toTimestamp(input.followUpAt) } : {}),
+        ...(input.atsName !== undefined ? { atsName: input.atsName } : {}),
+        ...(input.requisitionId !== undefined ? { requisitionId: input.requisitionId } : {}),
+        updatedAt: now,
+      });
+      documentSnapshots.forEach((snapshot) =>
+        transaction.update(snapshot.ref, {
+          state: "submitted",
+          submittedAt: toTimestamp(input.submittedAt),
+          submissionId,
+        }),
+      );
+      return { replayed: false, dryRun: false };
+    });
+
+    if (outcome.dryRun && outcome.appData && outcome.submissionData && outcome.documentSnapshots) {
+      const documents = outcome.documentSnapshots.map((snapshot) =>
+        mapDoc(snapshot.id, {
+          ...snapshot.data()!,
+          state: "submitted",
+          submittedAt: toTimestamp(input.submittedAt),
+          submissionId,
+        }),
+      );
+      const application = mapApp(input.applicationId, {
+        ...outcome.appData,
+        status: "applied",
+        appliedAt: toTimestamp(input.submittedAt),
+        ...(input.followUpAt !== undefined ? { followUpAt: toTimestamp(input.followUpAt) } : {}),
+      });
+      return {
+        replayed: false,
+        dryRun: true,
+        verified: true,
+        application,
+        submission: { ...mapSubmission("dry-run", outcome.submissionData), documents },
+        event: null,
+        documents,
+      };
+    }
+
+    const [application, submission, event] = await Promise.all([
+      this.getApplication(input.applicationId, userId),
+      this.getApplicationSubmission(submissionId, userId),
+      this.events.doc(eventId).get(),
+    ]);
+    if (!application || !submission) throw new Error("verification_failed");
+    const documents = await Promise.all(
+      submission.documentIds.map(async (documentId) => {
+        const document = await this.getDocument(documentId, userId);
+        if (!document) throw new Error("verification_failed");
+        return document;
+      }),
+    );
+    submission.documents = documents;
+    return {
+      replayed: outcome.replayed,
+      dryRun: false,
+      verified:
+        application.status === "applied" &&
+        application.appliedAt?.getTime() === input.submittedAt.getTime() &&
+        documents.length === submission.documentIds.length,
+      application,
+      submission,
+      event: event.exists ? mapEvent(event.id, event.data()!) : null,
+      documents,
+    };
+  }
+
+  private async resolveSubmissionDocuments(
+    submission: ApplicationSubmissionRecord,
+    userId: string,
+  ): Promise<ApplicationSubmissionRecord> {
+    const documents = await Promise.all(
+      submission.documentIds.map(async (documentId) => {
+        const document = await this.getDocument(documentId, userId);
+        if (!document || document.submissionId !== submission.id) {
+          throw new Error("verification_failed");
+        }
+        return document;
+      }),
+    );
+    return { ...submission, documents };
+  }
+
+  async listApplicationSubmissions(
+    applicationId: string,
+    userId: string,
+    includeAnswers = false,
+  ): Promise<ApplicationSubmissionRecord[]> {
+    const application = await this.getApplication(applicationId, userId);
+    if (!application) throw new Error("not_found");
+    const snapshot = await this.submissions
+      .where("applicationId", "==", applicationId)
+      .where("userId", "==", userId)
+      .orderBy("submittedAt", "desc")
+      .get();
+    return Promise.all(
+      snapshot.docs.map((document) =>
+        this.resolveSubmissionDocuments(
+          mapSubmission(document.id, document.data(), includeAnswers),
+          userId,
+        ),
+      ),
+    );
+  }
+
+  async listUserSubmissions(userId: string): Promise<ApplicationSubmissionRecord[]> {
+    const snapshot = await this.submissions
+      .where("userId", "==", userId)
+      .orderBy("submittedAt", "desc")
+      .get();
+    return snapshot.docs.map((document) => mapSubmission(document.id, document.data()));
+  }
+
+  async getApplicationSubmission(
+    id: string,
+    userId: string,
+  ): Promise<ApplicationSubmissionRecord | null> {
+    const snapshot = await this.submissions.doc(id).get();
+    if (!snapshot.exists || snapshot.data()!.userId !== userId) return null;
+    const submission = mapSubmission(id, snapshot.data()!);
+    const application = await this.getApplication(submission.applicationId, userId);
+    if (!application) return null;
+    return this.resolveSubmissionDocuments(submission, userId);
+  }
+
+  async createApplicationEvent(
+    applicationId: string,
+    userId: string,
+    input: CreateApplicationEventInput,
+  ): Promise<ApplicationEventRecord> {
+    const requestHash = submissionRequestHash({
+      applicationId,
+      type: input.type,
+      occurredAt: input.occurredAt,
+      metadata: input.metadata ?? {},
+    });
+    const eventId = input.idempotencyKey
+      ? submissionRequestHash({ userId, key: input.idempotencyKey }).slice(0, 40)
+      : this.events.doc().id;
+    const eventRef = this.events.doc(eventId);
+    const eventData = await this.db.runTransaction(async (transaction) => {
+      const appRef = this.apps.doc(applicationId);
+      const [application, existing] = await Promise.all([
+        transaction.get(appRef),
+        transaction.get(eventRef),
+      ]);
+      if (!application.exists || application.data()!.userId !== userId) throw new Error("not_found");
+      if (application.data()!.deletionState === "in_progress") throw new Error("application_deleting");
+      if (existing.exists) {
+        if (!input.idempotencyKey || existing.data()!.userId !== userId || existing.data()!.requestHash !== requestHash) {
+          throw new Error("idempotency_conflict");
+        }
+        return existing.data()!;
+      }
+      const data = {
+        userId,
+        applicationId,
+        type: input.type,
+        idempotencyKey: input.idempotencyKey ?? null,
+        requestHash,
+        occurredAt: toTimestamp(input.occurredAt),
+        source: input.source ?? null,
+        actor: input.actor ?? null,
+        metadata: input.metadata ?? {},
+        createdAt: Timestamp.now(),
+      };
+      transaction.create(eventRef, data);
+      return data;
+    });
+    return mapEvent(eventId, eventData);
+  }
+
+  async listApplicationEvents(
+    applicationId: string,
+    userId: string,
+    limit = 100,
+  ): Promise<ApplicationEventRecord[]> {
+    const application = await this.getApplication(applicationId, userId);
+    if (!application) throw new Error("not_found");
+    const snapshot = await this.events
+      .where("applicationId", "==", applicationId)
+      .where("userId", "==", userId)
+      .orderBy("occurredAt", "desc")
+      .limit(Math.max(1, Math.min(500, limit)))
+      .get();
+    return snapshot.docs.map((document) => mapEvent(document.id, document.data()));
   }
 
   async listApplicationsFiltered(
@@ -366,33 +944,14 @@ export class FirestoreAdapter implements DatabaseAdapter {
       const item = items[i];
       try {
         if (item.id) {
-          // Update
-          const ref = this.apps.doc(item.id);
-          const existing = await ref.get();
-          if (!existing.exists || existing.data()!.userId !== userId) {
-            results.push({ index: i, id: item.id, operation: "updated", error: "Not found or access denied" });
-            failed++;
-            continue;
-          }
-          const update: Record<string, unknown> = { updatedAt: FieldValue.serverTimestamp() };
-          if (item.company !== undefined) update.company = item.company;
-          if (item.role !== undefined) update.role = item.role;
-          if (item.status !== undefined) update.status = normalizeStatus(item.status);
-          if (item.appliedAt !== undefined) update.appliedAt = toTimestamp(item.appliedAt);
-          if (item.lastContact !== undefined) update.lastContact = toTimestamp(item.lastContact);
-          if (item.followUpAt !== undefined) update.followUpAt = toTimestamp(item.followUpAt);
-          if (item.notes !== undefined) update.notes = item.notes;
-          if (item.jobDescription !== undefined) update.jobDescription = item.jobDescription;
-          if (item.source !== undefined) update.source = item.source;
-          if (item.remote !== undefined) update.remote = item.remote;
-          if (item.salaryMin !== undefined) update.salaryMin = item.salaryMin;
-          if (item.salaryMax !== undefined) update.salaryMax = item.salaryMax;
-          if (item.rating !== undefined) update.rating = item.rating;
-          if (item.jobUrl !== undefined) update.jobUrl = item.jobUrl;
-          Object.assign(update, sanitizeTriageFields(item as Record<string, unknown>));
-
-          await ref.update(update);
-          results.push({ index: i, id: item.id, operation: "updated" });
+          const update = { ...item } as BatchUpsertItem & { id?: string };
+          delete update.id;
+          const application = await this.updateApplication(
+            item.id,
+            userId,
+            update as UpdateApplicationInput,
+          );
+          results.push({ index: i, id: application.id, operation: "updated" });
           succeeded++;
         } else {
           // Create
@@ -401,15 +960,14 @@ export class FirestoreAdapter implements DatabaseAdapter {
             failed++;
             continue;
           }
-          const now = Timestamp.now();
-          const ref = await this.apps.add({
-            userId,
+          const createData = {
+            ...item,
             company: item.company,
             role: item.role,
-            status: normalizeStatus(item.status || "applied"),
-            appliedAt: toTimestamp(resolveCreatedAtForCreate(item.appliedAt)),
-            lastContact: toTimestamp(item.lastContact ?? null),
-            followUpAt: toTimestamp(item.followUpAt ?? null),
+            status: item.status ?? "inbound",
+            appliedAt: item.appliedAt ?? null,
+            lastContact: item.lastContact ?? null,
+            followUpAt: item.followUpAt ?? null,
             notes: item.notes ?? null,
             jobDescription: item.jobDescription ?? null,
             source: item.source ?? null,
@@ -418,19 +976,11 @@ export class FirestoreAdapter implements DatabaseAdapter {
             salaryMax: item.salaryMax ?? null,
             rating: item.rating ?? null,
             jobUrl: item.jobUrl ?? null,
-            ...sanitizeTriageFields({
-              companySize: item.companySize ?? null,
-              salaryBandMentioned: item.salaryBandMentioned ?? false,
-              triageQuality: item.triageQuality ?? null,
-              triageReason: item.triageReason ?? null,
-              incomingSource: item.incomingSource ?? null,
-              autoRejected: item.autoRejected ?? false,
-              autoRejectReason: item.autoRejectReason ?? null,
-            }),
-            createdAt: now,
-            updatedAt: now,
-          });
-          results.push({ index: i, id: ref.id, operation: "created" });
+            resumeId: item.resumeId ?? null,
+          } as CreateApplicationInput & { id?: string };
+          delete createData.id;
+          const application = await this.createApplication(userId, createData);
+          results.push({ index: i, id: application.id, operation: "created" });
           succeeded++;
         }
       } catch (e) {
@@ -447,48 +997,20 @@ export class FirestoreAdapter implements DatabaseAdapter {
     const results: BatchDeleteResult["results"] = [];
     let succeeded = 0;
     let failed = 0;
-
-    // Verify ownership and collect refs for batch delete
-    const toDelete: { id: string; ref: FirebaseFirestore.DocumentReference }[] = [];
     for (const id of ids) {
-      const ref = this.apps.doc(id);
-      const existing = await ref.get();
-      if (!existing.exists || existing.data()!.userId !== userId) {
-        results.push({ id, deleted: false, error: "Not found or access denied" });
-        failed++;
-      } else {
-        toDelete.push({ id, ref });
-      }
-    }
-
-    if (toDelete.length > 0) {
-      // Collect associated contacts for cascade delete
-      const appIds = toDelete.map((d) => d.id);
-      const contactRefs: FirebaseFirestore.DocumentReference[] = [];
-      for (let i = 0; i < appIds.length; i += 30) {
-        const chunk = appIds.slice(i, i + 30);
-        const contactSnap = await this.contacts.where("applicationId", "in", chunk).get();
-        contactSnap.docs.forEach((d) => contactRefs.push(d.ref));
-      }
-
-      // Firestore batches have a 500 operation limit; chunk if needed
-      const allRefs = [
-        ...contactRefs,
-        ...toDelete.map(({ ref }) => ref),
-      ];
-      for (let i = 0; i < allRefs.length; i += 499) {
-        const chunk = allRefs.slice(i, i + 499);
-        const batch = this.db.batch();
-        chunk.forEach((ref) => batch.delete(ref));
-        await batch.commit();
-      }
-
-      for (const { id } of toDelete) {
+      try {
+        await this.deleteApplicationCascade(id, userId);
         results.push({ id, deleted: true });
-        succeeded++;
+        succeeded += 1;
+      } catch (error) {
+        results.push({
+          id,
+          deleted: false,
+          error: error instanceof Error ? error.message : "delete_failed",
+        });
+        failed += 1;
       }
     }
-
     return { total: ids.length, succeeded, failed, results };
   }
 
@@ -499,8 +1021,9 @@ export class FirestoreAdapter implements DatabaseAdapter {
     return doc.exists && doc.data()!.userId === userId;
   }
 
-  async createContact(applicationId: string, data: CreateContactInput): Promise<ContactRecord> {
-    const ref = await this.contacts.add({
+  async createContact(applicationId: string, userId: string, data: CreateContactInput): Promise<ContactRecord> {
+    const reference = this.contacts.doc();
+    const payload = {
       applicationId,
       name: data.name,
       email: data.email,
@@ -508,43 +1031,50 @@ export class FirestoreAdapter implements DatabaseAdapter {
       role: data.role,
       linkedIn: data.linkedIn,
       createdAt: Timestamp.now(),
+    };
+    await this.db.runTransaction(async (transaction) => {
+      const application = await transaction.get(this.apps.doc(applicationId));
+      if (!application.exists || application.data()!.userId !== userId) throw new Error("not_found");
+      if (application.data()!.deletionState === "in_progress") throw new Error("application_deleting");
+      transaction.create(reference, payload);
     });
-    const snap = await ref.get();
-    return mapContact(ref.id, snap.data()!);
+    return mapContact(reference.id, payload);
   }
 
   async updateContact(id: string, applicationId: string, userId: string, data: UpdateContactInput): Promise<ContactRecord> {
-    // Verify ownership chain
-    if (!(await this.verifyApplicationOwner(applicationId, userId))) {
-      throw new Error("Not found");
-    }
-    const ref = this.contacts.doc(id);
-    const existing = await ref.get();
-    if (!existing.exists || existing.data()!.applicationId !== applicationId) {
-      throw new Error("Not found");
-    }
+    const reference = this.contacts.doc(id);
     const update: Record<string, unknown> = {};
     if (data.name !== undefined) update.name = data.name;
     if (data.email !== undefined) update.email = data.email;
     if (data.phone !== undefined) update.phone = data.phone;
     if (data.role !== undefined) update.role = data.role;
     if (data.linkedIn !== undefined) update.linkedIn = data.linkedIn;
-
-    await ref.update(update);
-    const snap = await ref.get();
-    return mapContact(id, snap.data()!);
+    await this.db.runTransaction(async (transaction) => {
+      const [application, contact] = await Promise.all([
+        transaction.get(this.apps.doc(applicationId)),
+        transaction.get(reference),
+      ]);
+      if (!application.exists || application.data()!.userId !== userId) throw new Error("not_found");
+      if (application.data()!.deletionState === "in_progress") throw new Error("application_deleting");
+      if (!contact.exists || contact.data()!.applicationId !== applicationId) throw new Error("not_found");
+      transaction.update(reference, update);
+    });
+    const snapshot = await reference.get();
+    return mapContact(id, snapshot.data()!);
   }
 
   async deleteContact(id: string, applicationId: string, userId: string): Promise<void> {
-    if (!(await this.verifyApplicationOwner(applicationId, userId))) {
-      throw new Error("Not found");
-    }
-    const ref = this.contacts.doc(id);
-    const existing = await ref.get();
-    if (!existing.exists || existing.data()!.applicationId !== applicationId) {
-      throw new Error("Not found");
-    }
-    await ref.delete();
+    const reference = this.contacts.doc(id);
+    await this.db.runTransaction(async (transaction) => {
+      const [application, contact] = await Promise.all([
+        transaction.get(this.apps.doc(applicationId)),
+        transaction.get(reference),
+      ]);
+      if (!application.exists || application.data()!.userId !== userId) throw new Error("not_found");
+      if (application.data()!.deletionState === "in_progress") throw new Error("application_deleting");
+      if (!contact.exists || contact.data()!.applicationId !== applicationId) throw new Error("not_found");
+      transaction.delete(reference);
+    });
   }
 
   // ── Documents ───────────────────────────────────────────────────────────
@@ -572,7 +1102,7 @@ export class FirestoreAdapter implements DatabaseAdapter {
     });
 
     if (allAppIds.size > 0) {
-      const appMap = await this.loadAppRefs([...allAppIds]);
+      const appMap = await this.loadAppRefs(Array.from(allAppIds));
       for (let i = 0; i < documents.length; i++) {
         const ids: string[] = snap.docs[i].data().applicationIds ?? [];
         documents[i].applications = ids
@@ -583,94 +1113,186 @@ export class FirestoreAdapter implements DatabaseAdapter {
     return documents;
   }
 
+  async listDocumentsFiltered(
+    userId: string | null,
+    filter: ListDocumentsFilter,
+  ): Promise<Partial<DocumentRecord>[]> {
+    let documents = await this.listDocuments(userId);
+    if (filter.applicationId) {
+      documents = documents.filter((document) =>
+        document.applications?.some((application) => application.id === filter.applicationId),
+      );
+    }
+    if (filter.documentType) documents = documents.filter((document) => document.documentType === filter.documentType);
+    if (filter.state) documents = documents.filter((document) => document.state === filter.state);
+    if (filter.submissionId) documents = documents.filter((document) => document.submissionId === filter.submissionId);
+    if (filter.excludeSubmissionArtifacts) {
+      documents = documents.filter((document) =>
+        !document.submissionId && document.state !== "submitted" && document.state !== "historical"
+      );
+    }
+    if (filter.orphaned !== undefined) {
+      documents = documents.filter((document) =>
+        filter.orphaned ? !document.applications?.length : Boolean(document.applications?.length),
+      );
+    }
+    const pageSize = Math.max(1, Math.min(200, filter.pageSize ?? filter.limit ?? 50));
+    const page = Math.max(1, filter.page ?? 1);
+    const pageDocuments = documents.slice((page - 1) * pageSize, page * pageSize);
+    if (!filter.fields?.length) return pageDocuments;
+    return pageDocuments.map((document) => {
+      const selected: Partial<DocumentRecord> = { id: document.id };
+      for (const field of filter.fields ?? []) {
+        if (field in document) {
+          (selected as Record<string, unknown>)[field] = document[field as keyof DocumentRecord];
+        }
+      }
+      return selected;
+    });
+  }
+
   async getDocument(id: string, userId: string | null): Promise<DocumentRecord | null> {
-    const doc = await this.docs.doc(id).get();
-    if (!doc.exists) return null;
-    const data = doc.data()!;
+    const document = await this.docs.doc(id).get();
+    if (!document.exists) return null;
+    const data = document.data()!;
     if (userId && data.userId !== userId) return null;
-    return mapDoc(id, data);
+    const record = mapDoc(id, data);
+    const applicationIds: string[] = Array.isArray(data.applicationIds) ? data.applicationIds : [];
+    const applicationMap = await this.loadAppRefs(applicationIds);
+    record.applications = applicationIds
+      .map((applicationId) => applicationMap.get(applicationId))
+      .filter((application): application is NonNullable<typeof application> => Boolean(application));
+    return record;
+  }
+
+  async updateDocumentMetadata(
+    id: string,
+    userId: string,
+    data: UpdateDocumentMetadataInput,
+  ): Promise<DocumentRecord> {
+    const reference = this.docs.doc(id);
+    const update: Record<string, unknown> = {};
+    if (data.documentType !== undefined) update.documentType = data.documentType;
+    if (data.state !== undefined) update.state = data.state;
+    if (data.version !== undefined) update.version = data.version;
+    if (data.contentHash !== undefined) update.contentHash = data.contentHash;
+    if (data.source !== undefined) update.source = data.source;
+    if (data.generatedAt !== undefined) update.generatedAt = toTimestamp(data.generatedAt);
+    if (data.submittedAt !== undefined) update.submittedAt = toTimestamp(data.submittedAt);
+    await this.db.runTransaction(async (transaction) => {
+      const existing = await transaction.get(reference);
+      if (!existing.exists || existing.data()!.userId !== userId) throw new Error("not_found");
+      const submissionId = existing.data()!.submissionId;
+      const keys = Object.keys(data);
+      const stateOnly = keys.every((key) => key === "state");
+      const immutable = submissionId || existing.data()!.state === "submitted" || existing.data()!.state === "historical";
+      if (immutable) {
+        if (!stateOnly || (data.state !== "submitted" && data.state !== "historical")) {
+          throw new Error("submitted_document_immutable");
+        }
+      } else if (data.state === "submitted") {
+        throw new Error("submitted_state_reserved");
+      }
+      transaction.update(reference, update);
+    });
+    return (await this.getDocument(id, userId))!;
   }
 
   async createDocument(userId: string, data: CreateDocumentInput): Promise<DocumentRecord> {
-    const { applicationIds, ...rest } = data;
-
-    // Verify ownership of referenced applications and load refs in one batch
-    let appMap = new Map<string, { id: string; company: string; role: string }>();
-    if (applicationIds.length > 0) {
-      appMap = await this.loadVerifiedAppRefs(applicationIds, userId);
-    }
-    const safeIds = Array.from(appMap.keys());
-
-    const ref = await this.docs.add({
+    const { applicationIds, submissionId, ...rest } = data;
+    if (submissionId || rest.state === "submitted") throw new Error("submitted_state_reserved");
+    const uniqueApplicationIds = Array.from(new Set(applicationIds));
+    const applicationReferences = uniqueApplicationIds.map((applicationId) => this.apps.doc(applicationId));
+    const reference = this.docs.doc();
+    const payload = {
       userId,
       ...rest,
-      applicationIds: safeIds,
+      applicationIds: uniqueApplicationIds,
       uploadedAt: Timestamp.now(),
+    };
+    const applicationData = await this.db.runTransaction(async (transaction) => {
+      const applicationSnapshots = await Promise.all(
+        applicationReferences.map((applicationReference) => transaction.get(applicationReference)),
+      );
+      if (applicationSnapshots.some((snapshot) =>
+        !snapshot.exists
+        || snapshot.data()!.userId !== userId
+        || snapshot.data()!.deletionState === "in_progress"
+      )) {
+        throw new Error("invalid_applications");
+      }
+      transaction.create(reference, payload);
+      return applicationSnapshots.map((snapshot) => ({
+        id: snapshot.id,
+        company: String(snapshot.data()!.company),
+        role: String(snapshot.data()!.role),
+      }));
     });
-    const snap = await ref.get();
-    const rec = mapDoc(ref.id, snap.data()!);
-
-    // Populate resolved app refs
-    rec.applications = safeIds
-      .map((id) => appMap.get(id))
-      .filter((a): a is NonNullable<typeof a> => !!a);
-
-    return rec;
+    const record = mapDoc(reference.id, payload);
+    record.applications = applicationData;
+    return record;
   }
 
   async updateDocumentLinks(id: string, userId: string, applicationIds: string[]): Promise<DocumentRecord> {
-    const ref = this.docs.doc(id);
-    const existing = await ref.get();
-    if (!existing.exists || existing.data()!.userId !== userId) {
-      throw new Error("Not found");
-    }
-
-    // Verify ownership of referenced applications and load refs in one batch
-    let appMap = new Map<string, { id: string; company: string; role: string }>();
-    if (applicationIds.length > 0) {
-      appMap = await this.loadVerifiedAppRefs(applicationIds, userId);
-    }
-    const safeIds = Array.from(appMap.keys());
-    await ref.update({ applicationIds: safeIds });
-
-    const rec = mapDoc(id, (await ref.get()).data()!);
-    // Populate resolved app refs
-    rec.applications = safeIds
-      .map((aid) => appMap.get(aid))
-      .filter((a): a is NonNullable<typeof a> => !!a);
-    return rec;
+    const reference = this.docs.doc(id);
+    const uniqueApplicationIds = Array.from(new Set(applicationIds));
+    const applicationReferences = uniqueApplicationIds.map((applicationId) => this.apps.doc(applicationId));
+    await this.db.runTransaction(async (transaction) => {
+      const existing = await transaction.get(reference);
+      if (!existing.exists || existing.data()!.userId !== userId) throw new Error("not_found");
+      if (
+        existing.data()!.submissionId
+        || existing.data()!.state === "submitted"
+        || existing.data()!.state === "historical"
+      ) throw new Error("submitted_document_immutable");
+      const applicationSnapshots = await Promise.all(
+        applicationReferences.map((applicationReference) => transaction.get(applicationReference)),
+      );
+      if (applicationSnapshots.some((snapshot) =>
+        !snapshot.exists
+        || snapshot.data()!.userId !== userId
+        || snapshot.data()!.deletionState === "in_progress"
+      )) {
+        throw new Error("invalid_applications");
+      }
+      transaction.update(reference, { applicationIds: uniqueApplicationIds });
+    });
+    return (await this.getDocument(id, userId))!;
   }
 
   async renameDocument(id: string, userId: string, newName: string): Promise<DocumentRecord | null> {
-    const ref = this.docs.doc(id);
-    const existing = await ref.get();
-    if (!existing.exists || existing.data()!.userId !== userId) return null;
-    await ref.update({ originalName: newName });
-    const updated = await ref.get();
-    const data = updated.data()!;
-    const rec = mapDoc(id, data);
-    const appIds: string[] = data.applicationIds ?? [];
-
-    // Verify ownership of referenced applications and load refs in one batch
-    let appMap = new Map<string, { id: string; company: string; role: string }>();
-    if (appIds.length > 0) {
-      appMap = await this.loadVerifiedAppRefs(appIds, userId);
-    }
-    rec.applications = appIds
-      .map((aid) => appMap.get(aid))
-      .filter((a): a is NonNullable<typeof a> => !!a);
-
-    return rec;
+    const reference = this.docs.doc(id);
+    const changed = await this.db.runTransaction(async (transaction) => {
+      const existing = await transaction.get(reference);
+      if (!existing.exists || existing.data()!.userId !== userId) return false;
+      if (
+        existing.data()!.submissionId
+        || existing.data()!.state === "submitted"
+        || existing.data()!.state === "historical"
+      ) throw new Error("submitted_document_immutable");
+      transaction.update(reference, { originalName: newName });
+      return true;
+    });
+    return changed ? this.getDocument(id, userId) : null;
   }
 
   async deleteDocument(id: string, userId: string): Promise<DocumentRecord | null> {
-    const ref = this.docs.doc(id);
-    const existing = await ref.get();
-    if (!existing.exists || existing.data()!.userId !== userId) return null;
-    const rec = mapDoc(id, existing.data()!);
+    const reference = this.docs.doc(id);
+    const document = await this.db.runTransaction(async (transaction) => {
+      const existing = await transaction.get(reference);
+      if (!existing.exists || existing.data()!.userId !== userId) return null;
+      if (
+        existing.data()!.submissionId
+        || existing.data()!.state === "submitted"
+        || existing.data()!.state === "historical"
+      ) throw new Error("submitted_document_immutable");
+      const record = mapDoc(id, existing.data()!);
+      transaction.delete(reference);
+      return record;
+    });
+    if (!document) return null;
     await prisma.shareLink.deleteMany({ where: { userId, targetType: "document", targetId: id } });
-    await ref.delete();
-    return rec;
+    return document;
   }
 
   // ── Users ───────────────────────────────────────────────────────────────

--- a/lib/db/firestore-adapter.ts
+++ b/lib/db/firestore-adapter.ts
@@ -439,28 +439,33 @@ export class FirestoreAdapter implements DatabaseAdapter {
       snapshot.docs.forEach((document) => documents.set(document.id, document));
     }
 
+    // Preserve and detach every document before deleting any submission. This ordering
+    // makes the multi-batch cascade retryable: while document batches are incomplete,
+    // submission rows remain available to rediscover every submitted artifact. Once a
+    // submission deletion starts, all associated documents have already been preserved.
+    const documentOperations = Array.from(documents.values()).map((document) => {
+      const data = document.data();
+      const submissionId = typeof data.submissionId === "string" ? data.submissionId : null;
+      const belongsToDeletedSubmission = submissionId !== null && deletedSubmissionIds.has(submissionId);
+      return {
+        type: "update" as const,
+        ref: document.ref,
+        data: {
+          applicationIds: ((data.applicationIds as string[] | undefined) ?? [])
+            .filter((applicationId) => applicationId !== id),
+          submissionId: belongsToDeletedSubmission ? null : submissionId,
+          state: belongsToDeletedSubmission ? "historical" : (data.state ?? "current"),
+        },
+      };
+    });
     const operations: Array<
       | { type: "delete"; ref: FirebaseFirestore.DocumentReference }
       | { type: "update"; ref: FirebaseFirestore.DocumentReference; data: Record<string, unknown> }
     > = [
+      ...documentOperations,
       ...contactSnap.docs.map((document) => ({ type: "delete" as const, ref: document.ref })),
-      ...submissionSnap.docs.map((document) => ({ type: "delete" as const, ref: document.ref })),
       ...eventSnap.docs.map((document) => ({ type: "delete" as const, ref: document.ref })),
-      ...Array.from(documents.values()).map((document) => {
-        const data = document.data();
-        const submissionId = typeof data.submissionId === "string" ? data.submissionId : null;
-        const belongsToDeletedSubmission = submissionId !== null && deletedSubmissionIds.has(submissionId);
-        return {
-          type: "update" as const,
-          ref: document.ref,
-          data: {
-            applicationIds: ((data.applicationIds as string[] | undefined) ?? [])
-              .filter((applicationId) => applicationId !== id),
-            submissionId: belongsToDeletedSubmission ? null : submissionId,
-            state: belongsToDeletedSubmission ? "historical" : (data.state ?? "current"),
-          },
-        };
-      }),
+      ...submissionSnap.docs.map((document) => ({ type: "delete" as const, ref: document.ref })),
     ];
     for (let offset = 0; offset < operations.length; offset += 450) {
       const batch = this.db.batch();

--- a/lib/db/prisma-adapter.ts
+++ b/lib/db/prisma-adapter.ts
@@ -567,7 +567,11 @@ export class PrismaAdapter implements DatabaseAdapter {
           })
         : [];
       if (documents.length !== uniqueDocumentIds.length) throw new Error("invalid_documents");
-      if (documents.some((document) => document.submissionId !== null)) {
+      if (documents.some((document) =>
+        document.submissionId !== null
+        || document.state === "submitted"
+        || document.state === "historical"
+      )) {
         throw new Error("document_already_submitted");
       }
 
@@ -647,6 +651,7 @@ export class PrismaAdapter implements DatabaseAdapter {
             id: { in: uniqueDocumentIds.map(nid) },
             userId,
             submissionId: null,
+            state: { notIn: ["submitted", "historical"] },
           },
           data: { state: "submitted", submittedAt: input.submittedAt, submissionId: created.id },
         });
@@ -1132,7 +1137,9 @@ export class PrismaAdapter implements DatabaseAdapter {
     const stateOnly = keys.every((key) => key === "state");
     const immutable = existing.submissionId !== null || existing.state === "submitted" || existing.state === "historical";
     if (immutable) {
-      if (!stateOnly || (data.state !== "submitted" && data.state !== "historical")) {
+      const allowedState = data.state === existing.state
+        || (existing.state === "submitted" && data.state === "historical");
+      if (!stateOnly || !allowedState) {
         throw new Error("submitted_document_immutable");
       }
     } else if (data.state === "submitted") {

--- a/lib/db/prisma-adapter.ts
+++ b/lib/db/prisma-adapter.ts
@@ -1,8 +1,9 @@
 import { prisma } from "@/lib/prisma";
-import { Prisma } from "@prisma/client";
+import { Prisma, type ApplicationSubmission, type ApplicationEvent, type Document as PrismaDocument } from "@prisma/client";
 import { normalizeStatus } from "@/types";
 import { sanitizeTriageFields } from "./sanitize";
-import { resolveCreatedAtForCreate } from "@/lib/applications/defaults";
+import { resolveAppliedAtForCreate } from "@/lib/applications/defaults";
+import { submissionRequestHash } from "@/lib/applications/submission";
 import type { DatabaseAdapter } from "./adapter";
 import type {
   ApplicationRecord,
@@ -29,6 +30,13 @@ import type {
   UpsertCvProfileInput,
   CvPatchRecord,
   UpsertCvPatchInput,
+  ApplicationSubmissionRecord,
+  ApplicationEventRecord,
+  RecordSubmissionInput,
+  RecordSubmissionResult,
+  CreateApplicationEventInput,
+  ListDocumentsFilter,
+  UpdateDocumentMetadataInput,
 } from "./types";
 
 // ── Helpers: convert Prisma int IDs ↔ string IDs ────────────────────────────
@@ -37,8 +45,13 @@ function sid(n: number): string {
   return String(n);
 }
 
-function nid(s: string): number {
-  return parseInt(s, 10);
+function nid(id: string): number {
+  if (!/^[1-9]\d*$/.test(id)) throw new Error(`Invalid numeric id: ${id}`);
+  const parsed = Number(id);
+  if (!Number.isSafeInteger(parsed) || parsed > 2_147_483_647) {
+    throw new Error(`Invalid numeric id: ${id}`);
+  }
+  return parsed;
 }
 
 // Use Prisma's generated payload type instead of a long inline type
@@ -53,15 +66,94 @@ function mapApp(a: AppRow): ApplicationRecord {
     ...a,
     id: sid(a.id),
     status: normalizeStatus(a.status),
+    eligibleCountries: Array.isArray(a.eligibleCountries) ? (a.eligibleCountries as string[]) : [],
+    primaryLocations: Array.isArray(a.primaryLocations) ? (a.primaryLocations as string[]) : [],
     contacts: a.contacts?.map(mapContact),
   };
 }
 
-function mapDoc(d: { id: number; userId: string; filename: string; originalName: string; size: number; mimeType: string; uploadedAt: Date; applications?: { id: number; company: string; role: string }[] }): DocumentRecord {
+type DocumentWithApplications = PrismaDocument & {
+  applications?: { id: number; company: string; role: string }[];
+};
+
+function mapDoc(d: DocumentWithApplications): DocumentRecord {
   return {
     ...d,
     id: sid(d.id),
+    submissionId: d.submissionId ? sid(d.submissionId) : null,
     applications: d.applications?.map((a) => ({ id: sid(a.id), company: a.company, role: a.role })),
+  };
+}
+
+function mapSubmission(
+  row: ApplicationSubmission & { documents?: DocumentWithApplications[] },
+  includeAnswers = true,
+): ApplicationSubmissionRecord {
+  return {
+    ...row,
+    id: sid(row.id),
+    applicationId: sid(row.applicationId),
+    answers: includeAnswers
+      ? (row.answers as unknown as ApplicationSubmissionRecord["answers"])
+      : [],
+    documentIds: row.documentIds as unknown as string[],
+    documents: row.documents?.map(mapDoc),
+  };
+}
+
+function mapEvent(row: ApplicationEvent): ApplicationEventRecord {
+  return {
+    ...row,
+    id: sid(row.id),
+    applicationId: sid(row.applicationId),
+    metadata: row.metadata as unknown as Record<string, unknown> | null,
+  };
+}
+
+function submissionEventKey(idempotencyKey: string): string {
+  return `submission:${idempotencyKey}`;
+}
+
+async function loadSubmissionReplay(
+  userId: string,
+  idempotencyKey: string,
+  requestHash: string,
+): Promise<RecordSubmissionResult | null> {
+  const submission = await prisma.applicationSubmission.findUnique({
+    where: { userId_idempotencyKey: { userId, idempotencyKey } },
+    include: {
+      documents: {
+        include: { applications: { select: { id: true, company: true, role: true } } },
+      },
+    },
+  });
+  if (!submission) return null;
+  if (submission.requestHash !== requestHash) throw new Error("idempotency_conflict");
+  const [application, event] = await Promise.all([
+    prisma.application.findFirst({
+      where: { id: submission.applicationId, userId },
+      include: { contacts: true },
+    }),
+    prisma.applicationEvent.findUnique({
+      where: {
+        userId_idempotencyKey: {
+          userId,
+          idempotencyKey: submissionEventKey(idempotencyKey),
+        },
+      },
+    }),
+  ]);
+  if (!application) throw new Error("not_found");
+  const mappedSubmission = mapSubmission(submission);
+  return {
+    replayed: true,
+    dryRun: false,
+    verified:
+      application.status === "applied" && submission.documents.length === mappedSubmission.documentIds.length,
+    application: mapApp(application),
+    submission: mappedSubmission,
+    event: event ? mapEvent(event) : null,
+    documents: submission.documents.map(mapDoc),
   };
 }
 
@@ -100,6 +192,39 @@ function pickFields(apps: ApplicationRecord[], fields?: string[]): Partial<Appli
     picked.id = app.id;
     return picked;
   });
+}
+
+function pickDocumentFields(
+  documents: DocumentRecord[],
+  fields?: string[],
+): Partial<DocumentRecord>[] {
+  if (!fields?.length) return documents;
+  return documents.map((document) => {
+    const picked: Partial<DocumentRecord> = { id: document.id };
+    for (const field of fields) {
+      if (field in document) {
+        (picked as Record<string, unknown>)[field] =
+          document[field as keyof DocumentRecord];
+      }
+    }
+    return picked;
+  });
+}
+
+const STRUCTURED_APPLICATION_FIELDS = [
+  "canonicalJobUrl", "workMode", "eligibleCountries", "primaryLocations",
+  "officeDaysMin", "travelPercent", "visaSponsorship", "rightToWorkRequired",
+  "timezoneOverlap", "salaryCurrency", "salaryPeriod", "salaryType", "atsName",
+  "requisitionId", "jobCapturedAt", "jobVerifiedAt", "jobPostedAt", "jobClosedAt",
+  "jobContentHash", "jobLiveness", "jobSummary", "currentStage",
+] as const;
+
+function structuredApplicationData(data: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const field of STRUCTURED_APPLICATION_FIELDS) {
+    if (data[field] !== undefined) result[field] = data[field];
+  }
+  return result;
 }
 
 // ── Implementation ──────────────────────────────────────────────────────────
@@ -153,24 +278,52 @@ export class PrismaAdapter implements DatabaseAdapter {
   }
 
   async createApplication(userId: string, data: CreateApplicationInput): Promise<ApplicationRecord> {
-    const row = await prisma.application.create({
-      data: {
-        userId,
-        ...data,
-        status: normalizeStatus(data.status),
-        appliedAt: resolveCreatedAtForCreate(data.appliedAt),
-      },
-      include: { contacts: true },
-    });
-    return mapApp(row);
+    try {
+      const row = await prisma.application.create({
+        data: {
+          userId,
+          ...data,
+          status: normalizeStatus(data.status),
+          appliedAt: resolveAppliedAtForCreate(data.status, data.appliedAt),
+        },
+        include: { contacts: true },
+      });
+      return mapApp(row);
+    } catch (error) {
+      if (
+        data.canonicalJobUrl &&
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === "P2002"
+      ) {
+        throw new Error("canonical_job_url_conflict");
+      }
+      throw error;
+    }
   }
 
   async updateApplication(id: string, userId: string, data: UpdateApplicationInput): Promise<ApplicationRecord> {
+    const { expectedUpdatedAt, ...update } = data;
+    if (expectedUpdatedAt) {
+      const result = await prisma.application.updateMany({
+        where: { id: nid(id), userId, updatedAt: expectedUpdatedAt },
+        data: {
+          ...update,
+          ...(update.status !== undefined ? { status: normalizeStatus(update.status) } : {}),
+        },
+      });
+      if (result.count !== 1) throw new Error("conflict");
+      const row = await prisma.application.findFirstOrThrow({
+        where: { id: nid(id), userId },
+        include: { contacts: true },
+      });
+      return mapApp(row);
+    }
+
     const row = await prisma.application.update({
       where: { id: nid(id), userId },
       data: {
-        ...data,
-        ...(data.status !== undefined ? { status: normalizeStatus(data.status) } : {}),
+        ...update,
+        ...(update.status !== undefined ? { status: normalizeStatus(update.status) } : {}),
       },
       include: { contacts: true },
     });
@@ -178,7 +331,511 @@ export class PrismaAdapter implements DatabaseAdapter {
   }
 
   async deleteApplication(id: string, userId: string): Promise<void> {
-    await prisma.application.delete({ where: { id: nid(id), userId } });
+    await prisma.$transaction(async (tx) => {
+      const applicationId = nid(id);
+      const locked = await tx.$queryRaw<Array<{ id: number }>>`
+        SELECT "id" FROM "Application"
+        WHERE "id" = ${applicationId} AND "userId" = ${userId}
+        FOR UPDATE
+      `;
+      if (!locked.length) throw new Error("not_found");
+      const submissions = await tx.applicationSubmission.findMany({
+        where: { applicationId, userId },
+        select: { id: true },
+      });
+      if (submissions.length) {
+        await tx.document.updateMany({
+          where: {
+            userId,
+            submissionId: { in: submissions.map((submission) => submission.id) },
+          },
+          data: { state: "historical", submissionId: null },
+        });
+      }
+      await tx.application.delete({ where: { id: applicationId, userId } });
+    });
+  }
+
+  async findApplicationByCanonicalJobUrl(
+    userId: string,
+    canonicalJobUrl: string,
+  ): Promise<ApplicationRecord | null> {
+    const row = await prisma.application.findFirst({
+      where: { userId, canonicalJobUrl },
+      include: { contacts: true },
+    });
+    return row ? mapApp(row) : null;
+  }
+
+  async appendApplicationNote(
+    id: string,
+    userId: string,
+    note: string,
+    eventInput: CreateApplicationEventInput,
+  ): Promise<{ application: ApplicationRecord; event: ApplicationEventRecord }> {
+    const requestHash = submissionRequestHash({ applicationId: id, note, type: eventInput.type });
+    const loadReplay = async () => {
+      if (!eventInput.idempotencyKey) return null;
+      const event = await prisma.applicationEvent.findUnique({
+        where: {
+          userId_idempotencyKey: { userId, idempotencyKey: eventInput.idempotencyKey },
+        },
+      });
+      if (!event) return null;
+      const metadata = (event.metadata ?? {}) as Record<string, unknown>;
+      if (metadata.requestHash !== requestHash) throw new Error("idempotency_conflict");
+      const application = await prisma.application.findFirst({
+        where: { id: nid(id), userId },
+        include: { contacts: true },
+      });
+      if (!application) throw new Error("not_found");
+      return { application: mapApp(application), event: mapEvent(event) };
+    };
+    const existingReplay = await loadReplay();
+    if (existingReplay) return existingReplay;
+
+    try {
+      return await prisma.$transaction(async (tx) => {
+        const existing = await tx.application.findFirst({
+          where: { id: nid(id), userId },
+          include: { contacts: true },
+        });
+        if (!existing) throw new Error("not_found");
+        if (eventInput.idempotencyKey) {
+          const replay = await tx.applicationEvent.findUnique({
+            where: {
+              userId_idempotencyKey: {
+                userId,
+                idempotencyKey: eventInput.idempotencyKey,
+              },
+            },
+          });
+          if (replay) {
+            const metadata = (replay.metadata ?? {}) as Record<string, unknown>;
+            if (metadata.requestHash !== requestHash) throw new Error("idempotency_conflict");
+            return { application: mapApp(existing), event: mapEvent(replay) };
+          }
+        }
+
+        const expectedUpdatedAt = eventInput.expectedUpdatedAt;
+        const changed = expectedUpdatedAt
+          ? await tx.$executeRaw`
+              UPDATE "Application"
+              SET "notes" = CASE
+                    WHEN "notes" IS NULL OR "notes" = '' THEN ${note}
+                    ELSE "notes" || E'\n\n' || ${note}
+                  END,
+                  "updatedAt" = NOW()
+              WHERE "id" = ${nid(id)}
+                AND "userId" = ${userId}
+                AND "updatedAt" = ${expectedUpdatedAt}
+                AND char_length(
+                  CASE
+                    WHEN "notes" IS NULL OR "notes" = '' THEN ${note}
+                    ELSE "notes" || E'\n\n' || ${note}
+                  END
+                ) <= 50000
+            `
+          : await tx.$executeRaw`
+              UPDATE "Application"
+              SET "notes" = CASE
+                    WHEN "notes" IS NULL OR "notes" = '' THEN ${note}
+                    ELSE "notes" || E'\n\n' || ${note}
+                  END,
+                  "updatedAt" = NOW()
+              WHERE "id" = ${nid(id)}
+                AND "userId" = ${userId}
+                AND char_length(
+                  CASE
+                    WHEN "notes" IS NULL OR "notes" = '' THEN ${note}
+                    ELSE "notes" || E'\n\n' || ${note}
+                  END
+                ) <= 50000
+            `;
+        if (changed !== 1) {
+          const current = await tx.application.findFirst({ where: { id: nid(id), userId } });
+          if (!current) throw new Error("not_found");
+          if (expectedUpdatedAt && current.updatedAt.getTime() !== expectedUpdatedAt.getTime()) {
+            throw new Error("conflict");
+          }
+          throw new Error("notes_too_large");
+        }
+        const application = await tx.application.findFirstOrThrow({
+          where: { id: nid(id), userId },
+          include: { contacts: true },
+        });
+        const event = await tx.applicationEvent.create({
+          data: {
+            userId,
+            applicationId: nid(id),
+            type: eventInput.type,
+            idempotencyKey: eventInput.idempotencyKey ?? null,
+            occurredAt: eventInput.occurredAt,
+            source: eventInput.source ?? null,
+            actor: eventInput.actor ?? null,
+            metadata: {
+              ...(eventInput.metadata ?? {}),
+              requestHash,
+            } as Prisma.InputJsonValue,
+          },
+        });
+        return { application: mapApp(application), event: mapEvent(event) };
+      });
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+        const replay = await loadReplay();
+        if (replay) return replay;
+      }
+      throw error;
+    }
+  }
+
+  async recordApplicationSubmission(
+    userId: string,
+    input: RecordSubmissionInput,
+  ): Promise<RecordSubmissionResult> {
+    const hashable: Record<string, unknown> = { ...input };
+    delete hashable.idempotencyKey;
+    delete hashable.dryRun;
+    delete hashable.expectedUpdatedAt;
+    delete hashable.source;
+    delete hashable.actor;
+    const requestHash = submissionRequestHash(hashable);
+    const initialReplay = await loadSubmissionReplay(userId, input.idempotencyKey, requestHash);
+    if (initialReplay) return initialReplay;
+    try {
+      return await prisma.$transaction(async (tx) => {
+      const replay = await tx.applicationSubmission.findUnique({
+        where: { userId_idempotencyKey: { userId, idempotencyKey: input.idempotencyKey } },
+        include: {
+          documents: {
+            include: { applications: { select: { id: true, company: true, role: true } } },
+          },
+        },
+      });
+      if (replay) {
+        if (replay.requestHash !== requestHash) throw new Error("idempotency_conflict");
+        const [application, event] = await Promise.all([
+          tx.application.findFirstOrThrow({
+            where: { id: replay.applicationId, userId },
+            include: { contacts: true },
+          }),
+          tx.applicationEvent.findUnique({
+            where: {
+              userId_idempotencyKey: {
+                userId,
+                idempotencyKey: submissionEventKey(input.idempotencyKey),
+              },
+            },
+          }),
+        ]);
+        return {
+          replayed: true,
+          dryRun: false,
+          verified: true,
+          application: mapApp(application),
+          submission: mapSubmission(replay),
+          event: event ? mapEvent(event) : null,
+          documents: replay.documents.map(mapDoc),
+        };
+      }
+
+      const applicationId = nid(input.applicationId);
+      const locked = await tx.$queryRaw<Array<{ id: number }>>`
+        SELECT "id" FROM "Application"
+        WHERE "id" = ${applicationId} AND "userId" = ${userId}
+        FOR UPDATE
+      `;
+      if (!locked.length) throw new Error("not_found");
+      const application = await tx.application.findFirst({
+        where: { id: applicationId, userId },
+        include: { contacts: true },
+      });
+      if (!application) throw new Error("not_found");
+      if (
+        input.expectedUpdatedAt &&
+        application.updatedAt.getTime() !== input.expectedUpdatedAt.getTime()
+      ) {
+        throw new Error("conflict");
+      }
+
+      const uniqueDocumentIds = Array.from(new Set(input.documentIds));
+      const documents = uniqueDocumentIds.length
+        ? await tx.document.findMany({
+            where: { id: { in: uniqueDocumentIds.map(nid) }, userId },
+            include: { applications: { select: { id: true, company: true, role: true } } },
+          })
+        : [];
+      if (documents.length !== uniqueDocumentIds.length) throw new Error("invalid_documents");
+      if (documents.some((document) => document.submissionId !== null)) {
+        throw new Error("document_already_submitted");
+      }
+
+      if (input.dryRun) {
+        const predictedApplication = mapApp({
+          ...application,
+          status: "applied",
+          appliedAt: input.submittedAt,
+          followUpAt: input.followUpAt === undefined ? application.followUpAt : input.followUpAt,
+          atsName: input.atsName ?? application.atsName,
+          requisitionId: input.requisitionId ?? application.requisitionId,
+        });
+        const predictedDocuments = documents.map((document) =>
+          mapDoc({
+            ...document,
+            state: "submitted",
+            submittedAt: input.submittedAt,
+          }),
+        );
+        return {
+          replayed: false,
+          dryRun: true,
+          verified: true,
+          application: predictedApplication,
+          submission: {
+            id: "dry-run",
+            userId,
+            applicationId: input.applicationId,
+            idempotencyKey: input.idempotencyKey,
+            requestHash,
+            submittedAt: input.submittedAt,
+            applicationUrl: input.applicationUrl ?? null,
+            atsName: input.atsName ?? null,
+            requisitionId: input.requisitionId ?? null,
+            language: input.language ?? null,
+            answers: input.answers,
+            candidateSalaryMin: input.candidateSalaryMin ?? null,
+            candidateSalaryMax: input.candidateSalaryMax ?? null,
+            candidateSalaryCurrency: input.candidateSalaryCurrency ?? null,
+            candidateSalaryPeriod: input.candidateSalaryPeriod ?? null,
+            candidateSalaryType: input.candidateSalaryType ?? null,
+            candidateSalaryFlexible: input.candidateSalaryFlexible ?? false,
+            documentIds: uniqueDocumentIds,
+            createdAt: input.submittedAt,
+            documents: predictedDocuments,
+          },
+          event: null,
+          documents: predictedDocuments,
+        };
+      }
+
+      const created = await tx.applicationSubmission.create({
+        data: {
+          userId,
+          applicationId: nid(input.applicationId),
+          idempotencyKey: input.idempotencyKey,
+          requestHash,
+          submittedAt: input.submittedAt,
+          applicationUrl: input.applicationUrl ?? null,
+          atsName: input.atsName ?? null,
+          requisitionId: input.requisitionId ?? null,
+          language: input.language ?? null,
+          answers: input.answers as unknown as Prisma.InputJsonValue,
+          candidateSalaryMin: input.candidateSalaryMin ?? null,
+          candidateSalaryMax: input.candidateSalaryMax ?? null,
+          candidateSalaryCurrency: input.candidateSalaryCurrency ?? null,
+          candidateSalaryPeriod: input.candidateSalaryPeriod ?? null,
+          candidateSalaryType: input.candidateSalaryType ?? null,
+          candidateSalaryFlexible: input.candidateSalaryFlexible ?? false,
+          documentIds: uniqueDocumentIds as Prisma.InputJsonValue,
+        },
+      });
+
+      if (uniqueDocumentIds.length) {
+        const claimed = await tx.document.updateMany({
+          where: {
+            id: { in: uniqueDocumentIds.map(nid) },
+            userId,
+            submissionId: null,
+          },
+          data: { state: "submitted", submittedAt: input.submittedAt, submissionId: created.id },
+        });
+        if (claimed.count !== uniqueDocumentIds.length) {
+          throw new Error("document_already_submitted");
+        }
+      }
+
+      const applicationUpdate = {
+        status: "applied",
+        appliedAt: input.submittedAt,
+        ...(input.followUpAt !== undefined ? { followUpAt: input.followUpAt } : {}),
+        ...(input.atsName !== undefined ? { atsName: input.atsName } : {}),
+        ...(input.requisitionId !== undefined ? { requisitionId: input.requisitionId } : {}),
+      };
+      if (input.expectedUpdatedAt) {
+        const updated = await tx.application.updateMany({
+          where: {
+            id: nid(input.applicationId),
+            userId,
+            updatedAt: input.expectedUpdatedAt,
+          },
+          data: applicationUpdate,
+        });
+        if (updated.count !== 1) throw new Error("conflict");
+      } else {
+        await tx.application.update({
+          where: { id: nid(input.applicationId), userId },
+          data: applicationUpdate,
+        });
+      }
+      const updatedApplication = await tx.application.findFirstOrThrow({
+        where: { id: nid(input.applicationId), userId },
+        include: { contacts: true },
+      });
+      const event = await tx.applicationEvent.create({
+        data: {
+          userId,
+          applicationId: nid(input.applicationId),
+          type: "application_submitted",
+          idempotencyKey: submissionEventKey(input.idempotencyKey),
+          occurredAt: input.submittedAt,
+          source: input.source ?? "mcp",
+          actor: input.actor ?? null,
+          metadata: {
+            submissionId: sid(created.id),
+            documentIds: uniqueDocumentIds,
+            answerCount: input.answers.length,
+          },
+        },
+      });
+      const stored = await tx.applicationSubmission.findUniqueOrThrow({
+        where: { id: created.id },
+        include: {
+          documents: {
+            include: { applications: { select: { id: true, company: true, role: true } } },
+          },
+        },
+      });
+      return {
+        replayed: false,
+        dryRun: false,
+        verified:
+          updatedApplication.status === "applied" &&
+          updatedApplication.appliedAt?.getTime() === input.submittedAt.getTime() &&
+          stored.documents.length === uniqueDocumentIds.length,
+        application: mapApp(updatedApplication),
+        submission: mapSubmission(stored),
+        event: mapEvent(event),
+        documents: stored.documents.map(mapDoc),
+      };
+      });
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+        const replay = await loadSubmissionReplay(userId, input.idempotencyKey, requestHash);
+        if (replay) return replay;
+      }
+      throw error;
+    }
+  }
+
+  async listApplicationSubmissions(
+    applicationId: string,
+    userId: string,
+    includeAnswers = false,
+  ): Promise<ApplicationSubmissionRecord[]> {
+    const owns = await prisma.application.count({ where: { id: nid(applicationId), userId } });
+    if (!owns) throw new Error("not_found");
+    const rows = await prisma.applicationSubmission.findMany({
+      where: { applicationId: nid(applicationId), userId },
+      orderBy: { submittedAt: "desc" },
+      include: {
+        documents: {
+          include: { applications: { select: { id: true, company: true, role: true } } },
+        },
+      },
+    });
+    return rows.map((row) => mapSubmission(row, includeAnswers));
+  }
+
+  async listUserSubmissions(userId: string): Promise<ApplicationSubmissionRecord[]> {
+    const rows = await prisma.applicationSubmission.findMany({
+      where: { userId },
+      orderBy: { submittedAt: "desc" },
+    });
+    return rows.map((row) => mapSubmission(row));
+  }
+
+  async getApplicationSubmission(
+    id: string,
+    userId: string,
+  ): Promise<ApplicationSubmissionRecord | null> {
+    const row = await prisma.applicationSubmission.findFirst({
+      where: { id: nid(id), userId },
+      include: {
+        documents: {
+          include: { applications: { select: { id: true, company: true, role: true } } },
+        },
+      },
+    });
+    return row ? mapSubmission(row) : null;
+  }
+
+  async createApplicationEvent(
+    applicationId: string,
+    userId: string,
+    input: CreateApplicationEventInput,
+  ): Promise<ApplicationEventRecord> {
+    const owns = await prisma.application.count({ where: { id: nid(applicationId), userId } });
+    if (!owns) throw new Error("not_found");
+    const requestHash = submissionRequestHash({
+      applicationId,
+      type: input.type,
+      occurredAt: input.occurredAt,
+      metadata: input.metadata ?? {},
+    });
+    const loadReplay = async (): Promise<ApplicationEventRecord | null> => {
+      if (!input.idempotencyKey) return null;
+      const replay = await prisma.applicationEvent.findUnique({
+        where: {
+          userId_idempotencyKey: { userId, idempotencyKey: input.idempotencyKey },
+        },
+      });
+      if (!replay) return null;
+      const metadata = (replay.metadata ?? {}) as Record<string, unknown>;
+      if (metadata.requestHash !== requestHash) throw new Error("idempotency_conflict");
+      return mapEvent(replay);
+    };
+    const replay = await loadReplay();
+    if (replay) return replay;
+    try {
+      const row = await prisma.applicationEvent.create({
+        data: {
+          userId,
+          applicationId: nid(applicationId),
+          type: input.type,
+          idempotencyKey: input.idempotencyKey ?? null,
+          occurredAt: input.occurredAt,
+          source: input.source ?? null,
+          actor: input.actor ?? null,
+          metadata: {
+            ...(input.metadata ?? {}),
+            requestHash,
+          } as Prisma.InputJsonValue,
+        },
+      });
+      return mapEvent(row);
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+        const concurrentReplay = await loadReplay();
+        if (concurrentReplay) return concurrentReplay;
+      }
+      throw error;
+    }
+  }
+
+  async listApplicationEvents(
+    applicationId: string,
+    userId: string,
+    limit = 100,
+  ): Promise<ApplicationEventRecord[]> {
+    const owns = await prisma.application.count({ where: { id: nid(applicationId), userId } });
+    if (!owns) throw new Error("not_found");
+    const rows = await prisma.applicationEvent.findMany({
+      where: { applicationId: nid(applicationId), userId },
+      orderBy: { occurredAt: "desc" },
+      take: Math.max(1, Math.min(500, limit)),
+    });
+    return rows.map(mapEvent);
   }
 
   async listApplicationsFiltered(
@@ -283,6 +940,8 @@ export class PrismaAdapter implements DatabaseAdapter {
           if (item.salaryMax !== undefined) data.salaryMax = item.salaryMax;
           if (item.rating !== undefined) data.rating = item.rating;
           if (item.jobUrl !== undefined) data.jobUrl = item.jobUrl;
+          if (item.resumeId !== undefined) data.resumeId = item.resumeId;
+          Object.assign(data, structuredApplicationData(item as unknown as Record<string, unknown>));
           Object.assign(data, sanitizeTriageFields(item as Record<string, unknown>));
 
           const row = await prisma.application.update({
@@ -303,8 +962,8 @@ export class PrismaAdapter implements DatabaseAdapter {
               userId,
               company: item.company,
               role: item.role,
-              status: normalizeStatus(item.status || "applied"),
-              appliedAt: resolveCreatedAtForCreate(item.appliedAt),
+              status: normalizeStatus(item.status || "inbound"),
+              appliedAt: resolveAppliedAtForCreate(item.status || "inbound", item.appliedAt),
               lastContact: item.lastContact ?? null,
               followUpAt: item.followUpAt ?? null,
               notes: item.notes ?? null,
@@ -315,6 +974,8 @@ export class PrismaAdapter implements DatabaseAdapter {
               salaryMax: item.salaryMax ?? null,
               rating: item.rating ?? null,
               jobUrl: item.jobUrl ?? null,
+              resumeId: item.resumeId ?? null,
+              ...structuredApplicationData(item as unknown as Record<string, unknown>),
               ...sanitizeTriageFields({
                 companySize: item.companySize ?? null,
                 salaryBandMentioned: item.salaryBandMentioned ?? false,
@@ -344,20 +1005,11 @@ export class PrismaAdapter implements DatabaseAdapter {
     let succeeded = 0;
     let failed = 0;
 
-    // Process each delete independently — use deleteMany to avoid throwing on
-    // missing/unauthorized rows (returns count instead of P2025 error).
     for (const id of ids) {
       try {
-        const { count } = await prisma.application.deleteMany({
-          where: { id: nid(id), userId },
-        });
-        if (count > 0) {
-          results.push({ id, deleted: true });
-          succeeded++;
-        } else {
-          results.push({ id, deleted: false, error: "Not found or access denied" });
-          failed++;
-        }
+        await this.deleteApplication(id, userId);
+        results.push({ id, deleted: true });
+        succeeded++;
       } catch (e) {
         const msg = e instanceof Error ? e.message : "Unknown error";
         results.push({ id, deleted: false, error: msg });
@@ -378,9 +1030,15 @@ export class PrismaAdapter implements DatabaseAdapter {
     return !!app;
   }
 
-  async createContact(applicationId: string, data: CreateContactInput): Promise<ContactRecord> {
-    const row = await prisma.contact.create({
-      data: { applicationId: nid(applicationId), ...data },
+  async createContact(applicationId: string, userId: string, data: CreateContactInput): Promise<ContactRecord> {
+    const applicationNumericId = nid(applicationId);
+    const row = await prisma.$transaction(async (tx) => {
+      const application = await tx.application.findFirst({
+        where: { id: applicationNumericId, userId },
+        select: { id: true },
+      });
+      if (!application) throw new Error("not_found");
+      return tx.contact.create({ data: { applicationId: applicationNumericId, ...data } });
     });
     return mapContact(row);
   }
@@ -427,68 +1085,162 @@ export class PrismaAdapter implements DatabaseAdapter {
     return rows.map(mapDoc);
   }
 
+  async listDocumentsFiltered(
+    userId: string | null,
+    filter: ListDocumentsFilter,
+  ): Promise<Partial<DocumentRecord>[]> {
+    const where: Prisma.DocumentWhereInput = { ...userWhere(userId) };
+    if (filter.applicationId) where.applications = { some: { id: nid(filter.applicationId) } };
+    if (filter.documentType) where.documentType = filter.documentType;
+    if (filter.state) where.state = filter.state;
+    if (filter.submissionId) where.submissionId = nid(filter.submissionId);
+    if (filter.excludeSubmissionArtifacts) {
+      where.submissionId = null;
+      where.state = { notIn: ["submitted", "historical"] };
+    }
+    if (filter.orphaned === true) where.applications = { none: {} };
+    if (filter.orphaned === false) where.applications = { some: {} };
+    const pageSize = Math.max(1, Math.min(200, filter.pageSize ?? filter.limit ?? 50));
+    const page = Math.max(1, filter.page ?? 1);
+    const rows = await prisma.document.findMany({
+      where,
+      orderBy: { uploadedAt: "desc" },
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+      include: { applications: { select: { id: true, company: true, role: true } } },
+    });
+    return pickDocumentFields(rows.map(mapDoc), filter.fields);
+  }
+
   async getDocument(id: string, userId: string | null): Promise<DocumentRecord | null> {
     const row = await prisma.document.findFirst({
       where: { id: nid(id), ...userWhere(userId) },
+      include: { applications: { select: { id: true, company: true, role: true } } },
     });
     return row ? mapDoc(row) : null;
   }
 
-  async createDocument(userId: string, data: CreateDocumentInput): Promise<DocumentRecord> {
-    const { applicationIds, ...rest } = data;
-
-    // Verify all referenced applications belong to this user
-    let safeIds: number[] = [];
-    if (applicationIds.length > 0) {
-      const owned = await prisma.application.findMany({
-        where: { id: { in: applicationIds.map(nid) }, userId },
-        select: { id: true },
-      });
-      safeIds = owned.map((a) => a.id);
+  async updateDocumentMetadata(
+    id: string,
+    userId: string,
+    data: UpdateDocumentMetadataInput,
+  ): Promise<DocumentRecord> {
+    const documentId = nid(id);
+    const existing = await prisma.document.findFirst({ where: { id: documentId, userId } });
+    if (!existing) throw new Error("not_found");
+    const keys = Object.keys(data);
+    const stateOnly = keys.every((key) => key === "state");
+    const immutable = existing.submissionId !== null || existing.state === "submitted" || existing.state === "historical";
+    if (immutable) {
+      if (!stateOnly || (data.state !== "submitted" && data.state !== "historical")) {
+        throw new Error("submitted_document_immutable");
+      }
+    } else if (data.state === "submitted") {
+      throw new Error("submitted_state_reserved");
     }
-
-    const row = await prisma.document.create({
-      data: {
+    const changed = await prisma.document.updateMany({
+      where: {
+        id: documentId,
         userId,
-        ...rest,
-        applications: safeIds.length ? { connect: safeIds.map((id) => ({ id })) } : undefined,
+        submissionId: existing.submissionId,
+        state: existing.state,
       },
-      include: { applications: { select: { id: true, company: true, role: true } } },
+      data,
+    });
+    if (changed.count !== 1) throw new Error("submitted_document_immutable");
+    return (await this.getDocument(id, userId))!;
+  }
+
+  async createDocument(userId: string, data: CreateDocumentInput): Promise<DocumentRecord> {
+    const { applicationIds, submissionId, ...rest } = data;
+    if (submissionId || rest.state === "submitted") throw new Error("submitted_state_reserved");
+    const requestedApplicationIds = Array.from(new Set(applicationIds.map(nid)));
+    const row = await prisma.$transaction(async (tx) => {
+      const owned = requestedApplicationIds.length
+        ? await tx.application.findMany({
+            where: { id: { in: requestedApplicationIds }, userId },
+            select: { id: true },
+          })
+        : [];
+      if (owned.length !== requestedApplicationIds.length) throw new Error("invalid_applications");
+      return tx.document.create({
+        data: {
+          userId,
+          ...rest,
+          submissionId: null,
+          applications: requestedApplicationIds.length
+            ? { connect: requestedApplicationIds.map((id) => ({ id })) }
+            : undefined,
+        },
+        include: { applications: { select: { id: true, company: true, role: true } } },
+      });
     });
     return mapDoc(row);
   }
 
   async updateDocumentLinks(id: string, userId: string, applicationIds: string[]): Promise<DocumentRecord> {
-    const owned = await prisma.application.findMany({
-      where: { id: { in: applicationIds.map(nid) }, userId },
-      select: { id: true },
+    const documentId = nid(id);
+    const requestedApplicationIds = Array.from(new Set(applicationIds)).map(nid);
+    return prisma.$transaction(async (tx) => {
+      const locked = await tx.$queryRaw<Array<{ submissionId: number | null; state: string }>>`
+        SELECT "submissionId", "state"
+        FROM "Document"
+        WHERE "id" = ${documentId} AND "userId" = ${userId}
+        FOR UPDATE
+      `;
+      if (!locked.length) throw new Error("not_found");
+      if (locked[0].submissionId !== null || locked[0].state === "submitted" || locked[0].state === "historical") {
+        throw new Error("submitted_document_immutable");
+      }
+      const owned = await tx.application.findMany({
+        where: { id: { in: requestedApplicationIds }, userId },
+        select: { id: true },
+      });
+      if (owned.length !== requestedApplicationIds.length) throw new Error("invalid_applications");
+      const row = await tx.document.update({
+        where: { id: documentId, userId },
+        data: { applications: { set: owned.map((application) => ({ id: application.id })) } },
+        include: { applications: { select: { id: true, company: true, role: true } } },
+      });
+      return mapDoc(row);
     });
-
-    const row = await prisma.document.update({
-      where: { id: nid(id), userId },
-      data: { applications: { set: owned.map((a) => ({ id: a.id })) } },
-      include: { applications: { select: { id: true, company: true, role: true } } },
-    });
-    return mapDoc(row);
   }
 
   async renameDocument(id: string, userId: string, newName: string): Promise<DocumentRecord | null> {
-    const existing = await prisma.document.findFirst({ where: { id: nid(id), userId } });
-    if (!existing) return null;
-    const row = await prisma.document.update({
-      where: { id: nid(id), userId },
+    const documentId = nid(id);
+    const changed = await prisma.document.updateMany({
+      where: { id: documentId, userId, submissionId: null, state: { notIn: ["submitted", "historical"] } },
       data: { originalName: newName },
-      include: { applications: { select: { id: true, company: true, role: true } } },
     });
-    return mapDoc(row);
+    if (changed.count === 1) return this.getDocument(id, userId);
+    const existing = await prisma.document.findFirst({
+      where: { id: documentId, userId },
+      select: { submissionId: true, state: true },
+    });
+    if (!existing) return null;
+    throw new Error("submitted_document_immutable");
   }
 
   async deleteDocument(id: string, userId: string): Promise<DocumentRecord | null> {
-    const doc = await prisma.document.findFirst({ where: { id: nid(id), userId } });
-    if (!doc) return null;
-    await prisma.shareLink.deleteMany({ where: { userId, targetType: "document", targetId: id } });
-    await prisma.document.delete({ where: { id: nid(id), userId } });
-    return mapDoc(doc);
+    const documentId = nid(id);
+    return prisma.$transaction(async (tx) => {
+      const locked = await tx.$queryRaw<Array<{ submissionId: number | null; state: string }>>`
+        SELECT "submissionId", "state"
+        FROM "Document"
+        WHERE "id" = ${documentId} AND "userId" = ${userId}
+        FOR UPDATE
+      `;
+      if (!locked.length) return null;
+      if (locked[0].submissionId !== null || locked[0].state === "submitted" || locked[0].state === "historical") {
+        throw new Error("submitted_document_immutable");
+      }
+      const document = await tx.document.findFirstOrThrow({
+        where: { id: documentId, userId },
+      });
+      await tx.shareLink.deleteMany({ where: { userId, targetType: "document", targetId: id } });
+      await tx.document.delete({ where: { id: documentId, userId } });
+      return mapDoc(document);
+    });
   }
 
   // Users

--- a/lib/db/prisma-adapter.ts
+++ b/lib/db/prisma-adapter.ts
@@ -303,31 +303,49 @@ export class PrismaAdapter implements DatabaseAdapter {
 
   async updateApplication(id: string, userId: string, data: UpdateApplicationInput): Promise<ApplicationRecord> {
     const { expectedUpdatedAt, ...update } = data;
-    if (expectedUpdatedAt) {
-      const result = await prisma.application.updateMany({
-        where: { id: nid(id), userId, updatedAt: expectedUpdatedAt },
+    const applicationId = nid(id);
+    try {
+      if (expectedUpdatedAt) {
+        const result = await prisma.application.updateMany({
+          where: { id: applicationId, userId, updatedAt: expectedUpdatedAt },
+          data: {
+            ...update,
+            ...(update.status !== undefined ? { status: normalizeStatus(update.status) } : {}),
+          },
+        });
+        if (result.count !== 1) {
+          const current = await prisma.application.findFirst({
+            where: { id: applicationId, userId },
+            select: { id: true },
+          });
+          throw new Error(current ? "conflict" : "not_found");
+        }
+        const row = await prisma.application.findFirstOrThrow({
+          where: { id: applicationId, userId },
+          include: { contacts: true },
+        });
+        return mapApp(row);
+      }
+
+      const row = await prisma.application.update({
+        where: { id: applicationId, userId },
         data: {
           ...update,
           ...(update.status !== undefined ? { status: normalizeStatus(update.status) } : {}),
         },
-      });
-      if (result.count !== 1) throw new Error("conflict");
-      const row = await prisma.application.findFirstOrThrow({
-        where: { id: nid(id), userId },
         include: { contacts: true },
       });
       return mapApp(row);
+    } catch (error) {
+      if (error instanceof Error && (error.message === "conflict" || error.message === "not_found")) {
+        throw error;
+      }
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        if (error.code === "P2002") throw new Error("canonical_job_url_conflict");
+        if (error.code === "P2025") throw new Error("not_found");
+      }
+      throw error;
     }
-
-    const row = await prisma.application.update({
-      where: { id: nid(id), userId },
-      data: {
-        ...update,
-        ...(update.status !== undefined ? { status: normalizeStatus(update.status) } : {}),
-      },
-      include: { contacts: true },
-    });
-    return mapApp(row);
   }
 
   async deleteApplication(id: string, userId: string): Promise<void> {
@@ -1095,7 +1113,10 @@ export class PrismaAdapter implements DatabaseAdapter {
     filter: ListDocumentsFilter,
   ): Promise<Partial<DocumentRecord>[]> {
     const where: Prisma.DocumentWhereInput = { ...userWhere(userId) };
-    if (filter.applicationId) where.applications = { some: { id: nid(filter.applicationId) } };
+    const applicationPredicates: Prisma.DocumentWhereInput[] = [];
+    if (filter.applicationId) {
+      applicationPredicates.push({ applications: { some: { id: nid(filter.applicationId) } } });
+    }
     if (filter.documentType) where.documentType = filter.documentType;
     if (filter.state) where.state = filter.state;
     if (filter.submissionId) where.submissionId = nid(filter.submissionId);
@@ -1103,8 +1124,9 @@ export class PrismaAdapter implements DatabaseAdapter {
       where.submissionId = null;
       where.state = { notIn: ["submitted", "historical"] };
     }
-    if (filter.orphaned === true) where.applications = { none: {} };
-    if (filter.orphaned === false) where.applications = { some: {} };
+    if (filter.orphaned === true) applicationPredicates.push({ applications: { none: {} } });
+    if (filter.orphaned === false) applicationPredicates.push({ applications: { some: {} } });
+    if (applicationPredicates.length) where.AND = applicationPredicates;
     const pageSize = Math.max(1, Math.min(200, filter.pageSize ?? filter.limit ?? 50));
     const page = Math.max(1, filter.page ?? 1);
     const rows = await prisma.document.findMany({

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -17,6 +17,7 @@ export interface ApplicationRecord {
   salaryMax: number | null;
   rating: number | null;
   jobUrl: string | null;
+  canonicalJobUrl: string | null;
   resumeId: string | null;
   companySize: string | null;
   salaryBandMentioned: boolean;
@@ -26,6 +27,27 @@ export interface ApplicationRecord {
   autoRejected: boolean;
   autoRejectReason: string | null;
   archivedAt: Date | null;
+  workMode: string | null;
+  eligibleCountries: string[];
+  primaryLocations: string[];
+  officeDaysMin: number | null;
+  travelPercent: number | null;
+  visaSponsorship: boolean | null;
+  rightToWorkRequired: boolean | null;
+  timezoneOverlap: string | null;
+  salaryCurrency: string | null;
+  salaryPeriod: string | null;
+  salaryType: string | null;
+  atsName: string | null;
+  requisitionId: string | null;
+  jobCapturedAt: Date | null;
+  jobVerifiedAt: Date | null;
+  jobPostedAt: Date | null;
+  jobClosedAt: Date | null;
+  jobContentHash: string | null;
+  jobLiveness: string | null;
+  jobSummary: string | null;
+  currentStage: string | null;
   createdAt: Date;
   updatedAt: Date;
   contacts?: ContactRecord[];
@@ -49,8 +71,60 @@ export interface DocumentRecord {
   originalName: string;
   size: number;
   mimeType: string;
+  documentType: string;
+  state: string;
+  version: number;
+  contentHash: string | null;
+  source: string | null;
+  generatedAt: Date | null;
+  submittedAt: Date | null;
+  submissionId: string | null;
   uploadedAt: Date;
   applications?: ApplicationRef[];
+}
+
+export interface SubmissionAnswerRecord {
+  key?: string;
+  question: string;
+  answer: string;
+  kind?: "text" | "boolean" | "number" | "choice" | "salary" | "other";
+  sensitive?: boolean;
+}
+
+export interface ApplicationSubmissionRecord {
+  id: string;
+  userId: string;
+  applicationId: string;
+  idempotencyKey: string;
+  requestHash: string;
+  submittedAt: Date;
+  applicationUrl: string | null;
+  atsName: string | null;
+  requisitionId: string | null;
+  language: string | null;
+  answers: SubmissionAnswerRecord[];
+  candidateSalaryMin: number | null;
+  candidateSalaryMax: number | null;
+  candidateSalaryCurrency: string | null;
+  candidateSalaryPeriod: string | null;
+  candidateSalaryType: string | null;
+  candidateSalaryFlexible: boolean;
+  documentIds: string[];
+  createdAt: Date;
+  documents?: DocumentRecord[];
+}
+
+export interface ApplicationEventRecord {
+  id: string;
+  userId: string;
+  applicationId: string;
+  type: string;
+  idempotencyKey: string | null;
+  occurredAt: Date;
+  source: string | null;
+  actor: string | null;
+  metadata: Record<string, unknown> | null;
+  createdAt: Date;
 }
 
 export interface ApplicationRef {
@@ -94,7 +168,32 @@ export interface AuditLogRecord {
 
 // ── Input types (passed into adapter) ────────────────────────────────────────
 
-export interface CreateApplicationInput {
+export interface StructuredApplicationMetadataInput {
+  canonicalJobUrl?: string | null;
+  workMode?: string | null;
+  eligibleCountries?: string[];
+  primaryLocations?: string[];
+  officeDaysMin?: number | null;
+  travelPercent?: number | null;
+  visaSponsorship?: boolean | null;
+  rightToWorkRequired?: boolean | null;
+  timezoneOverlap?: string | null;
+  salaryCurrency?: string | null;
+  salaryPeriod?: string | null;
+  salaryType?: string | null;
+  atsName?: string | null;
+  requisitionId?: string | null;
+  jobCapturedAt?: Date | null;
+  jobVerifiedAt?: Date | null;
+  jobPostedAt?: Date | null;
+  jobClosedAt?: Date | null;
+  jobContentHash?: string | null;
+  jobLiveness?: string | null;
+  jobSummary?: string | null;
+  currentStage?: string | null;
+}
+
+export interface CreateApplicationInput extends StructuredApplicationMetadataInput {
   company: string;
   role: string;
   status: string;
@@ -119,7 +218,7 @@ export interface CreateApplicationInput {
   autoRejectReason?: string | null;
 }
 
-export interface UpdateApplicationInput {
+export interface UpdateApplicationInput extends StructuredApplicationMetadataInput {
   company?: string;
   role?: string;
   status?: string;
@@ -143,6 +242,7 @@ export interface UpdateApplicationInput {
   autoRejected?: boolean;
   autoRejectReason?: string | null;
   archivedAt?: Date | null;
+  expectedUpdatedAt?: Date;
 }
 
 export interface CreateContactInput {
@@ -182,6 +282,80 @@ export interface CreateDocumentInput {
   size: number;
   mimeType: string;
   applicationIds: string[];
+  documentType?: string;
+  state?: string;
+  version?: number;
+  contentHash?: string | null;
+  source?: string | null;
+  generatedAt?: Date | null;
+  submittedAt?: Date | null;
+  submissionId?: string | null;
+}
+
+export interface UpdateDocumentMetadataInput {
+  documentType?: string;
+  state?: string;
+  version?: number;
+  contentHash?: string | null;
+  source?: string | null;
+  generatedAt?: Date | null;
+  submittedAt?: Date | null;
+}
+
+export interface ListDocumentsFilter {
+  applicationId?: string;
+  documentType?: string;
+  state?: string;
+  submissionId?: string;
+  orphaned?: boolean;
+  excludeSubmissionArtifacts?: boolean;
+  fields?: string[];
+  limit?: number;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface RecordSubmissionInput {
+  applicationId: string;
+  idempotencyKey: string;
+  submittedAt: Date;
+  followUpAt?: Date | null;
+  applicationUrl?: string | null;
+  atsName?: string | null;
+  requisitionId?: string | null;
+  language?: string | null;
+  answers: SubmissionAnswerRecord[];
+  candidateSalaryMin?: number | null;
+  candidateSalaryMax?: number | null;
+  candidateSalaryCurrency?: string | null;
+  candidateSalaryPeriod?: string | null;
+  candidateSalaryType?: string | null;
+  candidateSalaryFlexible?: boolean;
+  documentIds: string[];
+  source?: string | null;
+  actor?: string | null;
+  dryRun?: boolean;
+  expectedUpdatedAt?: Date;
+}
+
+export interface RecordSubmissionResult {
+  replayed: boolean;
+  dryRun: boolean;
+  verified: boolean;
+  application: ApplicationRecord;
+  submission: ApplicationSubmissionRecord;
+  event: ApplicationEventRecord | null;
+  documents: DocumentRecord[];
+}
+
+export interface CreateApplicationEventInput {
+  type: string;
+  idempotencyKey?: string | null;
+  expectedUpdatedAt?: Date;
+  occurredAt: Date;
+  source?: string | null;
+  actor?: string | null;
+  metadata?: Record<string, unknown> | null;
 }
 
 // ── Pagination types ─────────────────────────────────────────────────────────
@@ -215,7 +389,7 @@ export interface ListApplicationsFilter {
   pageSize?: number;
 }
 
-export interface BatchUpsertItem {
+export interface BatchUpsertItem extends StructuredApplicationMetadataInput {
   id?: string;
   company?: string;
   role?: string;

--- a/lib/documents/__tests__/access.test.ts
+++ b/lib/documents/__tests__/access.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSubmissionDocument,
+  requiresSubmissionScopeForDocumentMutation,
+} from "../access";
+
+describe("submission document access policy", () => {
+  it("identifies linked, submitted, and historical artifacts as sensitive", () => {
+    expect(isSubmissionDocument({ submissionId: "submission-1", state: "current" })).toBe(true);
+    expect(isSubmissionDocument({ submissionId: null, state: "submitted" })).toBe(true);
+    expect(isSubmissionDocument({ submissionId: null, state: "historical" })).toBe(true);
+    expect(isSubmissionDocument({ submissionId: null, state: "current" })).toBe(false);
+  });
+
+  it("requires submission scope before entering a sensitive lifecycle state", () => {
+    const current = { submissionId: null, state: "current" };
+    expect(requiresSubmissionScopeForDocumentMutation(current, "submitted")).toBe(true);
+    expect(requiresSubmissionScopeForDocumentMutation(current, "historical")).toBe(true);
+    expect(requiresSubmissionScopeForDocumentMutation(current, "superseded")).toBe(false);
+  });
+
+  it("requires submission scope for same-state updates of immutable artifacts", () => {
+    expect(requiresSubmissionScopeForDocumentMutation({ submissionId: "submission-1", state: "submitted" }, "submitted"))
+      .toBe(true);
+    expect(requiresSubmissionScopeForDocumentMutation({ submissionId: null, state: "historical" }, "historical"))
+      .toBe(true);
+  });
+});

--- a/lib/documents/__tests__/upload.test.ts
+++ b/lib/documents/__tests__/upload.test.ts
@@ -60,6 +60,11 @@ describe("uploadDocument", () => {
       size: PDF_BYTES.length,
       mimeType: "application/pdf",
       applicationIds: ["app-1"],
+      documentType: "other",
+      state: "current",
+      version: 1,
+      contentHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+      source: "upload",
     });
   });
 

--- a/lib/documents/access.ts
+++ b/lib/documents/access.ts
@@ -1,0 +1,19 @@
+export interface SubmissionDocumentLike {
+  submissionId?: string | null;
+  state?: string | null;
+}
+
+export function isSubmissionDocument(document: SubmissionDocumentLike): boolean {
+  return Boolean(document.submissionId)
+    || document.state === "submitted"
+    || document.state === "historical";
+}
+
+export function requiresSubmissionScopeForDocumentMutation(
+  document: SubmissionDocumentLike,
+  requestedState?: string,
+): boolean {
+  return isSubmissionDocument(document)
+    || requestedState === "submitted"
+    || requestedState === "historical";
+}

--- a/lib/documents/service.ts
+++ b/lib/documents/service.ts
@@ -1,0 +1,19 @@
+import { deleteFile } from "@/lib/storage";
+import type { DatabaseAdapter } from "@/lib/db/adapter";
+import type { DocumentRecord } from "@/lib/db/types";
+
+/**
+ * Shared deletion path for REST and MCP. Database metadata is removed first so
+ * callers cannot access a document that is being deleted; storage deletion is
+ * idempotent and uses ignoreNotFound semantics.
+ */
+export async function deleteDocumentWithContent(
+  db: DatabaseAdapter,
+  id: string,
+  userId: string,
+): Promise<DocumentRecord | null> {
+  const document = await db.deleteDocument(id, userId);
+  if (!document) return null;
+  await deleteFile(document.filename);
+  return document;
+}

--- a/lib/documents/upload.ts
+++ b/lib/documents/upload.ts
@@ -1,9 +1,10 @@
 import crypto from "crypto";
 import { getDb } from "@/lib/db";
-import { uploadFile } from "@/lib/storage";
+import { deleteFile, uploadFile } from "@/lib/storage";
 import type { DocumentRecord } from "@/lib/db/types";
 
-export const MAX_DOCUMENT_UPLOAD_SIZE = 10 * 1024 * 1024; // 10 MB
+export const MAX_DOCUMENT_UPLOAD_SIZE = 10 * 1024 * 1024;
+export const MAX_DOCUMENT_BASE64_SIZE = Math.ceil(MAX_DOCUMENT_UPLOAD_SIZE / 3) * 4 + 4;
 export const ALLOWED_DOCUMENT_MIME_TYPES = [
   "application/pdf",
   "image/jpeg",
@@ -48,6 +49,9 @@ export type McpToolResponse = {
 
 export function decodeBase64Content(contentBase64: string): Buffer {
   const normalized = contentBase64.replace(/\s/g, "");
+  if (normalized.length > MAX_DOCUMENT_BASE64_SIZE) {
+    throw new DocumentUploadError("too_large", "File too large (max 10 MB)");
+  }
   if (!normalized || !/^[A-Za-z0-9+/]*={0,2}$/.test(normalized)) {
     throw new DocumentUploadError("invalid_base64", "Invalid base64 content");
   }
@@ -57,8 +61,22 @@ export function decodeBase64Content(contentBase64: string): Buffer {
   if (encoded.replace(/=+$/, "") !== normalized.replace(/=+$/, "")) {
     throw new DocumentUploadError("invalid_base64", "Invalid base64 content");
   }
-
   return decoded;
+}
+
+function matchesMimeSignature(buffer: Buffer, mimeType: string): boolean {
+  if (mimeType === "application/pdf") return buffer.subarray(0, 5).toString("ascii") === "%PDF-";
+  if (mimeType === "image/jpeg") {
+    return buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff;
+  }
+  if (mimeType === "image/png") {
+    return buffer.subarray(0, 8).equals(Buffer.from("89504e470d0a1a0a", "hex"));
+  }
+  if (mimeType === "image/webp") {
+    return buffer.subarray(0, 4).toString("ascii") === "RIFF"
+      && buffer.subarray(8, 12).toString("ascii") === "WEBP";
+  }
+  return false;
 }
 
 export async function uploadDocument({
@@ -71,25 +89,36 @@ export async function uploadDocument({
   if (buffer.length > MAX_DOCUMENT_UPLOAD_SIZE) {
     throw new DocumentUploadError("too_large", "File too large (max 10 MB)");
   }
-
   if (!ALLOWED_DOCUMENT_MIME_TYPES.includes(mimeType as (typeof ALLOWED_DOCUMENT_MIME_TYPES)[number])) {
     throw new DocumentUploadError(
       "unsupported_type",
       "Unsupported file type. Allowed: PDF, JPEG, PNG, WEBP",
     );
   }
+  if (!matchesMimeSignature(buffer, mimeType)) {
+    throw new DocumentUploadError("unsupported_type", "File bytes do not match the declared MIME type");
+  }
 
   const ext = MIME_TO_EXT[mimeType] || ".pdf";
   const storedFilename = `${crypto.randomUUID()}${ext}`;
   await uploadFile(storedFilename, buffer, mimeType);
-
-  return getDb().createDocument(userId, {
-    filename: storedFilename,
-    originalName: originalName.slice(0, 255),
-    size: buffer.length,
-    mimeType,
-    applicationIds,
-  });
+  try {
+    return await getDb().createDocument(userId, {
+      filename: storedFilename,
+      originalName: originalName.slice(0, 255),
+      size: buffer.length,
+      mimeType,
+      applicationIds,
+      documentType: "other",
+      state: "current",
+      version: 1,
+      contentHash: crypto.createHash("sha256").update(buffer).digest("hex"),
+      source: "upload",
+    });
+  } catch (error) {
+    await deleteFile(storedFilename).catch(() => {});
+    throw error;
+  }
 }
 
 export async function uploadDocumentContent(

--- a/lib/mcp-oauth.ts
+++ b/lib/mcp-oauth.ts
@@ -264,6 +264,8 @@ export async function verifyMcpAccessToken(
     userId: token.user.id,
     readScopeUserId: token.user.isAdmin ? null : token.user.id,
     user,
+    authType: "mcp_oauth",
+    scopes: token.scopes,
   };
 }
 
@@ -303,7 +305,7 @@ export function getOAuthMetadata(baseUrl: string) {
     grant_types_supported: ["authorization_code", "refresh_token"],
     token_endpoint_auth_methods_supported: ["client_secret_basic", "client_secret_post", "none"],
     code_challenge_methods_supported: ["S256"],
-    scopes_supported: ["mcp:tools"],
+    scopes_supported: ["mcp:tools", "mcp:submissions"],
   };
 }
 
@@ -312,7 +314,7 @@ export function getProtectedResourceMetadata(baseUrl: string) {
     resource: `${baseUrl}/api/mcp`,
     authorization_servers: [baseUrl],
     bearer_methods_supported: ["header"],
-    scopes_supported: ["mcp:tools"],
+    scopes_supported: ["mcp:tools", "mcp:submissions"],
     resource_name: "Nexus CRM MCP Server",
   };
 }

--- a/lib/mcp-oauth.ts
+++ b/lib/mcp-oauth.ts
@@ -20,6 +20,7 @@ export function getPublicBaseUrl(req: NextRequest): string {
 const AUTH_CODE_TTL_MS = 10 * 60 * 1000; // 10 minutes
 const ACCESS_TOKEN_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 const REFRESH_TOKEN_TTL_MS = 90 * 24 * 60 * 60 * 1000; // 90 days
+export const SENSITIVE_CONSENT_VERSION = 1;
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -33,6 +34,11 @@ function sha256Base64Url(data: string): string {
 
 function generateToken(prefix: string): string {
   return `${prefix}_${randomBytes(32).toString("hex")}`;
+}
+
+export function effectiveMcpScopes(scopes: string[], sensitiveConsentVersion: number): string[] {
+  if (sensitiveConsentVersion >= SENSITIVE_CONSENT_VERSION) return scopes;
+  return scopes.filter((scope) => scope !== "mcp:submissions");
 }
 
 // ── Dynamic Client Registration ──────────────────────────────────────────────
@@ -108,6 +114,7 @@ export async function createAuthCode(params: {
   redirectUri: string;
   codeChallenge: string;
   scopes: string[];
+  sensitiveConsentVersion?: number;
 }): Promise<string> {
   const code = randomBytes(32).toString("base64url");
   await prisma.mcpAuthCode.create({
@@ -118,6 +125,7 @@ export async function createAuthCode(params: {
       redirectUri: params.redirectUri,
       codeChallenge: params.codeChallenge,
       scopes: params.scopes,
+      sensitiveConsentVersion: params.sensitiveConsentVersion ?? 0,
       expiresAt: new Date(Date.now() + AUTH_CODE_TTL_MS),
     },
   });
@@ -155,6 +163,8 @@ export async function exchangeAuthCode(params: {
   const computedChallenge = sha256Base64Url(params.codeVerifier);
   if (computedChallenge !== authCode.codeChallenge) return null;
 
+  const grantedScopes = effectiveMcpScopes(authCode.scopes, authCode.sensitiveConsentVersion);
+
   // Issue tokens
   const accessToken = generateToken("mcp_at");
   const refreshToken = generateToken("mcp_rt");
@@ -164,7 +174,8 @@ export async function exchangeAuthCode(params: {
       tokenHash: sha256(accessToken),
       clientId: authCode.clientId,
       userId: authCode.userId,
-      scopes: authCode.scopes,
+      scopes: grantedScopes,
+      sensitiveConsentVersion: authCode.sensitiveConsentVersion,
       expiresAt: new Date(Date.now() + ACCESS_TOKEN_TTL_MS),
     },
   });
@@ -174,7 +185,8 @@ export async function exchangeAuthCode(params: {
       tokenHash: sha256(refreshToken),
       clientId: authCode.clientId,
       userId: authCode.userId,
-      scopes: authCode.scopes,
+      scopes: grantedScopes,
+      sensitiveConsentVersion: authCode.sensitiveConsentVersion,
       expiresAt: new Date(Date.now() + REFRESH_TOKEN_TTL_MS),
     },
   });
@@ -184,7 +196,7 @@ export async function exchangeAuthCode(params: {
     refresh_token: refreshToken,
     token_type: "Bearer",
     expires_in: Math.floor(ACCESS_TOKEN_TTL_MS / 1000),
-    scope: authCode.scopes.join(" "),
+    scope: grantedScopes.join(" "),
   };
 }
 
@@ -206,6 +218,7 @@ export async function exchangeRefreshToken(params: {
   // Rotate: delete old refresh token, issue new pair
   await prisma.mcpRefreshToken.delete({ where: { id: stored.id } });
 
+  const grantedScopes = effectiveMcpScopes(stored.scopes, stored.sensitiveConsentVersion);
   const newAccessToken = generateToken("mcp_at");
   const newRefreshToken = generateToken("mcp_rt");
 
@@ -214,7 +227,8 @@ export async function exchangeRefreshToken(params: {
       tokenHash: sha256(newAccessToken),
       clientId: stored.clientId,
       userId: stored.userId,
-      scopes: stored.scopes,
+      scopes: grantedScopes,
+      sensitiveConsentVersion: stored.sensitiveConsentVersion,
       expiresAt: new Date(Date.now() + ACCESS_TOKEN_TTL_MS),
     },
   });
@@ -224,7 +238,8 @@ export async function exchangeRefreshToken(params: {
       tokenHash: sha256(newRefreshToken),
       clientId: stored.clientId,
       userId: stored.userId,
-      scopes: stored.scopes,
+      scopes: grantedScopes,
+      sensitiveConsentVersion: stored.sensitiveConsentVersion,
       expiresAt: new Date(Date.now() + REFRESH_TOKEN_TTL_MS),
     },
   });
@@ -234,7 +249,7 @@ export async function exchangeRefreshToken(params: {
     refresh_token: newRefreshToken,
     token_type: "Bearer",
     expires_in: Math.floor(ACCESS_TOKEN_TTL_MS / 1000),
-    scope: stored.scopes.join(" "),
+    scope: grantedScopes.join(" "),
   };
 }
 
@@ -265,7 +280,7 @@ export async function verifyMcpAccessToken(
     readScopeUserId: token.user.isAdmin ? null : token.user.id,
     user,
     authType: "mcp_oauth",
-    scopes: token.scopes,
+    scopes: effectiveMcpScopes(token.scopes, token.sensitiveConsentVersion),
   };
 }
 

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -17,6 +17,8 @@ export type SessionAuthResult = {
   /** Use for read-only list/get operations. Null means global read access. */
   readScopeUserId: string | null;
   user: SessionUser;
+  authType?: "session" | "api_token" | "mcp_oauth";
+  scopes?: string[];
 };
 
 function parseAllowedEmails(): string[] {

--- a/openspec/changes/preserve-application-submission-package/.openspec.yaml
+++ b/openspec/changes/preserve-application-submission-package/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/openspec/changes/preserve-application-submission-package/design.md
+++ b/openspec/changes/preserve-application-submission-package/design.md
@@ -1,0 +1,76 @@
+## Context
+
+Nexus is the system of record for job opportunities, but the current model treats an application submission as a status change plus free-text notes. A submitted CV can be represented by a Reactive Resume ID or a loosely linked document, yet the exact submitted package is not immutable or queryable. MCP clients therefore perform read-modify-write note replacement and multiple calls that can partially succeed.
+
+The application and document data layer supports Prisma/PostgreSQL and Firestore through one adapter contract. The solution must preserve backend parity, user scoping, compatibility with existing records, and safe agent operation.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve exactly what was submitted and make it easy to recall for interviews.
+- Make submission recording atomic, idempotent, scoped, and read-back verified.
+- Separate advertised compensation from candidate expectations.
+- Replace overloaded booleans/free text with structured optional metadata while retaining legacy fields.
+- Make document retrieval token-efficient and lifecycle-aware.
+- Add an event timeline and deterministic healthchecks.
+- Make MCP create/update behavior consistent and safe under concurrent callers.
+
+**Non-Goals:**
+
+- Automatically submit applications to external ATS systems.
+- Delete historical documents automatically.
+- Store external credentials or application secrets in answers.
+- Remove legacy fields in this change.
+- Introduce an LLM dependency.
+
+## Decisions
+
+### Decision 1: ApplicationSubmission is a first-class immutable snapshot
+
+Each submission belongs to one application and user, stores submission metadata and a JSON answer array, and references the exact submitted documents. An idempotency key is unique per user. New submissions may be recorded for legitimate reapplications, but existing submissions are never overwritten.
+
+### Decision 2: Candidate expectation and advertised compensation remain separate
+
+Application fields retain advertised salary data with explicit currency, period, and compensation type. Submission records store the candidate's expectation as submitted. This prevents form answers from corrupting market data.
+
+### Decision 3: ApplicationEvent is append-only
+
+Events record status/stage changes, note additions, submissions, contacts, follow-ups, and operational changes. Notes remain for compatibility, but MCP clients use append-note/event operations instead of replacing a large notes blob.
+
+### Decision 4: Submitted document packages are immutable
+
+Documents gain type, state, version, hash, source, generated/submitted timestamps, and optional submission linkage. A document linked to a submission cannot be silently reclassified as a draft or superseded without an explicit metadata update; the submission retains its material IDs.
+
+### Decision 5: Backwards-compatible structured application metadata
+
+`remote` remains a compatibility field. New structured fields cover work mode, countries, locations, office days, travel, sponsorship, right-to-work, timezone overlap, ATS/requisition, JD timestamps/hash/liveness, current interview stage, and normalized summary.
+
+### Decision 6: Atomic submission recording lives in the adapter
+
+`recordApplicationSubmission` verifies ownership and document ownership, checks idempotency, creates the submission and event, updates application status/appliedAt/follow-up, and marks submitted documents in one backend-specific atomic operation where supported. The returned result includes the application, submission, materials, and verification status.
+
+### Decision 7: Optimistic concurrency is optional and fail-closed when supplied
+
+Updates may include `expectedUpdatedAt`. Prisma uses a conditional update and Firestore uses a transaction. A mismatch returns a conflict rather than overwriting newer data. `dryRun` validates and returns intended changes without mutation.
+
+### Decision 8: No arbitrary URL fetch in the initial implementation
+
+An MCP tool that fetches arbitrary URLs would introduce SSRF, redirect, DNS rebinding, and payload risks. Token-efficient upload is provided through document metadata/filtering and existing HTTP multipart upload; a future signed-upload capability may be added behind the storage abstraction. This is a deliberate security exception to the audit's URL-upload option, not an omitted requirement.
+
+## Risks / Trade-offs
+
+- [Large additive schema] → Keep fields optional, retain legacy fields, and add adapter parity tests.
+- [Sensitive answers] → Scope every query by user, cap lengths/counts, support a `sensitive` flag, and never expose answers through list tools unless requested.
+- [Firestore transaction complexity] → Use dedicated collections and transaction/batch operations; add mock-backed parity tests.
+- [Migration compatibility] → Add nullable columns/defaults, no destructive backfill, and derive `workMode` from legacy `remote` only in read paths when absent.
+- [MCP route size] → Extract shared schemas/helpers and keep list tools field-selectable.
+- [Idempotency collisions] → Scope keys by user and return the existing submission on exact retries.
+
+## Migration Plan
+
+1. Apply additive Prisma migration and regenerate the client.
+2. Deploy code that tolerates absent Firestore fields and collections.
+3. Existing applications remain unchanged; new creates default to inbound/no appliedAt.
+4. Optionally backfill document hashes and work mode asynchronously later.
+5. Rollback code safely; additive database objects may remain unused.

--- a/openspec/changes/preserve-application-submission-package/proposal.md
+++ b/openspec/changes/preserve-application-submission-package/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+Nexus can track an opportunity and attach files, but it cannot preserve an application submission as a first-class, immutable package. Submitted answers and candidate salary expectations are currently appended to notes, document versions have no lifecycle metadata, and MCP clients must coordinate several non-atomic calls to mark an application applied. This makes later interview recall, duplicate-safe automation, and reliable agent workflows unnecessarily difficult.
+
+## What Changes
+
+- Add structured application submission records with exact answers, candidate compensation expectations, submission metadata, idempotency, and immutable links to the submitted document package.
+- Add application event history for submissions, notes, stage changes, contacts, follow-ups, and other lifecycle events.
+- Add document type, state, version, hash, source, generation/submission timestamps, and submission linkage.
+- Add structured work-model, location/eligibility, compensation, ATS/requisition, JD snapshot, liveness, and interview-stage metadata.
+- Change new applications to default to `inbound` with no `appliedAt` until an explicit submission is recorded.
+- Make MCP create/update schemas symmetrical and add atomic submission, note append, event, healthcheck, duplicate-safe lookup/upsert, document filtering, and metadata tools.
+- Add optimistic concurrency, idempotency, dry-run validation, and verified mutation results.
+- Update REST/OpenAPI/LLM documentation and both Prisma and Firestore adapters.
+
+## Capabilities
+
+### New Capabilities
+
+- `application-submission-package`: Structured, immutable application submissions, answers, compensation expectations, and submitted materials.
+- `application-timeline-health`: Auditable application events and deterministic pipeline/submission healthchecks.
+- `document-lifecycle-metadata`: Typed, versioned, hashed, filterable document metadata with submission linkage.
+- `career-application-metadata`: Structured work model, location eligibility, compensation, ATS, JD snapshot, and stage metadata.
+- `mcp-career-operations`: Safe, idempotent, token-efficient MCP workflows for career application operations.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Database: additive Prisma migration and Firestore-compatible collections/fields.
+- Adapter contract: new submission, event, healthcheck, document filtering, metadata, and concurrency operations.
+- MCP: new tools and backwards-compatible optional fields; `create_application` default changes from applied to inbound.
+- REST/docs: application and document metadata contracts, submission/event routes, OpenAPI and LLM guide.
+- Existing records remain readable; legacy `remote` and salary fields remain available during migration.

--- a/openspec/changes/preserve-application-submission-package/specs/application-submission-package/spec.md
+++ b/openspec/changes/preserve-application-submission-package/specs/application-submission-package/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: Structured immutable submission snapshots
+Nexus SHALL persist each application submission as a first-class record owned by the same user as the application. A submission SHALL store the submitted-at timestamp, application URL and optional ATS/requisition/language metadata, the exact question/answer set, candidate compensation expectation, and the exact linked document IDs. Existing submission snapshots MUST NOT be overwritten.
+
+#### Scenario: Submitted application is recorded
+- **WHEN** an authenticated owner records an application submission with valid answers and owned document IDs
+- **THEN** Nexus creates one submission snapshot
+- **AND** returns the stored answers and resolved submitted materials on explicit retrieval
+
+#### Scenario: Another user references an application or document
+- **WHEN** a caller references an application or document they do not own
+- **THEN** Nexus rejects the operation without revealing whether the foreign record exists
+
+### Requirement: Atomic application transition
+Recording a submission SHALL atomically create the submission and submission event, update the application to `applied`, set `appliedAt`, optionally set `followUpAt`, and mark the submitted documents as submitted. A failed validation or persistence operation MUST leave all records unchanged.
+
+#### Scenario: Submission succeeds
+- **WHEN** all submission inputs pass validation
+- **THEN** the application, submission, event, and materials are updated as one operation
+- **AND** the response includes a successful verification summary
+
+#### Scenario: One submitted material is invalid
+- **WHEN** any referenced document is missing or not owned by the caller
+- **THEN** no submission, event, application update, or material state change is persisted
+
+### Requirement: Idempotent recording
+Submission recording SHALL accept a caller-provided idempotency key unique within the authenticated user's data. Retrying the same logical operation MUST return the existing submission without creating duplicate events or material changes.
+
+#### Scenario: Exact retry
+- **WHEN** a caller repeats a completed submission request using the same idempotency key
+- **THEN** Nexus returns the existing submission package
+- **AND** indicates that the operation was replayed
+
+### Requirement: Bounded answer metadata
+Each answer SHALL include a question and answer plus optional stable key, kind, and sensitive flag. Nexus SHALL enforce bounded counts and lengths and SHALL omit answer bodies from list operations unless explicitly requested.
+
+#### Scenario: Submission list is requested
+- **WHEN** a caller lists submissions without requesting answers
+- **THEN** Nexus returns submission summaries without answer bodies

--- a/openspec/changes/preserve-application-submission-package/specs/application-timeline-health/spec.md
+++ b/openspec/changes/preserve-application-submission-package/specs/application-timeline-health/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: Append-only application timeline
+Nexus SHALL preserve application lifecycle events as append-only records with event type, occurrence timestamp, optional actor/source, and bounded structured metadata. Events SHALL be scoped through application ownership.
+
+#### Scenario: Note is appended
+- **WHEN** an owner appends a note through the dedicated operation
+- **THEN** Nexus appends the text to the legacy notes field without replacing concurrent content
+- **AND** creates a corresponding timeline event
+
+#### Scenario: Status or stage changes
+- **WHEN** an application status or current stage changes
+- **THEN** a timeline event records the before and after values
+
+### Requirement: Optimistic concurrency
+Application mutations SHALL accept an optional expected update timestamp. When supplied, the mutation MUST fail with a conflict if the stored application changed after the caller read it.
+
+#### Scenario: Stale update
+- **WHEN** expectedUpdatedAt does not equal the stored updatedAt
+- **THEN** Nexus returns a conflict and leaves the record unchanged
+
+### Requirement: Dry-run validation
+Agent-facing compound mutations SHALL support a dry-run mode that validates ownership, limits, consistency, and intended changes without persisting data.
+
+#### Scenario: Dry-run submission
+- **WHEN** a valid submission request sets dryRun
+- **THEN** Nexus returns the planned changes and validation result
+- **AND** creates no submission, event, or material mutation
+
+### Requirement: Deterministic healthcheck
+Nexus SHALL calculate health findings without an LLM. The healthcheck SHALL identify inconsistent status/application dates, missing next action, incomplete submitted packages, missing submitted answers or materials, stale follow-ups, and orphan documents. Findings SHALL include stable codes, severity, affected record IDs, and suggested remediation.
+
+#### Scenario: Applied application lacks a submission package
+- **WHEN** an applied application has no submission record
+- **THEN** the healthcheck emits an `applied_without_submission` finding
+
+#### Scenario: Rejected application retains materials
+- **WHEN** a rejected application has linked documents
+- **THEN** Nexus treats the materials as historical
+- **AND** does not recommend deletion solely because the application is rejected

--- a/openspec/changes/preserve-application-submission-package/specs/career-application-metadata/spec.md
+++ b/openspec/changes/preserve-application-submission-package/specs/career-application-metadata/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Structured work and eligibility metadata
+Applications SHALL optionally store work mode, eligible countries, primary locations, minimum office days, travel percentage, sponsorship availability, right-to-work requirement, and timezone overlap. The legacy remote boolean SHALL remain compatible.
+
+#### Scenario: Legacy remote application is read
+- **WHEN** an application has `remote=true` and no work mode
+- **THEN** clients may derive remote work mode without mutating the stored record
+
+### Requirement: Separate compensation concepts
+Advertised compensation SHALL support currency, period, and compensation type. Candidate expectations SHALL be stored in the submission snapshot and MUST NOT overwrite advertised salary fields.
+
+#### Scenario: Candidate submits a minimum salary answer
+- **WHEN** a submission includes a candidate compensation expectation
+- **THEN** the value is stored on the submission
+- **AND** the advertised salary range remains unchanged
+
+### Requirement: ATS and JD provenance
+Applications SHALL optionally store ATS name, requisition ID, captured/verified/posted/closed timestamps, content hash, liveness state, and normalized job summary while retaining the raw job description snapshot.
+
+#### Scenario: Job description is refreshed
+- **WHEN** a caller records a verified JD snapshot
+- **THEN** Nexus stores verification metadata and hash separately from free-text notes
+
+### Requirement: Detailed process stage
+Applications SHALL optionally store the current interview stage independently of the broad pipeline status.
+
+#### Scenario: Technical interview is scheduled
+- **WHEN** the application remains broadly in `interview`
+- **THEN** currentStage can identify the specific technical interview step
+
+### Requirement: Safe creation defaults
+New applications SHALL default to `inbound` and SHALL have no `appliedAt` unless the caller explicitly records an applied status or submission.
+
+#### Scenario: MCP client creates a lead
+- **WHEN** status and appliedAt are omitted
+- **THEN** Nexus creates an inbound application with appliedAt null

--- a/openspec/changes/preserve-application-submission-package/specs/document-lifecycle-metadata/spec.md
+++ b/openspec/changes/preserve-application-submission-package/specs/document-lifecycle-metadata/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Typed document lifecycle metadata
+Each document SHALL support a type, lifecycle state, version, content hash, source, generation timestamp, submission timestamp, and optional submission linkage. Existing documents SHALL remain readable with safe defaults.
+
+#### Scenario: Existing untyped document is read
+- **WHEN** a legacy document lacks lifecycle fields
+- **THEN** Nexus returns it with compatible default metadata
+
+#### Scenario: Document becomes submitted
+- **WHEN** a submission package includes a document
+- **THEN** Nexus records its submitted state and timestamp
+- **AND** links it to that submission
+
+### Requirement: Consistent resolved links
+Single-document and list-document reads SHALL consistently return resolved application references subject to caller scope.
+
+#### Scenario: Single linked document is retrieved
+- **WHEN** an owner retrieves a linked document by ID
+- **THEN** the response includes the owned application's ID, company, and role
+
+### Requirement: Token-efficient document listing
+Document listing SHALL support pagination, filtering by application, type, state, submission linkage, and orphan status, plus field selection and bounded limits.
+
+#### Scenario: Agent lists submitted CVs for one application
+- **WHEN** filters specify application ID, type `cv`, and state `submitted`
+- **THEN** only matching documents are returned
+- **AND** large binary content is not included
+
+### Requirement: Historical preservation
+Nexus SHALL support `draft`, `current`, `submitted`, `superseded`, `historical`, and `orphaned` lifecycle states. Terminal application status MUST NOT automatically delete documents.
+
+#### Scenario: Application is rejected
+- **WHEN** a linked application's status changes to rejected
+- **THEN** submitted materials remain retrievable for later recall

--- a/openspec/changes/preserve-application-submission-package/specs/document-lifecycle-metadata/spec.md
+++ b/openspec/changes/preserve-application-submission-package/specs/document-lifecycle-metadata/spec.md
@@ -12,6 +12,11 @@ Each document SHALL support a type, lifecycle state, version, content hash, sour
 - **THEN** Nexus records its submitted state and timestamp
 - **AND** links it to that submission
 
+#### Scenario: Submitted document resists reclassification
+- **WHEN** a caller attempts to change a submitted or historical document to `draft` or `superseded`
+- **THEN** Nexus rejects the reclassification
+- **AND** preserves the submission linkage, submitted timestamp, and original material identity
+
 ### Requirement: Consistent resolved links
 Single-document and list-document reads SHALL consistently return resolved application references subject to caller scope.
 

--- a/openspec/changes/preserve-application-submission-package/specs/mcp-career-operations/spec.md
+++ b/openspec/changes/preserve-application-submission-package/specs/mcp-career-operations/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: Symmetric application mutation tools
+MCP create, update, and batch-upsert tools SHALL expose the same applicable application metadata fields and validation rules. Create SHALL default to inbound/no applied date.
+
+#### Scenario: Agent moves from discovery to application
+- **WHEN** the agent creates an inbound lead and later records a submission
+- **THEN** no intermediate operation falsely marks the lead applied
+
+### Requirement: Atomic submission tool
+MCP SHALL expose `record_application_submission` with structured answers, candidate expectation, material IDs, submitted/follow-up timestamps, idempotency, dry-run, and verification output.
+
+#### Scenario: Agent records final application package
+- **WHEN** the tool succeeds
+- **THEN** one response returns the updated application, immutable submission summary, resolved materials, event, and verification checks
+
+### Requirement: Dedicated retrieval and append tools
+MCP SHALL expose tools to list/get submissions, append notes, add/list events, run healthchecks, and get an interview-recall package. List tools SHALL exclude large fields by default.
+
+#### Scenario: Interview preparation is requested
+- **WHEN** an agent requests the application's recall package
+- **THEN** Nexus returns the job snapshot, submitted answers, candidate expectation, exact submitted materials, contacts, and timeline in one bounded response
+
+### Requirement: Duplicate-safe application intake
+MCP SHALL support exact canonical job URL lookup and idempotent create-or-update behavior without fuzzy company matching.
+
+#### Scenario: Same ATS URL is imported again
+- **WHEN** a caller upserts an application with a canonical URL already owned by the user
+- **THEN** Nexus updates or returns that application instead of creating a duplicate
+
+### Requirement: Structured errors and verification
+Agent-facing tools SHALL return stable error codes for validation, not found/access denied, conflict, and duplicate/idempotent replay. Successful mutations SHALL include verification data sufficient for read-back confirmation.
+
+#### Scenario: Concurrency conflict
+- **WHEN** an update carries a stale expectedUpdatedAt
+- **THEN** the tool returns a stable `conflict` code and no mutation
+
+### Requirement: MCP operational health
+MCP SHALL expose a lightweight health tool reporting server version, active database provider, and capability availability without exposing secrets or user data.
+
+#### Scenario: Agent checks prerequisites
+- **WHEN** the health tool is called by an authenticated user
+- **THEN** it reports usable capabilities and backend identity without credentials
+
+### Requirement: Safe document ergonomics
+MCP SHALL expose filtered document listing and metadata updates. The server MUST NOT fetch arbitrary caller-provided URLs unless a separately specified SSRF-safe upload design is implemented.
+
+#### Scenario: Agent needs a submitted CV
+- **WHEN** it filters documents by application, type, and state
+- **THEN** the matching metadata is returned without requiring a full unfiltered document dump

--- a/openspec/changes/preserve-application-submission-package/tasks.md
+++ b/openspec/changes/preserve-application-submission-package/tasks.md
@@ -1,0 +1,56 @@
+## 1. Contracts and failing tests
+
+- [x] 1.1 Add failing tests for inbound/no-appliedAt creation defaults and create/update schema parity
+- [x] 1.2 Add failing adapter contract tests for structured application metadata
+- [x] 1.3 Add failing tests for submission idempotency, ownership, answer limits, exact material linkage, and atomic status/follow-up updates
+- [x] 1.4 Add failing tests for append-only events, note append, optimistic concurrency, and dry-run validation
+- [x] 1.5 Add failing tests for document lifecycle metadata and filtering
+- [x] 1.6 Add failing tests for deterministic healthcheck findings and duplicate-safe URL lookup
+
+## 2. Persistence and migration
+
+- [x] 2.1 Add additive Prisma application/document fields and ApplicationSubmission/ApplicationEvent models
+- [x] 2.2 Add SQL migration with indexes, ownership constraints, idempotency uniqueness, and cascading relations
+- [x] 2.3 Extend shared database types and adapter interface
+- [x] 2.4 Implement Prisma adapter operations and transactions
+- [x] 2.5 Implement Firestore fields, collections, transactions, filters, and parity tests
+- [x] 2.6 Generate Prisma client and validate schema/migration
+
+## 3. Application metadata and lifecycle
+
+- [x] 3.1 Default new applications to inbound and leave appliedAt null
+- [x] 3.2 Add structured work, location, compensation, ATS, JD, liveness, and interview-stage metadata to create/update/batch flows
+- [x] 3.3 Add append-note and application-event use cases
+- [x] 3.4 Add optimistic concurrency and dry-run behavior
+- [x] 3.5 Add exact canonical-job-URL lookup and duplicate-safe upsert
+
+## 4. Submission packages
+
+- [x] 4.1 Implement structured ApplicationSubmission and answer validation
+- [x] 4.2 Implement atomic/idempotent submission recording and read-back verification
+- [x] 4.3 Implement list/get submission operations with answers excluded by default from list results
+- [x] 4.4 Link and mark exact submitted materials without mutating historical packages
+
+## 5. Documents and healthchecks
+
+- [x] 5.1 Add document type/state/version/hash/source/timestamp metadata
+- [x] 5.2 Add filtered/paginated/field-selectable document listing and consistent application links on get
+- [x] 5.3 Add deterministic pipeline healthcheck for next action, submission package, answers, materials, status/date consistency, and orphan documents
+- [x] 5.4 Preserve rejected-application materials as historical rather than auto-deleting
+
+## 6. MCP, REST, and documentation
+
+- [x] 6.1 Make create/update MCP schemas symmetrical and expose structured metadata
+- [x] 6.2 Add MCP tools for record/list/get submission, append note, add/list events, healthcheck, duplicate lookup/upsert, document metadata/filtering
+- [x] 6.3 Add dry-run/idempotency/concurrency arguments and structured error/verification responses
+- [x] 6.4 Add REST submission/event routes and document filters
+- [x] 6.5 Update OpenAPI, llm.txt, README, and MCP tool documentation
+
+## 7. Verification and delivery
+
+- [ ] 7.1 Run Prisma validation/generation and migration checks *(schema/client validation passed; live PostgreSQL apply blocked because Docker daemon is unavailable)*
+- [x] 7.2 Run the full Vitest suite and confirm new tests failed before implementation and pass afterward
+- [x] 7.3 Run ESLint and production build, comparing against baseline warnings
+- [x] 7.4 Run strict OpenSpec validation
+- [ ] 7.5 Run independent security/code review and address findings
+- [ ] 7.6 Open PR, request CodeRabbit, address all actionable comments, wait for green CI, and merge

--- a/openspec/changes/preserve-application-submission-package/tasks.md
+++ b/openspec/changes/preserve-application-submission-package/tasks.md
@@ -52,5 +52,5 @@
 - [x] 7.2 Run the full Vitest suite and confirm new tests failed before implementation and pass afterward
 - [x] 7.3 Run ESLint and production build, comparing against baseline warnings
 - [x] 7.4 Run strict OpenSpec validation
-- [ ] 7.5 Run independent security/code review and address findings
-- [ ] 7.6 Open PR, request CodeRabbit, address all actionable comments, wait for green CI, and merge
+- [x] 7.5 Run independent security/code review and address findings
+- [ ] 7.6 Open PR, request CodeRabbit, address all actionable comments, wait for green CI, and merge *(PR #127 open; actionable Codex findings addressed; CI and GitGuardian green; merge pending)*

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,13 +60,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -75,9 +75,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -85,21 +85,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -116,14 +116,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -133,14 +133,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -160,9 +160,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -170,29 +170,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -202,9 +202,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -212,9 +212,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -222,9 +222,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -232,27 +232,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -271,9 +271,9 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.0.tgz",
-      "integrity": "sha512-TgUkdp71C9pIbBcHudc+gXZnihEDOjUAmXO1VO4HHGES7QLZcShR0stfKIxLSNIYx2fqhmJChOjm/wkF8wv4gA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.7.tgz",
+      "integrity": "sha512-ppj9ouYku+RX0ljtgZd+KMO5mkM2bCqg8H2PYAFWnLsHEIKIdRojqbJ2i3eVHrisuxy7nOFCmngTDdWtUCdXUQ==",
       "license": "MIT",
       "dependencies": {
         "core-js-pure": "^3.48.0"
@@ -283,33 +283,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -317,121 +317,151 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@better-auth/core": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.5.4.tgz",
-      "integrity": "sha512-k5AdwPRQETZn0vdB60EB9CDxxfllpJXKqVxTjyXIUSRz7delNGlU0cR/iRP3VfVJwvYR1NbekphBDNo+KGoEzQ==",
+      "version": "1.6.23",
+      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.23.tgz",
+      "integrity": "sha512-beEhOs0uVeOxYOZKUfIEBd/nQV2Bd4/6wyLxZ0OFkn6CMTK2Vi+hXuZLnyPBeB6RdHpebEoJWiHqwHxBIxgPDQ==",
       "license": "MIT",
       "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.39.0",
         "@standard-schema/spec": "^1.1.0",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
-        "@better-auth/utils": "0.3.1",
-        "@better-fetch/fetch": "1.1.21",
+        "@better-auth/utils": "0.4.2",
+        "@better-fetch/fetch": "1.3.1",
         "@cloudflare/workers-types": ">=4",
-        "better-call": "1.3.2",
+        "@opentelemetry/api": "^1.9.0",
+        "better-call": "1.3.7",
         "jose": "^6.1.0",
-        "kysely": "^0.28.5",
+        "kysely": "^0.28.5 || ^0.29.0",
         "nanostores": "^1.0.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
           "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
         }
       }
     },
     "node_modules/@better-auth/drizzle-adapter": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.5.4.tgz",
-      "integrity": "sha512-4M4nMAWrDd3TmpV6dONkJjybBVKRZghe5Oj0NNyDEoXubxastQdO7Sb5B54I1rTx5yoMgsqaB+kbJnu/9UgjQg==",
+      "version": "1.6.23",
+      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.23.tgz",
+      "integrity": "sha512-2+/PTVfIP9E7iz6af8TB3lhnowHUj9ljC66kECmHaFEdUqPgzHoWux9epotKwO7XDg2ui4ttWQ8CMeNFLvQeKQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "1.5.4",
-        "@better-auth/utils": "^0.3.0",
-        "drizzle-orm": ">=0.41.0"
+        "@better-auth/core": "^1.6.23",
+        "@better-auth/utils": "0.4.2",
+        "drizzle-orm": "^0.45.2"
+      },
+      "peerDependenciesMeta": {
+        "drizzle-orm": {
+          "optional": true
+        }
       }
     },
     "node_modules/@better-auth/kysely-adapter": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.5.4.tgz",
-      "integrity": "sha512-DPww7rIfz6Ed7dZlJSW9xMQ42VKaJLB5Cs+pPqd+UHKRyighKjf3VgvMIcAdFPc4olQ0qRHo3+ZJhFlBCxRhxA==",
+      "version": "1.6.23",
+      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.23.tgz",
+      "integrity": "sha512-zbNJsMbG09exfkGyvFqBLLqWoMPAUWjxCuUnEK5AsjbYoZeIjj/QGZgdf4CapVWryKxjA9Q6Jlr6fbiPpC3VAg==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "1.5.4",
-        "@better-auth/utils": "^0.3.0",
-        "kysely": "^0.27.0 || ^0.28.0"
+        "@better-auth/core": "^1.6.23",
+        "@better-auth/utils": "0.4.2",
+        "kysely": "^0.28.17 || ^0.29.0"
+      },
+      "peerDependenciesMeta": {
+        "kysely": {
+          "optional": true
+        }
       }
     },
     "node_modules/@better-auth/memory-adapter": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.5.4.tgz",
-      "integrity": "sha512-iiWYut9rbQqiAsgRBtj6+nxanwjapxRgpIJbiS2o81h7b9iclE0AiDA0Foes590gdFQvskNauZcCpuF8ytxthg==",
+      "version": "1.6.23",
+      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.23.tgz",
+      "integrity": "sha512-krIiR0pIVkaKlAzm690n5bcMW4NGbqeMg0HQSD9fz/KcQF/eWLqcq9gG/BhHTj2i/y96qH+W5JWPmaSOS5iTgQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "1.5.4",
-        "@better-auth/utils": "^0.3.0"
+        "@better-auth/core": "^1.6.23",
+        "@better-auth/utils": "0.4.2"
       }
     },
     "node_modules/@better-auth/mongo-adapter": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.5.4.tgz",
-      "integrity": "sha512-ArzJN5Obk6i6+vLK1HpPzLIcsjxZYXPPUvxVU8eyU5HyoUT2MlswWfPQ8UJAKPn0iq/T4PVp/wZcQMhWk1tuNA==",
+      "version": "1.6.23",
+      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.23.tgz",
+      "integrity": "sha512-7+QdevitGlKBbP6JbiSk5SBnzPsKV/mDrQBGBn8hwByQLeJwqpqbuBPw7ZI8vzUlFfAAnyFiqwP3Eb8mxnp7pA==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "1.5.4",
-        "@better-auth/utils": "^0.3.0",
+        "@better-auth/core": "^1.6.23",
+        "@better-auth/utils": "0.4.2",
         "mongodb": "^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "mongodb": {
+          "optional": true
+        }
       }
     },
     "node_modules/@better-auth/prisma-adapter": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.5.4.tgz",
-      "integrity": "sha512-ZQTbcBopw/ezjjbNFsfR3CRp0QciC4tJCarAnB5G9fZtUYbDjfY0vZOxIRmU4kI3x755CXQpGqTrkwmXaMRa3w==",
+      "version": "1.6.23",
+      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.23.tgz",
+      "integrity": "sha512-2qSdzidq4tkb1eS5TTqb4Nzg0mdZWm3Qky9SYeXeb8PpVQbC2sxqJhEM5mK7y12uU6I8hc64wO9f7AFVNL+6UQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "1.5.4",
-        "@better-auth/utils": "^0.3.0",
+        "@better-auth/core": "^1.6.23",
+        "@better-auth/utils": "0.4.2",
         "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
         "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@prisma/client": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        }
       }
     },
     "node_modules/@better-auth/telemetry": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.5.4.tgz",
-      "integrity": "sha512-mGXTY7Ecxo7uvlMr6TFCBUvlH0NUMOeE9LKgPhG4HyhBN6VfCEg/DD9PG0Z2IatmMWQbckkt7ox5A0eBpG9m5w==",
+      "version": "1.6.23",
+      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.23.tgz",
+      "integrity": "sha512-/R2Kb+z2BpDOOWwVHqOk+c0VNpuwfCv4Hp5Yr9003WIZPax/zyNraGLB9CFE8qF2gZW8Dsz419k4I8CPrGzpDA==",
       "license": "MIT",
-      "dependencies": {
-        "@better-auth/utils": "0.3.1",
-        "@better-fetch/fetch": "1.1.21"
-      },
       "peerDependencies": {
-        "@better-auth/core": "1.5.4"
+        "@better-auth/core": "^1.6.23",
+        "@better-auth/utils": "0.4.2",
+        "@better-fetch/fetch": "1.3.1"
       }
     },
     "node_modules/@better-auth/utils": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.3.1.tgz",
-      "integrity": "sha512-+CGp4UmZSUrHHnpHhLPYu6cV+wSUSvVbZbNykxhUDocpVNTo9uFFxw/NqJlh1iC4wQ9HKKWGCKuZ5wUgS0v6Kg==",
-      "license": "MIT"
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.4.2.tgz",
+      "integrity": "sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^2.0.1"
+      }
     },
     "node_modules/@better-fetch/fetch": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
-      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.3.1.tgz",
+      "integrity": "sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==",
+      "license": "MIT"
     },
     "node_modules/@dnd-kit/accessibility": {
       "version": "3.1.1",
@@ -487,21 +517,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
-      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -509,9 +539,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1212,56 +1242,34 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@formatjs/ecma402-abstract": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-3.1.1.tgz",
-      "integrity": "sha512-jhZbTwda+2tcNrs4kKvxrPLPjx8QsBCLCUgrrJ/S+G9YrGHWLhAyFMMBHJBnBoOwuLHd7L14FgYudviKaxkO2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/fast-memoize": "3.1.0",
-        "@formatjs/intl-localematcher": "0.8.1",
-        "decimal.js": "^10.6.0",
-        "tslib": "^2.8.1"
-      }
-    },
     "node_modules/@formatjs/fast-memoize": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.0.tgz",
-      "integrity": "sha512-b5mvSWCI+XVKiz5WhnBCY3RJ4ZwfjAidU0yVlKa3d3MSgKmH1hC3tBGEAtYyN5mqL7N0G5x0BOUYyO8CEupWgg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.1"
-      }
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.7.tgz",
+      "integrity": "sha512-zXfhLpvA6T7+efdt9JLbBwZ00tT7NsBMDVnDu8rpHeNNv8KfRZAMo2gkG0k9lK/Nzc//3kJ9pImsfuJxk3KhUA==",
+      "license": "MIT"
     },
     "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.1.tgz",
-      "integrity": "sha512-sSDmSvmmoVQ92XqWb499KrIhv/vLisJU8ITFrx7T7NZHUmMY7EL9xgRowAosaljhqnj/5iufG24QrdzB6X3ItA==",
+      "version": "3.5.14",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.14.tgz",
+      "integrity": "sha512-jDvgtoLqe3U6yzoBlToMTkWBe38qSi7LN7kFlnXzd5ig8nn+4tSlED0xtEtdYakZVZGJJY2rW1D5xS3BFZh6kA==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "3.1.1",
-        "@formatjs/icu-skeleton-parser": "2.1.1",
-        "tslib": "^2.8.1"
+        "@formatjs/icu-skeleton-parser": "2.1.11"
       }
     },
     "node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.1.tgz",
-      "integrity": "sha512-PSFABlcNefjI6yyk8f7nyX1DC7NHmq6WaCHZLySEXBrXuLOB2f935YsnzuPjlz+ibhb9yWTdPeVX1OVcj24w2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "3.1.1",
-        "tslib": "^2.8.1"
-      }
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.11.tgz",
+      "integrity": "sha512-j8cUmOJzVgkHuS0QiQ6ga76UIoLOFSAMWhs7aZJztH3aAdCOAE6vpC8KVvFB4cU10ON0y2/5oOVmPJ43s2lTwA==",
+      "license": "MIT"
     },
     "node_modules/@formatjs/intl-localematcher": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.8.1.tgz",
-      "integrity": "sha512-xwEuwQFdtSq1UKtQnyTZWC+eHdv7Uygoa+H2k/9uzBVQjDyp9r20LNDNKedWXll7FssT3GRHvqsdJGYSUWqYFA==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.8.12.tgz",
+      "integrity": "sha512-5H3r5ZJ2jZqHEv9K343lvHmeMDKMxssawAVD2H4J9xtu0ZXb6MlNxwLqdwBxJSHFU0C24KSZnffgmAi+59mK4A==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/fast-memoize": "3.1.0",
-        "tslib": "^2.8.1"
+        "@formatjs/fast-memoize": "3.1.7"
       }
     },
     "node_modules/@google-cloud/firestore": {
@@ -1313,9 +1321,9 @@
       }
     },
     "node_modules/@google-cloud/storage": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.19.0.tgz",
-      "integrity": "sha512-n2FjE7NAOYyshogdc7KQOl/VZb4sneqPjWouSyia9CMDdMhRX5+RIbqalNmC7LOLzuLAN89VlF2HvG8na9G+zQ==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.21.0.tgz",
+      "integrity": "sha512-l+IFTkd+6Y5LoAuXyYCKNAKtw/Ci+rAMqgdTB1jv4iZiLhw0rtq+0qjIRbBizXkNzEFmXiXUW0H7sZQQvk1ffA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/paginator": "^5.0.0",
@@ -1331,17 +1339,16 @@
         "mime": "^3.0.0",
         "p-limit": "^3.0.1",
         "retry-request": "^7.0.0",
-        "teeny-request": "^9.0.0",
-        "uuid": "^8.0.0"
+        "teeny-request": "^9.0.0"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
-      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -1391,9 +1398,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -2128,16 +2135,6 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
-    "node_modules/@mongodb-js/saslprep": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.6.tgz",
-      "integrity": "sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "sparse-bitfield": "^3.0.3"
-      }
-    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -2319,6 +2316,18 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2377,20 +2386,19 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/@oxc-project/runtime": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.115.0.tgz",
-      "integrity": "sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==",
-      "devOptional": true,
-      "license": "MIT",
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "license": "Apache-2.0",
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": ">=14"
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.115.0.tgz",
-      "integrity": "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==",
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
       "devOptional": true,
       "license": "MIT",
       "funding": {
@@ -2693,9 +2701,9 @@
       }
     },
     "node_modules/@parcel/watcher/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2737,60 +2745,66 @@
       }
     },
     "node_modules/@prisma/config": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.2.tgz",
-      "integrity": "sha512-kadBGDl+aUswv/zZMk9Mx0C8UZs1kjao8H9/JpI4Wh4SHZaM7zkTwiKn/iFLfRg+XtOAo/Z/c6pAYhijKl0nzQ==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.3.tgz",
+      "integrity": "sha512-CBPT44BjlQxEt8kiMEauji2WHTDoVBOKl7UlewXmUgBPnr/oPRZC3psci5chJnYmH0ivEIog2OU9PGWoki3DLQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "c12": "3.1.0",
         "deepmerge-ts": "7.1.5",
-        "effect": "3.18.4",
+        "effect": "3.21.0",
         "empathic": "2.0.0"
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.2.tgz",
-      "integrity": "sha512-lFnEZsLdFLmEVCVNdskLDCL8Uup41GDfU0LUfquw+ercJC8ODTuL0WNKgOKmYxCJVvFwf0OuZBzW99DuWmoH2A==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.3.tgz",
+      "integrity": "sha512-ljkJ+SgpXNktLG0Q/n4JGYCkKf0f8oYLyjImS2I8e2q2WCfdRRtWER062ZV/ixaNP2M2VKlWXVJiGzZaUgbKZw==",
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.2.tgz",
-      "integrity": "sha512-TTkJ8r+uk/uqczX40wb+ODG0E0icVsMgwCTyTHXehaEfb0uo80M9g1aW1tEJrxmFHeOZFXdI2sTA1j1AgcHi4A==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.3.tgz",
+      "integrity": "sha512-RSYxtlYFl5pJ8ZePgMv0lZ9IzVCOdTPOegrs2qcbAEFrBI1G33h6wyC9kjQvo0DnYEhEVY0X4LsuFHXLKQk88g==",
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.19.2",
+        "@prisma/debug": "6.19.3",
         "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
-        "@prisma/fetch-engine": "6.19.2",
-        "@prisma/get-platform": "6.19.2"
+        "@prisma/fetch-engine": "6.19.3",
+        "@prisma/get-platform": "6.19.3"
       }
     },
     "node_modules/@prisma/engines-version": {
       "version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7.tgz",
       "integrity": "sha512-03bgb1VD5gvuumNf+7fVGBzfpJPjmqV423l/WxsWk2cNQ42JD0/SsFBPhN6z8iAvdHs07/7ei77SKu7aZfq8bA==",
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.2.tgz",
-      "integrity": "sha512-h4Ff4Pho+SR1S8XerMCC12X//oY2bG3Iug/fUnudfcXEUnIeRiBdXHFdGlGOgQ3HqKgosTEhkZMvGM9tWtYC+Q==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.3.tgz",
+      "integrity": "sha512-tKtl/qco9Nt7LU5iKhpultD8O4vMCZcU2CHjNTnRrL1QvSUr5W/GcyFPjNL87GtRrwBc7ubXXD9xy4EvLvt8JA==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.19.2",
+        "@prisma/debug": "6.19.3",
         "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
-        "@prisma/get-platform": "6.19.2"
+        "@prisma/get-platform": "6.19.3"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.2.tgz",
-      "integrity": "sha512-PGLr06JUSTqIvztJtAzIxOwtWKtJm5WwOG6xpsgD37Rc84FpfUBGLKz65YpJBGtkRQGXTYEFie7pYALocC3MtA==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.3.tgz",
+      "integrity": "sha512-xFj1VcJ1N3MKooOQAGO0W5tsd0W2QzIvW7DD7c/8H14Zmp4jseeWAITm+w2LLoLrlhoHdPPh0NMZ8mfL6puoHA==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.19.2"
+        "@prisma/debug": "6.19.3"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -2808,41 +2822,33 @@
       "optional": true
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause",
       "optional": true
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause",
       "optional": true
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause",
-      "optional": true
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
       "license": "BSD-3-Clause",
       "optional": true
     },
@@ -2861,9 +2867,9 @@
       "optional": true
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
       "license": "BSD-3-Clause",
       "optional": true
     },
@@ -3042,9 +3048,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.9.tgz",
-      "integrity": "sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
       "cpu": [
         "arm64"
       ],
@@ -3059,9 +3065,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.9.tgz",
-      "integrity": "sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
       "cpu": [
         "arm64"
       ],
@@ -3076,9 +3082,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.9.tgz",
-      "integrity": "sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
       "cpu": [
         "x64"
       ],
@@ -3093,9 +3099,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.9.tgz",
-      "integrity": "sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
       "cpu": [
         "x64"
       ],
@@ -3110,9 +3116,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.9.tgz",
-      "integrity": "sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
       "cpu": [
         "arm"
       ],
@@ -3127,9 +3133,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.9.tgz",
-      "integrity": "sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
       "cpu": [
         "arm64"
       ],
@@ -3144,9 +3150,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.9.tgz",
-      "integrity": "sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
       "cpu": [
         "arm64"
       ],
@@ -3161,9 +3167,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.9.tgz",
-      "integrity": "sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
       "cpu": [
         "ppc64"
       ],
@@ -3178,9 +3184,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.9.tgz",
-      "integrity": "sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
       "cpu": [
         "s390x"
       ],
@@ -3195,9 +3201,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.9.tgz",
-      "integrity": "sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
       "cpu": [
         "x64"
       ],
@@ -3212,9 +3218,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.9.tgz",
-      "integrity": "sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
       "cpu": [
         "x64"
       ],
@@ -3229,9 +3235,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.9.tgz",
-      "integrity": "sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
       "cpu": [
         "arm64"
       ],
@@ -3246,9 +3252,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.9.tgz",
-      "integrity": "sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
       "cpu": [
         "wasm32"
       ],
@@ -3256,33 +3262,37 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
-      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.9.tgz",
-      "integrity": "sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
       "cpu": [
         "arm64"
       ],
@@ -3297,9 +3307,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.9.tgz",
-      "integrity": "sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
       "cpu": [
         "x64"
       ],
@@ -3314,9 +3324,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.9.tgz",
-      "integrity": "sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -3347,13 +3357,13 @@
       "license": "MIT"
     },
     "node_modules/@swagger-api/apidom-ast": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-1.6.0.tgz",
-      "integrity": "sha512-ez1KnBdAzoh5a6ijDXzu5nADkVZXlnL1RkLl8n2u2tjiNg9597xxmFdEHLVa31Vxr1yYj0WtYGLA5e2Kp0KNrQ==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-1.11.3.tgz",
+      "integrity": "sha512-Nfi/0vy+cIHClX7raXamtHnCMBbwI1PEg+yroIzyy8LcCH7zcS0Xi4ARG3CkDQswOnWO2gLDAUAFjDvkQWdZ+A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-error": "^1.6.0",
+        "@swagger-api/apidom-error": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -3361,14 +3371,14 @@
       }
     },
     "node_modules/@swagger-api/apidom-core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-1.6.0.tgz",
-      "integrity": "sha512-gA1MVoXe19sjFLKGkWxp5VvSw3Tk0CSChfItJjFeFHpLSGrfm+LlXp37TmNSns53Ky0F7x7TB/5kAX5I/TO4xw==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-1.11.3.tgz",
+      "integrity": "sha512-21/PXEqCzsWkiwKWHt0TPJE7GUtog3BhMlvYLUEPbteXOrk+PNazbjYDPl4zfZGRLaoGhTqpFBY5pXafdzaHWQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.6.0",
-        "@swagger-api/apidom-error": "^1.6.0",
+        "@swagger-api/apidom-ast": "^1.11.3",
+        "@swagger-api/apidom-error": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "minim": "~0.23.8",
         "ramda": "~0.30.0",
@@ -3378,37 +3388,37 @@
       }
     },
     "node_modules/@swagger-api/apidom-error": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-1.6.0.tgz",
-      "integrity": "sha512-xp/cQ1xQ/4Vd/hhQfONK7ea9oVc3JUXAYyfRzvDR0lxISly/SyD2jMcqXzHtrylBAnv7V2HSsbC1BWo7ZJDLSQ==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-1.11.3.tgz",
+      "integrity": "sha512-Z4mIDyZUF2kDFHBzKsxkYSaHpGSvGDc7gAkdzLKxcQk4849iCUXxs0PpQLxZxfYcmUSwkw7AZmIP/OKGpsR8JA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7"
       }
     },
     "node_modules/@swagger-api/apidom-json-pointer": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.6.0.tgz",
-      "integrity": "sha512-RO6P5Gt64AnthGXKeqIFjQCLVFbAJvLYAb67TkvRQ9US4lNixFtFsYJnhLCC4ymz4dTT1hacG0cmTRGcEHF9ig==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.11.3.tgz",
+      "integrity": "sha512-z6eEvJ5HIb0aFqVldHyU5Guut+bv/opu28i+rrfDb1LEG3IWk5T3DbW9d/nWpAfNze/bjwiZvPphmkuycijb2w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-error": "^1.6.0",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-error": "^1.11.3",
         "@swaggerexpert/json-pointer": "^2.10.1"
       }
     },
     "node_modules/@swagger-api/apidom-ns-api-design-systems": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-1.6.0.tgz",
-      "integrity": "sha512-EYJfQ4JYuUo2J4QiiLnA/8LmM1k7AQcf1XVE+NrIpZ1160GIzqE+W5uOXkhAOImkP2Cb7EZZdE2cFE/tMYxNvw==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-1.11.3.tgz",
+      "integrity": "sha512-HTISScqScdnUc2BKqMaWM+ISU79AlHlr+XHUR9g0R8QiO4KzCkWUi6TncP0gvGoEY+BvfR0OkztfxYrelkksmg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-error": "^1.6.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.6.0",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-error": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -3416,15 +3426,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-arazzo-1": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-1.6.0.tgz",
-      "integrity": "sha512-5rF8PyBiIHh6NfC5Y0WypW11X6hQIWr88EKNOQbBuT/nnzAsOznrUCfQ99FYGLucwdOHaMIBn/b/n4ejGBto/A==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-1.11.3.tgz",
+      "integrity": "sha512-AHRSbuYy5oA8c/7j7nahxMASjt0cuOWyUk4yu+cKG+KS85ho2f2NiFThqQjtIJLisvrp+qNniJ1EwTfcCTivTQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.6.0",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -3432,15 +3442,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-asyncapi-2": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.6.0.tgz",
-      "integrity": "sha512-tOodfX+o7lonEAnSAxet7nCayW+EqtKPegT06WXt7Llq1LS9eYZ9YzXdFgIwCm8UzfEpZdVLqtxbdLX9vuUtSg==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.11.3.tgz",
+      "integrity": "sha512-bn/Pf52SCsSGcw7qO3gAje+KjhhpWJxWjjWQe5Jv9oPoXCnvGoSspSXMY3zIrhz9XfrP94AdWBUpOlWBoaaDBQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.6.0",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -3448,15 +3458,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-asyncapi-3": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-3/-/apidom-ns-asyncapi-3-1.6.0.tgz",
-      "integrity": "sha512-lRMvwTdtuPcwJEYLTX/UGtECpHi9UNYeT9rmWMw3LiKZrZzYc2L8q4ipPbpWwH8t7QfsF2u0iggCODU99lXCnw==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-3/-/apidom-ns-asyncapi-3-1.11.3.tgz",
+      "integrity": "sha512-QhZtf8YeMRVtgVioJj0qKdNG0LEzi9RPSrC9KWfCdwEBlkhNDhHFh6FIJWayYAwR6DPlOXjTYQf97V9QwIuRmQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.6.0",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -3464,15 +3474,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-2019-09": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2019-09/-/apidom-ns-json-schema-2019-09-1.6.0.tgz",
-      "integrity": "sha512-dee1i8wcAFgDEOzTsyoCzQhFLZ2JKzkK5KkRuryabvwS0hG2mKlogToFc8cO2MkkiLSpERm7DREALwSTFVHa0w==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2019-09/-/apidom-ns-json-schema-2019-09-1.11.3.tgz",
+      "integrity": "sha512-zHA4/oin6Fg6VN0bWmMRu1nt4Xnd05mF5T+Od6vEmid1bxDXpfSSMaPpdu+WCBJ5dDX19EeBVTJoAI0U4psxBg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-error": "^1.6.0",
-        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.6.0",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-error": "^1.11.3",
+        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -3480,15 +3490,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-2020-12": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2020-12/-/apidom-ns-json-schema-2020-12-1.6.0.tgz",
-      "integrity": "sha512-ldTxSnnIXskwpN6yCJkasqs32pJXwoXyad95crKT0xjZZr4fTrcAXXIyzdjBubiY9tK6elSrQGQxinJcV7ivWw==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2020-12/-/apidom-ns-json-schema-2020-12-1.11.3.tgz",
+      "integrity": "sha512-zUWRb5DlvlZXtf2JmiNqUwwgGc4eUAsUQPU59kP140vkPT98HDhNJx9UXoHLgP5F/Zk8f2rzeG237u+JnCT9/g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-error": "^1.6.0",
-        "@swagger-api/apidom-ns-json-schema-2019-09": "^1.6.0",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-error": "^1.11.3",
+        "@swagger-api/apidom-ns-json-schema-2019-09": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -3496,14 +3506,14 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-4": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-1.6.0.tgz",
-      "integrity": "sha512-t9HvHwrevEG7usosO6AdXmC8oYqje5nxHpUmODr72tUtCeAeGEGEb9lgqx7fBhjc3BYsRzOL1hX56m1gjEyCog==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-1.11.3.tgz",
+      "integrity": "sha512-udOM8ZQT7BzsyT9012R7/VjeazjOlyLwKpmpbgHZDG6uGHqsnWn9lN+F8/5Eox9qqBnQNqDNtDhBEMYjE6RYNQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.6.0",
-        "@swagger-api/apidom-core": "^1.6.0",
+        "@swagger-api/apidom-ast": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -3511,15 +3521,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-6": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-1.6.0.tgz",
-      "integrity": "sha512-aoyvQWgAOcZGTe5OfJ3r24DvXHHbrkKtAnxTOEdZzV/uOm6/cbuT8m02+aMOqWPxei1naC3ZHW9iHrETtfgV3w==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-1.11.3.tgz",
+      "integrity": "sha512-ZOgo5OtpQ6e5XQ5R1H8CYTYXEtnD0l+FyN065A6c2O1NxJXFKS2a5SZTvx+udA4mugtkTSmr7hAQe2ae+KAXQw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-error": "^1.6.0",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.6.0",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-error": "^1.11.3",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -3527,15 +3537,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-7": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-1.6.0.tgz",
-      "integrity": "sha512-GjmC4+AHQh22fRZOmV+jSYMJTXh243XvdACfIQ//39kQu7gQsimF4PVSY2IgWSvS/I1ukWdPBYmDvOKryBPGrw==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-1.11.3.tgz",
+      "integrity": "sha512-L5Sc0qMUrUbgVex3fN+tnNHjed/JCAwpwyzdHY8KgUfXHkfM5aLUyyAGirm+ObwZvGDEejsTT2Otp6B5S29eqw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-error": "^1.6.0",
-        "@swagger-api/apidom-ns-json-schema-draft-6": "^1.6.0",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-error": "^1.11.3",
+        "@swagger-api/apidom-ns-json-schema-draft-6": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -3543,16 +3553,16 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-2": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.6.0.tgz",
-      "integrity": "sha512-xbmYzagnB8rO7sYwNGVyxYbNBkjCWnMhlnMrxkPtfQ/2u2ANAmTnCB/S/cMswX5XofiRJbznKAjLDSKBS+mLpQ==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.11.3.tgz",
+      "integrity": "sha512-T241UD+1My1hVJHayTCz9f7rznmeM8rxQW4NtUnD8k677SShpnNkrfeoc1elrpJXdTsnEPIOLCK0EEIyEplHgA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-error": "^1.6.0",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.6.0",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-error": "^1.11.3",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -3560,15 +3570,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-0": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.6.0.tgz",
-      "integrity": "sha512-AOvW7a2H27inepcTBAWaBMjJLrCh5IPWD4nTU+gysULC7IW6gphO8hj3iUuTmFBcGh9be89GBbvv2y/EGAfx9w==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.11.3.tgz",
+      "integrity": "sha512-FZvBqWpZFciemMgWBGY89RIH5uLl6ZYtmMAhWzDcmEi1JSjmWKkoqZno//KlqSgbI09gbkzipdMjGK825givPA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-error": "^1.6.0",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.6.0",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-error": "^1.11.3",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -3576,17 +3586,17 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-1": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.6.0.tgz",
-      "integrity": "sha512-jCVypc8503zDSxAQlyV8j1vzwc75VBdWHtE2O0F+q5j9qNtGxw/ekbDkgrydYRaGBl92mf16dtPjtp5LwJD0Hw==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.11.3.tgz",
+      "integrity": "sha512-ObCP+l3/ZhuPaSqXqmSnCpEOIMalQns0c4IZgX6h3o7Jc6K6BcqDMeq4s17dwcQja9fFUtkoIIFuquJBKvK86Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.6.0",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-json-pointer": "^1.6.0",
-        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.6.0",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.6.0",
+        "@swagger-api/apidom-ast": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-json-pointer": "^1.11.3",
+        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -3594,18 +3604,18 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-2": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-2/-/apidom-ns-openapi-3-2-1.6.0.tgz",
-      "integrity": "sha512-QcFAUucaPaWiOKOEaaGqSfK3OtjeGJodWZLsuBQ0vrHaHkWyQ7jwsM1DJbc1Y8geOBeD2wIwdrdRjoulmqU1SA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-2/-/apidom-ns-openapi-3-2-1.11.3.tgz",
+      "integrity": "sha512-Ri7KLrfrpJeteghUdzbozxKve2NG5Z1aPWX91DI14j75+v/xBAu91AIZt7K+LV8JWUNk+VbhUlhgSH1JAIVa0g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.6.0",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-json-pointer": "^1.6.0",
-        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.6.0",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.6.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.6.0",
+        "@swagger-api/apidom-ast": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-json-pointer": "^1.11.3",
+        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -3613,144 +3623,144 @@
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-json": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.6.0.tgz",
-      "integrity": "sha512-vz/9k0X/kh6mLm+Fi+LGNk/yyFq28wxI29ZVLW+b7ulcODikv+NaDnyN2n2kLKCvIchPATzAEvqMvVMuuQwWlg==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.11.3.tgz",
+      "integrity": "sha512-6LcwiY2Ce1qmsq8CSxCoRMJ3q2quFnEsNgI48LpM9/PYK/idjsB/WrnU9xSl9fXm/aTo/bOO0ckc8KadxVykfA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-ns-api-design-systems": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-json": "^1.6.0",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-api-design-systems": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-yaml": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.6.0.tgz",
-      "integrity": "sha512-QAq4H6YzRtysSpvLtlJ8WZ22/1Mht+/iarrUOijxDZQPAGfYeUoIicnCqxkVZYSea85sQl+3kiCCB3nhSH+L0g==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.11.3.tgz",
+      "integrity": "sha512-zk2NuWAOvjEHYQ3lZ43VhAqJk+9KK452HeFfZFne4a4iALhCQ/wceK7tCG81jBMMoWnR0f1JS/vxz7/Y2CNwLA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-ns-api-design-systems": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.6.0",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-api-design-systems": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-arazzo-json-1": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-1.6.0.tgz",
-      "integrity": "sha512-syKPG3a9IGRvlGhXIEUzWhwbEuFbj+UwwtqaKu8zu771V+DRtH+wxyOkX54vKAIlApz/FgeUbmlWA1ZtYBlSIQ==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-1.11.3.tgz",
+      "integrity": "sha512-vXP6lYp6Q5/5nLkMJyBRTWYIZYxL6GnOsJsdnN0KdTHuoPXNZWsv5p2oPYlVE/W7gRAZDylUmYZQ1L9rr7BGRw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-ns-arazzo-1": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-json": "^1.6.0",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-arazzo-1": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-arazzo-yaml-1": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-1.6.0.tgz",
-      "integrity": "sha512-IVVLn+a8Q1iQcQsm4tXiAPghHJuJSB1rhIlDyHe3tSQgt9HOSiVpbnJDpwE/JBxxDxSAkeT6Ovo+fi2T5AmHYg==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-1.11.3.tgz",
+      "integrity": "sha512-zI57Q5DIf7TGv1A2gIk3umbPWMEFWYO3tEmfP0xJGDBn6gZRHgJvvVjn0wQrljigEEw1V3hRDUXk6Zzg3oVNvA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-ns-arazzo-1": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.6.0",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-arazzo-1": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.6.0.tgz",
-      "integrity": "sha512-aSUi22ELTDvdCLA3nIUOehuNBcHSeCqU7S7YNiHP/mwE4Q07pwQrYXijH2PROfCdjlZNNN34m6Ptakd92jliJQ==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.11.3.tgz",
+      "integrity": "sha512-VGl15mpHaL+SlsXaRvcVaWXir+pCLrj99QN//Kuir3cpPW6P9IdBztj11bjoIG3aX1bOIrU16/uOhV4G5J4Kag==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-json": "^1.6.0",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-3": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-3/-/apidom-parser-adapter-asyncapi-json-3-1.6.0.tgz",
-      "integrity": "sha512-Ic53vcFF9zniDyCXOGSwwuAdEBUn5lFEAa0m2i30R36cQFHBCCuvbzbMQjWdr+oML0Aw4XoqOwZCQgkJJICpPA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-3/-/apidom-parser-adapter-asyncapi-json-3-1.11.3.tgz",
+      "integrity": "sha512-37dNwdLAcAd7TZW8YqSbpuBoujfoM2AvXBoT1BUxzbYetwNkxP19Q1VtCEAzMxUEQ/9niBANSzuo0zClUEc2kw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-ns-asyncapi-3": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-json": "^1.6.0",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-asyncapi-3": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.6.0.tgz",
-      "integrity": "sha512-d/w7X+T4vT+KPqb+8xUm6n4pbHsGB28jdxE9rNVbxhu6D3owny2uxfglwaFh4fJG6FQMavCwl/QzfB4newdoKQ==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.11.3.tgz",
+      "integrity": "sha512-MEZHn+qROKehrXLhDhl7kSQADXjwU2NGSeNuBTr1/nINShpu4Tkxrk7xT0LY8GauKrZR9MyAnueATDQgK8NWhQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.6.0",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3/-/apidom-parser-adapter-asyncapi-yaml-3-1.6.0.tgz",
-      "integrity": "sha512-Wmf0LY59TZxQhqrJU2pcnUikcChVB4IqGPgjtOFLUoqPpz8FSwYbJ/SPnSMSl+QuncxROheSFsgZ6Tupv0sPHw==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3/-/apidom-parser-adapter-asyncapi-yaml-3-1.11.3.tgz",
+      "integrity": "sha512-qHOK0NXnG7t5Gx0xCIbyfrM5FXLgK6krlZRPlrlT6K853MWWWWmjAieuayPtu72Ak1hd/8U2/oWgbONnPqj76w==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-ns-asyncapi-3": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.6.0",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-asyncapi-3": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-json": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.6.0.tgz",
-      "integrity": "sha512-WdAS+dBAB2t18HuUgSZy5b8JM7uXfn1RlPymJNRMUsrKYCTtPrQ/0q3YfnBjPhtjSSNCp+p1wajxHAFS7cj2VA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.11.3.tgz",
+      "integrity": "sha512-Wj/DTb6mblsaxKfye9kXLwS+KmWWLAM2M2oSs4muOclhAOtcffr2H+STtiT3Hwrzb+cW8RpX6Htvey4rvbj/Jg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.6.0",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-error": "^1.6.0",
+        "@swagger-api/apidom-ast": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-error": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -3760,144 +3770,144 @@
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-2": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.6.0.tgz",
-      "integrity": "sha512-Q36W1FzdVaY7Oh98533dzCUghwb8k3ZMdlnV37V1H13FlUkj3tVZiWaeaCLwIakzQ7XXYaQTOP+VrRhDRjzhUA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.11.3.tgz",
+      "integrity": "sha512-aDR5vKSApqQgDkvJNJZqvp8slEWHGByz5bzDbw6ZHRPSIZcA2IEHdJPgWJVS5gNtJ+YAnA7veM39oqeoF2yy8w==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-ns-openapi-2": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-json": "^1.6.0",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-0": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.6.0.tgz",
-      "integrity": "sha512-UY+obOLTPHJvnXscdMY9XwZyuqcnBe6cu9TURjJgkO/QpOpPDqqZoRyurKZgRrX0Pv9B1zR3EIzhl01u/jeUaw==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.11.3.tgz",
+      "integrity": "sha512-hpSBiaVG7qbyJy25/Pl48NCT9uvvsOPAAj+xCAb9TwmIPBcFkVYvj6ZWJbYZsOmzUzcNLOZEOBjRNPN3G31zmQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-json": "^1.6.0",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-1": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.6.0.tgz",
-      "integrity": "sha512-4ch04/96lYMXQu6odqa6H0aJmV8UefnBJKX1CPuL4qcPSPMFCurcXHGpPHrwMu1p/4Q9H+yRVlYeNQV10xvM0w==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.11.3.tgz",
+      "integrity": "sha512-EP7U25s5We8Q/2olymVrJL2nKT+skTea6SnR8F3OETsBoef3i1XgQx7AHqUc9S83hp+bOxZ+oPyI6dNwO+J+MA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-json": "^1.6.0",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-2": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-2/-/apidom-parser-adapter-openapi-json-3-2-1.6.0.tgz",
-      "integrity": "sha512-fWR2gjMQg00QIimcXQMSVeLnCH/2iuDD/Dx8TzVHmKV/IKlu+TnmIVosdlDfRmOB+4duwU6/yfoA79IEhFeZdw==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-2/-/apidom-parser-adapter-openapi-json-3-2-1.11.3.tgz",
+      "integrity": "sha512-WLuMb0pwH+5hjosRHGvUFLm9iWP0/XNnEdrwdUio4y0eodjDwrPGb2LSdH3zaR8p7mKrqe007jqpjaLLsStzrQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-ns-openapi-3-2": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-json": "^1.6.0",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-3-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-2": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.6.0.tgz",
-      "integrity": "sha512-dkEh1Rw9uvuIAOTfKjWRX2rLWP+xJ/Eqdkqeo0I0BWFKXX49YcDpHJV4XHpmd5FbsjJ9vBYr0hAmkbl32TtR4g==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.11.3.tgz",
+      "integrity": "sha512-PyD0E4fwOhOCcP/Aqa9HlvZYuw825E6N0IRC69dxxt6Fy6w6Fv2KYRnRw8OINoog8I6/8uSZOLdeDla3FCqhFA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-ns-openapi-2": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.6.0",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.6.0.tgz",
-      "integrity": "sha512-6azq5YonWdzHcO9llK9zn1a+rGxlTz2Uf8p8NWDQnl2AZ56neDLYEL3mNDlrMXAy8dSJIHw+u9VF1OOzdslIHQ==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.11.3.tgz",
+      "integrity": "sha512-7ULkLaEAAVKRNWT525PdKOaUjrZ7G2ulH9VBsMJ9niaZN/n6hnSW8IR4Iaf0cLZ1MjsZsdWovq5slPz2hpqR4A==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.6.0",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.6.0.tgz",
-      "integrity": "sha512-g2tGCXyIAC0IA6JjA0HVxHWyCovyfAxDQ+pMAJ6qm4PfrZHB+oXKWKZHNNmQaFiKdc/SVdMQq6Up0mXOQs7IOQ==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.11.3.tgz",
+      "integrity": "sha512-2VqxGS0PaNrYeLgGyOl9m4m6EbJjrtxOswzWK2Rk3/M3gEDfnFdyOVffKWlcdEv6XFJ+wgLy5MPlODrzyOOKCA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.6.0",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2/-/apidom-parser-adapter-openapi-yaml-3-2-1.6.0.tgz",
-      "integrity": "sha512-NGkdG9X5Svi89ZBluNseyUBNdgB9MkbTTNmerVKKOmCCHaVbzIb6UFPXf1MifSFyT+wTeGZk6WZLgRIDsTAZ5Q==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2/-/apidom-parser-adapter-openapi-yaml-3-2-1.11.3.tgz",
+      "integrity": "sha512-fRJYMozAyIJP46kKbUPQX2wIzfX9FSC7ZxUn+VWOa587f3zZC3XmydGO46GA/TGuc8cWs7AFD/EfSKWDbsB3Tg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-ns-openapi-3-2": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.6.0",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-3-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.6.0.tgz",
-      "integrity": "sha512-UwSE5pPUJ+ag7ZCbesgx/SJ8zUD3Sx+2U4AD3/1G1EJ+0gb7FMYgihuOT8ujmBfZVGGm3HMIEIa1w3zha08v2g==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.11.3.tgz",
+      "integrity": "sha512-mSPMfVzDkLC+HPDI/6ho8TxI1PEcDJl/Y53gZdmfCU1xYzUdOF4s0iHalHHt0ipxYpt0EQXD+oGBnpp/TTx4IQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.6.0",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-error": "^1.6.0",
+        "@swagger-api/apidom-ast": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-error": "^1.11.3",
         "@tree-sitter-grammars/tree-sitter-yaml": "=0.7.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
@@ -3927,9 +3937,9 @@
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/node-addon-api": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.6.0.tgz",
-      "integrity": "sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
+      "integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -3949,46 +3959,46 @@
       }
     },
     "node_modules/@swagger-api/apidom-reference": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.6.0.tgz",
-      "integrity": "sha512-gYTDfWQM1heqrCCrCsZH+EWDyAkIGqEJnSJcVWKngwOkXJKeUwat8p1TOW4q3rkaTT+fBaYbrjTr9SkFtVbdMg==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.11.3.tgz",
+      "integrity": "sha512-Y0J+pAru/Est0wQJlFeQq2AsWyboOJP456Zv2wV4m0Ib1QY6N2wWiL6clkHpHA0pughemN6gcjBeNlMeRGqXuw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-error": "^1.6.0",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-error": "^1.11.3",
         "@types/ramda": "~0.30.0",
-        "axios": "^1.12.2",
+        "axios": "^1.16.0",
         "minimatch": "^10.2.1",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       },
       "optionalDependencies": {
-        "@swagger-api/apidom-json-pointer": "^1.6.0",
-        "@swagger-api/apidom-ns-arazzo-1": "^1.6.0",
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.6.0",
-        "@swagger-api/apidom-ns-openapi-2": "^1.6.0",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.6.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.6.0",
-        "@swagger-api/apidom-ns-openapi-3-2": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-arazzo-json-1": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-json": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "^1.6.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.6.0"
+        "@swagger-api/apidom-json-pointer": "^1.11.3",
+        "@swagger-api/apidom-ns-arazzo-1": "^1.11.3",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-2": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-3-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-arazzo-json-1": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3"
       }
     },
     "node_modules/@swagger-api/apidom-reference/node_modules/balanced-match": {
@@ -4001,9 +4011,9 @@
       }
     },
     "node_modules/@swagger-api/apidom-reference/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -4013,12 +4023,12 @@
       }
     },
     "node_modules/@swagger-api/apidom-reference/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -4638,18 +4648,18 @@
       }
     },
     "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -4790,23 +4800,6 @@
         "form-data": "^2.5.5"
       }
     },
-    "node_modules/@types/request/node_modules/form-data": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
-      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.35",
-        "safe-buffer": "^5.2.1"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
     "node_modules/@types/swagger-ui-react": {
       "version": "5.18.0",
       "resolved": "https://registry.npmjs.org/@types/swagger-ui-react/-/swagger-ui-react-5.18.0.tgz",
@@ -4842,29 +4835,12 @@
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
-    "node_modules/@types/webidl-conversions": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
-      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@types/whatwg-mimetype": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
       "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/whatwg-url": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
-      "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/webidl-conversions": "*"
-      }
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -5075,9 +5051,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5721,6 +5697,18 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/apg-lite": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/apg-lite/-/apg-lite-1.0.5.tgz",
@@ -5989,14 +5977,56 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -6036,9 +6066,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
-      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "version": "2.10.43",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -6048,26 +6078,26 @@
       }
     },
     "node_modules/better-auth": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.5.4.tgz",
-      "integrity": "sha512-ReykcEKx6Kp9560jG1wtlDBnftA7L7xb3ZZdDWm5yGXKKe2pUf+oBjH0fqekrkRII0m4XBVQbQ0mOrFv+3FdYg==",
+      "version": "1.6.23",
+      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.23.tgz",
+      "integrity": "sha512-4vOaRd9UiKGKm9R+ej0jjU1es3MiJIiNc9Qq3VCnYqOZ4/nb5272QqTxWYoDxyUXl5x6A2x2we5KZKQO9teTQQ==",
       "license": "MIT",
       "dependencies": {
-        "@better-auth/core": "1.5.4",
-        "@better-auth/drizzle-adapter": "1.5.4",
-        "@better-auth/kysely-adapter": "1.5.4",
-        "@better-auth/memory-adapter": "1.5.4",
-        "@better-auth/mongo-adapter": "1.5.4",
-        "@better-auth/prisma-adapter": "1.5.4",
-        "@better-auth/telemetry": "1.5.4",
-        "@better-auth/utils": "0.3.1",
-        "@better-fetch/fetch": "1.1.21",
+        "@better-auth/core": "1.6.23",
+        "@better-auth/drizzle-adapter": "1.6.23",
+        "@better-auth/kysely-adapter": "1.6.23",
+        "@better-auth/memory-adapter": "1.6.23",
+        "@better-auth/mongo-adapter": "1.6.23",
+        "@better-auth/prisma-adapter": "1.6.23",
+        "@better-auth/telemetry": "1.6.23",
+        "@better-auth/utils": "0.4.2",
+        "@better-fetch/fetch": "1.3.1",
         "@noble/ciphers": "^2.1.1",
         "@noble/hashes": "^2.0.1",
-        "better-call": "1.3.2",
+        "better-call": "1.3.7",
         "defu": "^6.1.4",
         "jose": "^6.1.3",
-        "kysely": "^0.28.11",
+        "kysely": "^0.28.17 || ^0.29.0",
         "nanostores": "^1.1.1",
         "zod": "^4.3.6"
       },
@@ -6079,7 +6109,7 @@
         "@tanstack/solid-start": "^1.0.0",
         "better-sqlite3": "^12.0.0",
         "drizzle-kit": ">=0.31.4",
-        "drizzle-orm": ">=0.41.0",
+        "drizzle-orm": "^0.45.2",
         "mongodb": "^6.0.0 || ^7.0.0",
         "mysql2": "^3.0.0",
         "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
@@ -6153,12 +6183,12 @@
       }
     },
     "node_modules/better-call": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.2.tgz",
-      "integrity": "sha512-4cZIfrerDsNTn3cm+MhLbUePN0gdwkhSXEuG7r/zuQ8c/H7iU0/jSK5TD3FW7U0MgKHce/8jGpPYNO4Ve+4NBw==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.7.tgz",
+      "integrity": "sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w==",
       "license": "MIT",
       "dependencies": {
-        "@better-auth/utils": "^0.3.1",
+        "@better-auth/utils": "^0.4.0",
         "@better-fetch/fetch": "^1.1.21",
         "rou3": "^0.7.12",
         "set-cookie-parser": "^3.0.1"
@@ -6215,9 +6245,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6257,9 +6287,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
       "dev": true,
       "funding": [
         {
@@ -6277,27 +6307,17 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/bson": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-7.2.0.tgz",
-      "integrity": "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">=20.19.0"
       }
     },
     "node_modules/buffer": {
@@ -6356,6 +6376,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
       "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.3",
@@ -6438,9 +6459,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001777",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001777.tgz",
-      "integrity": "sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==",
+      "version": "1.0.30001805",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz",
+      "integrity": "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==",
       "funding": [
         {
           "type": "opencollective",
@@ -6518,6 +6539,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -6533,6 +6555,7 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
       "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "consola": "^3.2.3"
@@ -6635,12 +6658,14 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
       "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/consola": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
       "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
@@ -6703,9 +6728,9 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.48.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.48.0.tgz",
-      "integrity": "sha512-1slJgk89tWC51HQ1AEqG+s2VuwpTRr8ocu4n20QUcH1v9lAN0RXen0Q0AABa/DK1I7RrNWLucplOHMx8hfTGTw==",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
+      "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
       "hasInstallScript": true,
       "license": "MIT",
       "funding": {
@@ -6860,12 +6885,6 @@
         }
       }
     },
-    "node_modules/decimal.js": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
-      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "license": "MIT"
-    },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
@@ -6908,6 +6927,7 @@
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
       "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"
@@ -6949,9 +6969,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "license": "MIT"
     },
     "node_modules/delayed-stream": {
@@ -6976,6 +6996,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
       "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/detect-libc": {
@@ -7007,9 +7028,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
-      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -7019,6 +7040,7 @@
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -7034,132 +7056,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/drizzle-orm": {
-      "version": "0.45.1",
-      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.1.tgz",
-      "integrity": "sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "peerDependencies": {
-        "@aws-sdk/client-rds-data": ">=3",
-        "@cloudflare/workers-types": ">=4",
-        "@electric-sql/pglite": ">=0.2.0",
-        "@libsql/client": ">=0.10.0",
-        "@libsql/client-wasm": ">=0.10.0",
-        "@neondatabase/serverless": ">=0.10.0",
-        "@op-engineering/op-sqlite": ">=2",
-        "@opentelemetry/api": "^1.4.1",
-        "@planetscale/database": ">=1.13",
-        "@prisma/client": "*",
-        "@tidbcloud/serverless": "*",
-        "@types/better-sqlite3": "*",
-        "@types/pg": "*",
-        "@types/sql.js": "*",
-        "@upstash/redis": ">=1.34.7",
-        "@vercel/postgres": ">=0.8.0",
-        "@xata.io/client": "*",
-        "better-sqlite3": ">=7",
-        "bun-types": "*",
-        "expo-sqlite": ">=14.0.0",
-        "gel": ">=2",
-        "knex": "*",
-        "kysely": "*",
-        "mysql2": ">=2",
-        "pg": ">=8",
-        "postgres": ">=3",
-        "sql.js": ">=1",
-        "sqlite3": ">=5"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/client-rds-data": {
-          "optional": true
-        },
-        "@cloudflare/workers-types": {
-          "optional": true
-        },
-        "@electric-sql/pglite": {
-          "optional": true
-        },
-        "@libsql/client": {
-          "optional": true
-        },
-        "@libsql/client-wasm": {
-          "optional": true
-        },
-        "@neondatabase/serverless": {
-          "optional": true
-        },
-        "@op-engineering/op-sqlite": {
-          "optional": true
-        },
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@planetscale/database": {
-          "optional": true
-        },
-        "@prisma/client": {
-          "optional": true
-        },
-        "@tidbcloud/serverless": {
-          "optional": true
-        },
-        "@types/better-sqlite3": {
-          "optional": true
-        },
-        "@types/pg": {
-          "optional": true
-        },
-        "@types/sql.js": {
-          "optional": true
-        },
-        "@upstash/redis": {
-          "optional": true
-        },
-        "@vercel/postgres": {
-          "optional": true
-        },
-        "@xata.io/client": {
-          "optional": true
-        },
-        "better-sqlite3": {
-          "optional": true
-        },
-        "bun-types": {
-          "optional": true
-        },
-        "expo-sqlite": {
-          "optional": true
-        },
-        "gel": {
-          "optional": true
-        },
-        "knex": {
-          "optional": true
-        },
-        "kysely": {
-          "optional": true
-        },
-        "mysql2": {
-          "optional": true
-        },
-        "pg": {
-          "optional": true
-        },
-        "postgres": {
-          "optional": true
-        },
-        "prisma": {
-          "optional": true
-        },
-        "sql.js": {
-          "optional": true
-        },
-        "sqlite3": {
-          "optional": true
-        }
       }
     },
     "node_modules/dunder-proto": {
@@ -7210,9 +7106,10 @@
       "license": "MIT"
     },
     "node_modules/effect": {
-      "version": "3.18.4",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-3.18.4.tgz",
-      "integrity": "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.0.tgz",
+      "integrity": "sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -7220,9 +7117,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.307",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
-      "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
+      "version": "1.5.389",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
+      "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
       "dev": true,
       "license": "ISC"
     },
@@ -7242,6 +7139,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
       "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -8084,12 +7982,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -8127,9 +8025,10 @@
       }
     },
     "node_modules/exsolve": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
-      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
+      "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/extend": {
@@ -8151,6 +8050,7 @@
       "version": "3.23.2",
       "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
       "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -8226,9 +8126,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "funding": [
         {
           "type": "github",
@@ -8242,21 +8142,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
-      "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.2.tgz",
-      "integrity": "sha512-pw/6pIl4k0CSpElPEJhDppLzaixDEuWui2CUQQBH/ECDf7+y6YwA4Gf7Tyb0Rfe4DIMuZipYj4AEL0nACKglvQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
       "funding": [
         {
           "type": "github",
@@ -8265,8 +8153,28 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.0.0",
-        "strnum": "^2.1.2"
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.0.tgz",
+      "integrity": "sha512-SLhnTEqE5QpJHq/6zl9bsmImEP2adv+y6Wy+cJa7nVTRzQh1OZfCe9k29M5xN74LWnu0xa1zrUrq3KnOKl92Fg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.2.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.3.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -8395,9 +8303,9 @@
       }
     },
     "node_modules/firebase-admin": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.7.0.tgz",
-      "integrity": "sha512-o3qS8zCJbApe7aKzkO2Pa380t9cHISqeSd3blqYTtOuUUUua3qZTLwNWgGUOss3td6wbzrZhiHIj3c8+fC046Q==",
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.10.0.tgz",
+      "integrity": "sha512-rbuCrJvYRwqBqvbccMS8fj/x2zsaMisdf5RQbRzQzr14Rbq9r2UlpuBHqWAwrO6c9dIRF56xF/xoepXsD5yDuQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
@@ -8407,9 +8315,7 @@
         "fast-deep-equal": "^3.1.1",
         "google-auth-library": "^10.6.1",
         "jsonwebtoken": "^9.0.0",
-        "jwks-rsa": "^3.1.0",
-        "node-forge": "^1.3.1",
-        "uuid": "^11.0.2"
+        "jwks-rsa": "^3.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -8483,19 +8389,6 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
-    "node_modules/firebase-admin/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -8511,16 +8404,16 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
-      "integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -8586,19 +8479,20 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
+      "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35",
+        "safe-buffer": "^5.2.1"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 0.12"
       }
     },
     "node_modules/format": {
@@ -8717,19 +8611,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/gaxios/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/generator-function": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
@@ -8832,6 +8713,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
       "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "citty": "^0.1.6",
@@ -8880,9 +8762,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -8995,20 +8877,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/google-gax/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/google-logging-utils": {
@@ -9149,9 +9017,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -9223,9 +9091,9 @@
       "license": "CC0-1.0"
     },
     "node_modules/hono": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
-      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "version": "4.12.30",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
+      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -9350,9 +9218,9 @@
       }
     },
     "node_modules/icu-minify": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/icu-minify/-/icu-minify-4.8.3.tgz",
-      "integrity": "sha512-65Av7FLosNk7bPbmQx5z5XG2Y3T2GFppcjiXh4z1idHeVgQxlDpAmkGoYI0eFzAvrOnjpWTL5FmPDhsdfRMPEA==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/icu-minify/-/icu-minify-4.13.2.tgz",
+      "integrity": "sha512-XhYQTEnBXBCyF6ERiwItFweoOXDUciujaGjIWCA7RhOCEPDfhVSTtuwfRq6HdVk7tKnYJh+yaurP96zGnaKsPg==",
       "funding": [
         {
           "type": "individual",
@@ -9452,15 +9320,13 @@
       }
     },
     "node_modules/intl-messageformat": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.1.2.tgz",
-      "integrity": "sha512-ucSrQmZGAxfiBHfBRXW/k7UC8MaGFlEj4Ry1tKiDcmgwQm1y3EDl40u+4VNHYomxJQMJi9NEI3riDRlth96jKg==",
+      "version": "11.2.11",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.11.tgz",
+      "integrity": "sha512-aDG5bvFRbQvRoT2Bh9FV6yV8t7o0MjEGknZ6pnin5Wt52PJwaBOHDfvz+oPEe78Pl3InQYKugBgCdXijLj6viQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "3.1.1",
-        "@formatjs/fast-memoize": "3.1.0",
-        "@formatjs/icu-messageformat-parser": "3.5.1",
-        "tslib": "^2.8.1"
+        "@formatjs/fast-memoize": "3.1.7",
+        "@formatjs/icu-messageformat-parser": "3.5.14"
       }
     },
     "node_modules/invariant": {
@@ -9473,9 +9339,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -9932,6 +9798,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-unsafe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+      "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/is-url": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
@@ -10069,9 +9947,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -10249,12 +10137,12 @@
       }
     },
     "node_modules/kysely": {
-      "version": "0.28.11",
-      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.11.tgz",
-      "integrity": "sha512-zpGIFg0HuoC893rIjYX1BETkVWdDnzTzF5e0kWXJFg5lE0k1/LfNWBejrcnOFu8Q2Rfq/hTDTU7XLUM8QOrpzg==",
+      "version": "0.29.3",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.29.3.tgz",
+      "integrity": "sha512-VHtBdW6XB/pgoTSqraM3UAa2rYoYdNXqnNPpX+8XXP+cwYbVEFuAp3HyPt1vpNfU9l7Y2kpUrA9QDPsy8uUqOQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -10581,9 +10469,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -10766,13 +10654,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/memory-pager": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
-      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
@@ -10886,67 +10767,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/mongodb": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.1.0.tgz",
-      "integrity": "sha512-kMfnKunbolQYwCIyrkxNJFB4Ypy91pYqua5NargS/f8ODNSJxT03ZU3n1JqL4mCzbSih8tvmMEMLpKTT7x5gCg==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@mongodb-js/saslprep": "^1.3.0",
-        "bson": "^7.1.1",
-        "mongodb-connection-string-url": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.806.0",
-        "@mongodb-js/zstd": "^7.0.0",
-        "gcp-metadata": "^7.0.1",
-        "kerberos": "^7.0.0",
-        "mongodb-client-encryption": ">=7.0.0 <7.1.0",
-        "snappy": "^7.3.2",
-        "socks": "^2.8.6"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/credential-providers": {
-          "optional": true
-        },
-        "@mongodb-js/zstd": {
-          "optional": true
-        },
-        "gcp-metadata": {
-          "optional": true
-        },
-        "kerberos": {
-          "optional": true
-        },
-        "mongodb-client-encryption": {
-          "optional": true
-        },
-        "snappy": {
-          "optional": true
-        },
-        "socks": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/mongodb-connection-string-url": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz",
-      "integrity": "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@types/whatwg-url": "^13.0.0",
-        "whatwg-url": "^14.1.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -10972,9 +10792,9 @@
       }
     },
     "node_modules/nanostores": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.1.1.tgz",
-      "integrity": "sha512-EYJqS25r2iBeTtGQCHidXl1VfZ1jXM7Q04zXJOrMlxVVmD0ptxJaNux92n1mJ7c5lN3zTq12MhH/8x59nP+qmg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.4.0.tgz",
+      "integrity": "sha512-i0tloweeudshAEuddpDxcg9Ik6pkPfVsHIgKyf143JrgG7/MOh0+q7BypdLXZPoOP7fOYt1eTcwGkyiVmhJFkA==",
       "funding": [
         {
           "type": "github",
@@ -11081,9 +10901,9 @@
       }
     },
     "node_modules/next-intl": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.8.3.tgz",
-      "integrity": "sha512-PvdBDWg+Leh7BR7GJUQbCDVVaBRn37GwDBWc9sv0rVQOJDQ5JU1rVzx9EEGuOGYo0DHAl70++9LQ7HxTawdL7w==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.13.2.tgz",
+      "integrity": "sha512-iCYycEP7/PE+1ue4MWBuz1qns6ESA+SGzuXxNMNN1qiYUh2fLhJPiZvHW1zZC7zMTn44aJUglOVZxUb1+hUz6g==",
       "funding": [
         {
           "type": "individual",
@@ -11095,16 +10915,15 @@
         "@formatjs/intl-localematcher": "^0.8.1",
         "@parcel/watcher": "^2.4.1",
         "@swc/core": "^1.15.2",
-        "icu-minify": "^4.8.3",
+        "icu-minify": "^4.13.2",
         "negotiator": "^1.0.0",
-        "next-intl-swc-plugin-extractor": "^4.8.3",
+        "next-intl-swc-plugin-extractor": "^4.13.2",
         "po-parser": "^2.1.1",
-        "use-intl": "^4.8.3"
+        "use-intl": "^4.13.2"
       },
       "peerDependencies": {
         "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0",
-        "typescript": "^5.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -11113,9 +10932,9 @@
       }
     },
     "node_modules/next-intl-swc-plugin-extractor": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/next-intl-swc-plugin-extractor/-/next-intl-swc-plugin-extractor-4.8.3.tgz",
-      "integrity": "sha512-YcaT+R9z69XkGhpDarVFWUprrCMbxgIQYPUaXoE6LGVnLjGdo8hu3gL6bramDVjNKViYY8a/pXPy7Bna0mXORg==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/next-intl-swc-plugin-extractor/-/next-intl-swc-plugin-extractor-4.13.2.tgz",
+      "integrity": "sha512-O30N/Y4ifzRe5Sz80jD1Qkg4VY6Zfef4SbHNNE166QkHswBf3/Kygpdd1X52sUUwTCk6uvdisO8ybfAN/VYJHQ==",
       "license": "MIT"
     },
     "node_modules/next-intl/node_modules/@swc/core": {
@@ -11266,27 +11085,11 @@
         }
       }
     },
-    "node_modules/node-fetch-commonjs": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch-commonjs/-/node-fetch-commonjs-3.3.2.tgz",
-      "integrity": "sha512-VBlAiynj3VMLrotgwOS3OyECFxas5y7ltLcK4t41lMUZeaK15Ym4QRkqN0EQKAFL42q9i21EPKjzLUPfltR72A==",
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
     "node_modules/node-fetch-native": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/node-fetch/node_modules/tr46": {
@@ -11311,15 +11114,6 @@
         "webidl-conversions": "^3.0.0"
       }
     },
-    "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
-      "license": "(BSD-3-Clause OR GPL-2.0)",
-      "engines": {
-        "node": ">= 6.13.0"
-      }
-    },
     "node_modules/node-gyp-build": {
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
@@ -11333,11 +11127,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-svg-path": {
       "version": "1.1.0",
@@ -11349,14 +11146,15 @@
       }
     },
     "node_modules/nypm": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
-      "integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.8.tgz",
+      "integrity": "sha512-Q9K4Diu6l5u6xJQogeFSs/zKtyMSgFKFtRQV+tHP4kL7KPm2grpBU0dFIwFaXwNxN0MtfKWc43VpCugAa+LPsw==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "citty": "^0.2.0",
+        "citty": "^0.2.2",
         "pathe": "^2.0.3",
-        "tinyexec": "^1.0.2"
+        "tinyexec": "^1.2.4"
       },
       "bin": {
         "nypm": "dist/cli.mjs"
@@ -11366,9 +11164,10 @@
       }
     },
     "node_modules/nypm/node_modules/citty": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.1.tgz",
-      "integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+      "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/object-assign": {
@@ -11517,6 +11316,7 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/on-finished": {
@@ -11706,6 +11506,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -11745,9 +11560,9 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -11758,12 +11573,14 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
       "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -11795,13 +11612,14 @@
       }
     },
     "node_modules/pkg-types": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
-      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "confbox": "^0.2.2",
-        "exsolve": "^1.0.7",
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
         "pathe": "^2.0.3"
       }
     },
@@ -11865,14 +11683,15 @@
       }
     },
     "node_modules/prisma": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.2.tgz",
-      "integrity": "sha512-XTKeKxtQElcq3U9/jHyxSPgiRgeYDKxWTPOf6NkXA0dNj5j40MfEsZkMbyNpwDWCUv7YBFUl7I2VK/6ALbmhEg==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.3.tgz",
+      "integrity": "sha512-++ZJ0ijLrDJF6hNB4t4uxg2br3fC4H9Yc9tcbjr2fcNFP3rh/SBNrAgjhsqBU4Ght8JPrVofG/ZkXfnSfnYsFg==",
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "6.19.2",
-        "@prisma/engines": "6.19.2"
+        "@prisma/config": "6.19.3",
+        "@prisma/engines": "6.19.3"
       },
       "bin": {
         "prisma": "build/index.js"
@@ -11933,25 +11752,24 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -11971,15 +11789,19 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -11989,6 +11811,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
       "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -12002,12 +11825,13 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -12128,6 +11952,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
       "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "defu": "^6.1.4",
@@ -12245,6 +12070,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -12500,14 +12326,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.9.tgz",
-      "integrity": "sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.115.0",
-        "@rolldown/pluginutils": "1.0.0-rc.9"
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -12516,21 +12342,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.9",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.9",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.9",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.9",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.9",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.9",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.9",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.9",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.9",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.9",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.9",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.9",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.9",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.9",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.9"
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
     "node_modules/rou3": {
@@ -12762,9 +12588,9 @@
       }
     },
     "node_modules/set-cookie-parser": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.0.1.tgz",
-      "integrity": "sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.2.tgz",
+      "integrity": "sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==",
       "license": "MIT"
     },
     "node_modules/set-function-length": {
@@ -12931,14 +12757,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -12950,13 +12776,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -13047,16 +12873,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/sparse-bitfield": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
-      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "memory-pager": "^1.0.2"
       }
     },
     "node_modules/sprintf-js": {
@@ -13336,16 +13152,19 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
-      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
+      }
     },
     "node_modules/stubs": {
       "version": "3.0.0",
@@ -13409,36 +13228,38 @@
       "license": "ISC"
     },
     "node_modules/swagger-client": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.37.0.tgz",
-      "integrity": "sha512-pzU+B+DkUbrSwlj4/E8sGeP1w84/CFgDJAt80fHu650TxnOHbqFLGQjiE6luvpRxTPdfK2zRHJP7I6CgUkI8yA==",
+      "version": "3.37.5",
+      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.37.5.tgz",
+      "integrity": "sha512-MuABJgD8vIsT5GVBTGj3HjmiEhArf58ng+YP4fo23NOJb/mKXOpKW3Rln90fnoi7ROt6IJsJy9d5kg8Yidn0/Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.22.15",
         "@scarf/scarf": "=1.4.0",
-        "@swagger-api/apidom-core": "^1.6.0",
-        "@swagger-api/apidom-error": "^1.6.0",
-        "@swagger-api/apidom-json-pointer": "^1.6.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.6.0",
-        "@swagger-api/apidom-ns-openapi-3-2": "^1.6.0",
-        "@swagger-api/apidom-reference": "^1.6.0",
+        "@swagger-api/apidom-core": "^1.11.0",
+        "@swagger-api/apidom-error": "^1.11.0",
+        "@swagger-api/apidom-json-pointer": "^1.11.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.0",
+        "@swagger-api/apidom-ns-openapi-3-2": "^1.11.0",
+        "@swagger-api/apidom-reference": "^1.11.0",
         "@swaggerexpert/cookie": "^2.0.2",
         "deepmerge": "~4.3.0",
         "fast-json-patch": "^3.0.0-1",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.2.0",
         "neotraverse": "=0.6.18",
         "node-abort-controller": "^3.1.1",
-        "node-fetch-commonjs": "^3.3.2",
         "openapi-path-templating": "^2.2.1",
         "openapi-server-url-templating": "^1.3.0",
         "ramda": "^0.30.1",
         "ramda-adjunct": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/swagger-ui-react": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-5.32.0.tgz",
-      "integrity": "sha512-2mmrtvfp0EA90pdT8qXTMu26ex03TG2bsjvDAwXhdfCm+9foyadYJN+nEvDHM6/c6/xtXbdAsb6cVxBvbltnpw==",
+      "version": "5.32.8",
+      "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-5.32.8.tgz",
+      "integrity": "sha512-Cstx4Tq8fT5l2TBxHxts8pG+ks0qKSkuO1pwUwgrQQiZ241Mqs+KUODLVIonsYXL/gqX143rkcipUa4d0Rid7w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.27.1",
@@ -13448,12 +13269,12 @@
         "classnames": "^2.5.1",
         "css.escape": "1.5.1",
         "deep-extend": "0.6.0",
-        "dompurify": "=3.2.6",
+        "dompurify": "^3.4.11",
         "ieee754": "^1.2.1",
         "immutable": "^3.x.x",
         "js-file-download": "^0.4.12",
-        "js-yaml": "=4.1.1",
-        "lodash": "^4.17.21",
+        "js-yaml": "=4.2.0",
+        "lodash": "^4.18.1",
         "prop-types": "^15.8.1",
         "randexp": "^0.5.3",
         "randombytes": "^2.1.0",
@@ -13470,7 +13291,7 @@
         "reselect": "^5.1.1",
         "serialize-error": "^8.1.0",
         "sha.js": "^2.4.12",
-        "swagger-client": "^3.37.0",
+        "swagger-client": "^3.37.4",
         "url-parse": "^1.5.10",
         "xml": "=1.0.1",
         "xml-but-prettier": "^1.0.1",
@@ -13576,19 +13397,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/teeny-request/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
@@ -13603,23 +13411,24 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -13647,9 +13456,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -13711,19 +13520,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/tr46": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/tree-sitter": {
       "version": "0.21.1",
       "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
@@ -13757,9 +13553,9 @@
       }
     },
     "node_modules/tree-sitter-json/node_modules/node-addon-api": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.6.0.tgz",
-      "integrity": "sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
+      "integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -13767,9 +13563,9 @@
       }
     },
     "node_modules/tree-sitter/node_modules/node-addon-api": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.6.0.tgz",
-      "integrity": "sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
+      "integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -14194,9 +13990,9 @@
       }
     },
     "node_modules/use-intl": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.8.3.tgz",
-      "integrity": "sha512-nLxlC/RH+le6g3amA508Itnn/00mE+J22ui21QhOWo5V9hCEC43+WtnRAITbJW0ztVZphev5X9gvOf2/Dk9PLA==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.13.2.tgz",
+      "integrity": "sha512-p6/gCromeBoec+wEuOIkPaytH77RBjW94KWv8MRsNrbI4UOx8QgwNhgl9lbPOKM/b0dpanLhCYztLEH5yQUjtg==",
       "funding": [
         {
           "type": "individual",
@@ -14207,7 +14003,7 @@
       "dependencies": {
         "@formatjs/fast-memoize": "^3.1.0",
         "@schummar/icu-type-parser": "1.21.5",
-        "icu-minify": "^4.8.3",
+        "icu-minify": "^4.13.2",
         "intl-messageformat": "^11.1.0"
       },
       "peerDependencies": {
@@ -14230,9 +14026,14 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -14248,18 +14049,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.0.tgz",
-      "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/runtime": "0.115.0",
         "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.9",
-        "tinyglobby": "^0.2.15"
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.4",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -14275,8 +14075,8 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.0.0-alpha.31",
-        "esbuild": "^0.27.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
         "sass": "^1.70.0",
@@ -14341,9 +14141,9 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -14436,9 +14236,9 @@
       }
     },
     "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -14463,16 +14263,6 @@
       "integrity": "sha512-+J/2VSHN8J47gQUAvF8KDadrfz6uFYVjxoxbKWDoXVsH2u7yLdarCnIURnrMA6uSRkgX3SdmqM5BOoQjPdSh5w==",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
@@ -14505,20 +14295,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tr46": "^5.1.0",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -14728,6 +14504,21 @@
       "license": "MIT",
       "dependencies": {
         "repeat-string": "^1.5.2"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/y18n": {

--- a/prisma/migrations/20260713060000_add_application_submission_package/migration.sql
+++ b/prisma/migrations/20260713060000_add_application_submission_package/migration.sql
@@ -100,3 +100,9 @@ ALTER TABLE "ApplicationEvent"
 
 ALTER TABLE "Document"
   ADD CONSTRAINT "Document_submissionId_fkey" FOREIGN KEY ("submissionId") REFERENCES "ApplicationSubmission"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Legacy OAuth grants may already contain the previously unprivileged string
+-- mcp:submissions. Version sensitive consent so those grants stay unprivileged.
+ALTER TABLE "McpAuthCode" ADD COLUMN "sensitiveConsentVersion" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "McpAccessToken" ADD COLUMN "sensitiveConsentVersion" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "McpRefreshToken" ADD COLUMN "sensitiveConsentVersion" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/migrations/20260713060000_add_application_submission_package/migration.sql
+++ b/prisma/migrations/20260713060000_add_application_submission_package/migration.sql
@@ -1,0 +1,102 @@
+-- Safe creation defaults for new opportunities. Existing rows are unchanged.
+ALTER TABLE "Application" ALTER COLUMN "status" SET DEFAULT 'inbound';
+
+-- Structured opportunity metadata.
+ALTER TABLE "Application"
+  ADD COLUMN "canonicalJobUrl" TEXT,
+  ADD COLUMN "workMode" TEXT,
+  ADD COLUMN "eligibleCountries" JSONB,
+  ADD COLUMN "primaryLocations" JSONB,
+  ADD COLUMN "officeDaysMin" INTEGER,
+  ADD COLUMN "travelPercent" INTEGER,
+  ADD COLUMN "visaSponsorship" BOOLEAN,
+  ADD COLUMN "rightToWorkRequired" BOOLEAN,
+  ADD COLUMN "timezoneOverlap" TEXT,
+  ADD COLUMN "salaryCurrency" TEXT,
+  ADD COLUMN "salaryPeriod" TEXT,
+  ADD COLUMN "salaryType" TEXT,
+  ADD COLUMN "atsName" TEXT,
+  ADD COLUMN "requisitionId" TEXT,
+  ADD COLUMN "jobCapturedAt" TIMESTAMP(3),
+  ADD COLUMN "jobVerifiedAt" TIMESTAMP(3),
+  ADD COLUMN "jobPostedAt" TIMESTAMP(3),
+  ADD COLUMN "jobClosedAt" TIMESTAMP(3),
+  ADD COLUMN "jobContentHash" TEXT,
+  ADD COLUMN "jobLiveness" TEXT,
+  ADD COLUMN "jobSummary" TEXT,
+  ADD COLUMN "currentStage" TEXT;
+
+CREATE UNIQUE INDEX "Application_userId_canonicalJobUrl_key" ON "Application"("userId", "canonicalJobUrl");
+CREATE INDEX "Application_userId_followUpAt_idx" ON "Application"("userId", "followUpAt");
+CREATE INDEX "Application_userId_status_idx" ON "Application"("userId", "status");
+
+-- Immutable application submission snapshots.
+CREATE TABLE "ApplicationSubmission" (
+  "id" SERIAL NOT NULL,
+  "userId" TEXT NOT NULL,
+  "applicationId" INTEGER NOT NULL,
+  "idempotencyKey" TEXT NOT NULL,
+  "requestHash" TEXT NOT NULL,
+  "submittedAt" TIMESTAMP(3) NOT NULL,
+  "applicationUrl" TEXT,
+  "atsName" TEXT,
+  "requisitionId" TEXT,
+  "language" TEXT,
+  "answers" JSONB NOT NULL,
+  "candidateSalaryMin" INTEGER,
+  "candidateSalaryMax" INTEGER,
+  "candidateSalaryCurrency" TEXT,
+  "candidateSalaryPeriod" TEXT,
+  "candidateSalaryType" TEXT,
+  "candidateSalaryFlexible" BOOLEAN NOT NULL DEFAULT false,
+  "documentIds" JSONB NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "ApplicationSubmission_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ApplicationSubmission_userId_idempotencyKey_key" ON "ApplicationSubmission"("userId", "idempotencyKey");
+CREATE INDEX "ApplicationSubmission_applicationId_submittedAt_idx" ON "ApplicationSubmission"("applicationId", "submittedAt");
+
+-- Append-only lifecycle events.
+CREATE TABLE "ApplicationEvent" (
+  "id" SERIAL NOT NULL,
+  "userId" TEXT NOT NULL,
+  "applicationId" INTEGER NOT NULL,
+  "type" TEXT NOT NULL,
+  "idempotencyKey" TEXT,
+  "occurredAt" TIMESTAMP(3) NOT NULL,
+  "source" TEXT,
+  "actor" TEXT,
+  "metadata" JSONB,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "ApplicationEvent_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ApplicationEvent_userId_idempotencyKey_key" ON "ApplicationEvent"("userId", "idempotencyKey");
+CREATE INDEX "ApplicationEvent_applicationId_occurredAt_idx" ON "ApplicationEvent"("applicationId", "occurredAt");
+CREATE INDEX "ApplicationEvent_userId_type_idx" ON "ApplicationEvent"("userId", "type");
+
+-- Document lifecycle metadata and exact submission linkage.
+ALTER TABLE "Document"
+  ADD COLUMN "documentType" TEXT NOT NULL DEFAULT 'other',
+  ADD COLUMN "state" TEXT NOT NULL DEFAULT 'current',
+  ADD COLUMN "version" INTEGER NOT NULL DEFAULT 1,
+  ADD COLUMN "contentHash" TEXT,
+  ADD COLUMN "source" TEXT,
+  ADD COLUMN "generatedAt" TIMESTAMP(3),
+  ADD COLUMN "submittedAt" TIMESTAMP(3),
+  ADD COLUMN "submissionId" INTEGER;
+
+CREATE INDEX "Document_userId_documentType_state_idx" ON "Document"("userId", "documentType", "state");
+CREATE INDEX "Document_submissionId_idx" ON "Document"("submissionId");
+
+ALTER TABLE "ApplicationSubmission"
+  ADD CONSTRAINT "ApplicationSubmission_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT "ApplicationSubmission_applicationId_fkey" FOREIGN KEY ("applicationId") REFERENCES "Application"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "ApplicationEvent"
+  ADD CONSTRAINT "ApplicationEvent_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT "ApplicationEvent_applicationId_fkey" FOREIGN KEY ("applicationId") REFERENCES "Application"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "Document"
+  ADD CONSTRAINT "Document_submissionId_fkey" FOREIGN KEY ("submissionId") REFERENCES "ApplicationSubmission"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,37 +8,65 @@ datasource db {
 }
 
 model Application {
-  id              Int       @id @default(autoincrement())
-  userId          String
-  user            User      @relation(fields: [userId], references: [id], onDelete: Cascade)
-  company         String
-  role            String
-  status          String    @default("applied")
-  appliedAt       DateTime?
-  lastContact     DateTime?
-  notes           String?
-  followUpAt      DateTime?
-  jobDescription  String?
-  source          String?
-  remote          Boolean   @default(false)
-  salaryMin       Int?      // minimum salary in EUR/year
-  salaryMax       Int?      // maximum salary in EUR/year
-  rating          Int?      // suitability rating 1–5
-  jobUrl          String?   // link to job listing / opportunity page
-  resumeId        String?   // Reactive Resume resume ID
-  companySize     String?   // micro | small | mid | large | enterprise
-  salaryBandMentioned Boolean @default(false)
-  triageQuality   Int?      // 1–5 triage score
-  triageReason    String?   // short note explaining the triage rating
-  incomingSource  String?   // linkedin | email | referral | outbound
-  autoRejected    Boolean   @default(false)
-  autoRejectReason String?  // reason for auto-rejection
-  archivedAt      DateTime?
-  createdAt       DateTime  @default(now())
-  updatedAt       DateTime  @updatedAt
-  documents       Document[]
-  contacts        Contact[]
-  cvPatch         CvPatch?
+  id                  Int                     @id @default(autoincrement())
+  userId              String
+  user                User                    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  company             String
+  role                String
+  status              String                  @default("inbound")
+  appliedAt           DateTime?
+  lastContact         DateTime?
+  notes               String?
+  followUpAt          DateTime?
+  jobDescription      String?
+  source              String?
+  remote              Boolean                 @default(false)
+  salaryMin           Int? // advertised minimum salary
+  salaryMax           Int? // advertised maximum salary
+  rating              Int? // suitability rating 1–5
+  jobUrl              String? // link to job listing / opportunity page
+  canonicalJobUrl     String? // normalized exact URL for duplicate-safe intake
+  resumeId            String? // Reactive Resume resume ID
+  companySize         String? // micro | small | mid | large | enterprise
+  salaryBandMentioned Boolean                 @default(false)
+  triageQuality       Int? // 1–5 triage score
+  triageReason        String? // short note explaining the triage rating
+  incomingSource      String? // linkedin | email | referral | outbound
+  autoRejected        Boolean                 @default(false)
+  autoRejectReason    String? // reason for auto-rejection
+  archivedAt          DateTime?
+  workMode            String? // remote | hybrid | onsite | flexible
+  eligibleCountries   Json?
+  primaryLocations    Json?
+  officeDaysMin       Int?
+  travelPercent       Int?
+  visaSponsorship     Boolean?
+  rightToWorkRequired Boolean?
+  timezoneOverlap     String?
+  salaryCurrency      String?
+  salaryPeriod        String? // annual | monthly | daily | hourly
+  salaryType          String? // base | total_compensation | contract_rate
+  atsName             String?
+  requisitionId       String?
+  jobCapturedAt       DateTime?
+  jobVerifiedAt       DateTime?
+  jobPostedAt         DateTime?
+  jobClosedAt         DateTime?
+  jobContentHash      String?
+  jobLiveness         String? // unknown | live | closed | expired
+  jobSummary          String?
+  currentStage        String?
+  createdAt           DateTime                @default(now())
+  updatedAt           DateTime                @updatedAt
+  documents           Document[]
+  contacts            Contact[]
+  cvPatch             CvPatch?
+  submissions         ApplicationSubmission[]
+  events              ApplicationEvent[]
+
+  @@unique([userId, canonicalJobUrl])
+  @@index([userId, followUpAt])
+  @@index([userId, status])
 }
 
 model Contact {
@@ -54,38 +82,99 @@ model Contact {
 }
 
 model Document {
-  id           Int           @id @default(autoincrement())
+  id           Int                    @id @default(autoincrement())
   userId       String
-  user         User          @relation(fields: [userId], references: [id], onDelete: Cascade)
-  filename     String        // stored filename on disk (uuid-based)
-  originalName String        // user-facing name
-  size         Int           // bytes
+  user         User                   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  filename     String // stored filename on disk (uuid-based)
+  originalName String // user-facing name
+  size         Int // bytes
   mimeType     String
-  uploadedAt   DateTime      @default(now())
+  documentType String                 @default("other")
+  state        String                 @default("current")
+  version      Int                    @default(1)
+  contentHash  String?
+  source       String?
+  generatedAt  DateTime?
+  submittedAt  DateTime?
+  submissionId Int?
+  submission   ApplicationSubmission? @relation(fields: [submissionId], references: [id], onDelete: SetNull)
+  uploadedAt   DateTime               @default(now())
   applications Application[]
+
+  @@index([userId, documentType, state])
+  @@index([submissionId])
+}
+
+model ApplicationSubmission {
+  id                      Int         @id @default(autoincrement())
+  userId                  String
+  user                    User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  applicationId           Int
+  application             Application @relation(fields: [applicationId], references: [id], onDelete: Cascade)
+  idempotencyKey          String
+  requestHash             String
+  submittedAt             DateTime
+  applicationUrl          String?
+  atsName                 String?
+  requisitionId           String?
+  language                String?
+  answers                 Json
+  candidateSalaryMin      Int?
+  candidateSalaryMax      Int?
+  candidateSalaryCurrency String?
+  candidateSalaryPeriod   String?
+  candidateSalaryType     String?
+  candidateSalaryFlexible Boolean     @default(false)
+  documentIds             Json
+  createdAt               DateTime    @default(now())
+  documents               Document[]
+
+  @@unique([userId, idempotencyKey])
+  @@index([applicationId, submittedAt])
+}
+
+model ApplicationEvent {
+  id             Int         @id @default(autoincrement())
+  userId         String
+  user           User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  applicationId  Int
+  application    Application @relation(fields: [applicationId], references: [id], onDelete: Cascade)
+  type           String
+  idempotencyKey String?
+  occurredAt     DateTime
+  source         String?
+  actor          String?
+  metadata       Json?
+  createdAt      DateTime    @default(now())
+
+  @@unique([userId, idempotencyKey])
+  @@index([applicationId, occurredAt])
+  @@index([userId, type])
 }
 
 model User {
-  id            String         @id
-  email         String         @unique
-  name          String?
-  image         String?
-  emailVerified Boolean        @default(false)
-  isAdmin       Boolean        @default(false)
-  createdAt     DateTime       @default(now())
-  updatedAt     DateTime       @updatedAt
-  sessions      Session[]
-  accounts      Account[]
-  applications  Application[]
-  documents     Document[]
-  apiTokens     UserApiToken[]
-  shareLinks    ShareLink[]
-  auditLogsAsActor    AdminAuditLog[]    @relation("auditActor")
-  auditLogsAsTarget   AdminAuditLog[]    @relation("auditTarget")
-  emailIntegration    EmailIntegration?
-  scannedEmails       ScannedEmail[]
-  mcpAccessTokens     McpAccessToken[]
-  cvProfile           CvProfile?
+  id                     String                  @id
+  email                  String                  @unique
+  name                   String?
+  image                  String?
+  emailVerified          Boolean                 @default(false)
+  isAdmin                Boolean                 @default(false)
+  createdAt              DateTime                @default(now())
+  updatedAt              DateTime                @updatedAt
+  sessions               Session[]
+  accounts               Account[]
+  applications           Application[]
+  documents              Document[]
+  apiTokens              UserApiToken[]
+  shareLinks             ShareLink[]
+  auditLogsAsActor       AdminAuditLog[]         @relation("auditActor")
+  auditLogsAsTarget      AdminAuditLog[]         @relation("auditTarget")
+  emailIntegration       EmailIntegration?
+  scannedEmails          ScannedEmail[]
+  mcpAccessTokens        McpAccessToken[]
+  cvProfile              CvProfile?
+  applicationSubmissions ApplicationSubmission[]
+  applicationEvents      ApplicationEvent[]
 }
 
 model UserApiToken {
@@ -101,25 +190,25 @@ model UserApiToken {
 }
 
 model ShareLink {
-  id         Int       @id @default(autoincrement())
-  code       String    @unique         // short URL-safe code (8 chars)
-  userId     String                    // creator
-  user       User      @relation(fields: [userId], references: [id], onDelete: Cascade)
-  targetType String                    // "share_page" | "document"
-  targetId   String?                   // e.g. document ID; null for share_page
-  createdAt  DateTime  @default(now())
+  id         Int      @id @default(autoincrement())
+  code       String   @unique // short URL-safe code (8 chars)
+  userId     String // creator
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  targetType String // "share_page" | "document"
+  targetId   String? // e.g. document ID; null for share_page
+  createdAt  DateTime @default(now())
 
   @@unique([userId, targetType, targetId])
 }
 
 model AdminAuditLog {
-  id         Int      @id @default(autoincrement())
-  actorId    String
-  actor      User     @relation("auditActor", fields: [actorId], references: [id], onDelete: Cascade)
-  action     String   // "grant_admin" | "revoke_admin"
-  targetId   String
-  target     User     @relation("auditTarget", fields: [targetId], references: [id], onDelete: Cascade)
-  createdAt  DateTime @default(now())
+  id        Int      @id @default(autoincrement())
+  actorId   String
+  actor     User     @relation("auditActor", fields: [actorId], references: [id], onDelete: Cascade)
+  action    String // "grant_admin" | "revoke_admin"
+  targetId  String
+  target    User     @relation("auditTarget", fields: [targetId], references: [id], onDelete: Cascade)
+  createdAt DateTime @default(now())
 
   @@index([createdAt])
 }
@@ -154,35 +243,35 @@ model Account {
 }
 
 model EmailIntegration {
-  id              Int      @id @default(autoincrement())
-  userId          String   @unique
-  user            User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  provider        String   // "gmail" | "outlook"
-  encryptedToken  String   // AES-256-GCM encrypted refresh token
-  lastHistoryId   String?  // Gmail history cursor for incremental sync
-  scanFrequency   Int      @default(15) // minutes between scans
-  autoImport      String   @default("review") // "off" | "review" | "auto"
-  scanDaysBack    Int      @default(7) // how many days back to scan on first run
-  enabled         Boolean  @default(true)
-  lastScanAt      DateTime?
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  id             Int       @id @default(autoincrement())
+  userId         String    @unique
+  user           User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  provider       String // "gmail" | "outlook"
+  encryptedToken String // AES-256-GCM encrypted refresh token
+  lastHistoryId  String? // Gmail history cursor for incremental sync
+  scanFrequency  Int       @default(15) // minutes between scans
+  autoImport     String    @default("review") // "off" | "review" | "auto"
+  scanDaysBack   Int       @default(7) // how many days back to scan on first run
+  enabled        Boolean   @default(true)
+  lastScanAt     DateTime?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
 }
 
 model ScannedEmail {
-  id              Int      @id @default(autoincrement())
-  userId          String
-  user            User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  messageId       String   // provider's unique message ID
-  subject         String
-  sender          String
-  receivedAt      DateTime
-  classification  String?  // "applied" | "interview" | "rejection" | "offer" | null
-  confidence      String   @default("low") // "high" | "medium" | "low"
-  extractedData   String?  // JSON: { company, role, date }
-  status          String   @default("pending") // "pending" | "imported" | "dismissed"
-  applicationId   Int?     // linked Application after import
-  createdAt       DateTime @default(now())
+  id             Int      @id @default(autoincrement())
+  userId         String
+  user           User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  messageId      String // provider's unique message ID
+  subject        String
+  sender         String
+  receivedAt     DateTime
+  classification String? // "applied" | "interview" | "rejection" | "offer" | null
+  confidence     String   @default("low") // "high" | "medium" | "low"
+  extractedData  String? // JSON: { company, role, date }
+  status         String   @default("pending") // "pending" | "imported" | "dismissed"
+  applicationId  Int? // linked Application after import
+  createdAt      DateTime @default(now())
 
   @@unique([userId, messageId])
   @@index([userId, status])
@@ -200,54 +289,54 @@ model Verification {
 // ── MCP OAuth 2.1 ───────────────────────────────────────────────────────────
 
 model McpOAuthClient {
-  id                   String   @id @default(cuid())
-  clientId             String   @unique
-  clientSecretHash     String?
-  clientName           String?
-  redirectUris         String[] // allowed redirect URIs
-  grantTypes           String[] // ["authorization_code", "refresh_token"]
-  responseTypes        String[] // ["code"]
-  tokenEndpointAuth    String   @default("client_secret_post")
+  id                    String    @id @default(cuid())
+  clientId              String    @unique
+  clientSecretHash      String?
+  clientName            String?
+  redirectUris          String[] // allowed redirect URIs
+  grantTypes            String[] // ["authorization_code", "refresh_token"]
+  responseTypes         String[] // ["code"]
+  tokenEndpointAuth     String    @default("client_secret_post")
   clientSecretExpiresAt DateTime? // null = never expires
-  createdAt            DateTime @default(now())
+  createdAt             DateTime  @default(now())
 }
 
 model McpAuthCode {
-  id              String   @id @default(cuid())
-  code            String   @unique
-  clientId        String
-  userId          String
-  redirectUri     String
-  codeChallenge   String   // PKCE S256
-  scopes          String[] // granted scopes
-  expiresAt       DateTime
-  used            Boolean  @default(false)
-  createdAt       DateTime @default(now())
+  id            String   @id @default(cuid())
+  code          String   @unique
+  clientId      String
+  userId        String
+  redirectUri   String
+  codeChallenge String // PKCE S256
+  scopes        String[] // granted scopes
+  expiresAt     DateTime
+  used          Boolean  @default(false)
+  createdAt     DateTime @default(now())
 
   @@index([code])
 }
 
 model McpAccessToken {
-  id         String   @id @default(cuid())
-  tokenHash  String   @unique
-  clientId   String
-  userId     String
-  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  scopes     String[]
-  expiresAt  DateTime
-  createdAt  DateTime @default(now())
+  id        String   @id @default(cuid())
+  tokenHash String   @unique
+  clientId  String
+  userId    String
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  scopes    String[]
+  expiresAt DateTime
+  createdAt DateTime @default(now())
 
   @@index([userId])
 }
 
 model McpRefreshToken {
-  id         String   @id @default(cuid())
-  tokenHash  String   @unique
-  clientId   String
-  userId     String
-  scopes     String[]
-  expiresAt  DateTime
-  createdAt  DateTime @default(now())
+  id        String   @id @default(cuid())
+  tokenHash String   @unique
+  clientId  String
+  userId    String
+  scopes    String[]
+  expiresAt DateTime
+  createdAt DateTime @default(now())
 }
 
 // ── CV Generation ────────────────────────────────────────────────────────────
@@ -257,10 +346,10 @@ model CvProfile {
   userId     String   @unique
   user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   name       String
-  contact    Json     // { email, phone, linkedin, github, location }
-  profile    String   // professional summary
-  skills     Json     // [{ category: string, items: string[] }]
-  experience Json     // [{ id, company, title, date, location, tier, bullets }]
+  contact    Json // { email, phone, linkedin, github, location }
+  profile    String // professional summary
+  skills     Json // [{ category: string, items: string[] }]
+  experience Json // [{ id, company, title, date, location, tier, bullets }]
   projects   Json     @default("[]") // [{ name, url, stack, description }]
   education  Json     @default("[]") // [{ institution, degree, date, location, details? }]
   createdAt  DateTime @default(now())
@@ -272,11 +361,11 @@ model CvPatch {
   applicationId    Int         @unique
   application      Application @relation(fields: [applicationId], references: [id], onDelete: Cascade)
   profileOverride  String?
-  experienceIds    Json        // string[] — ordered IDs of experience entries to include
-  skillCategories  Json        // string[] — ordered category names to include
+  experienceIds    Json // string[] — ordered IDs of experience entries to include
+  skillCategories  Json // string[] — ordered category names to include
   includeProjects  Boolean     @default(false)
   includeEducation Boolean     @default(true)
-  documentId       Int?        // ID of the generated CV Document
+  documentId       Int? // ID of the generated CV Document
   createdAt        DateTime    @default(now())
   updatedAt        DateTime    @updatedAt
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -302,41 +302,44 @@ model McpOAuthClient {
 }
 
 model McpAuthCode {
-  id            String   @id @default(cuid())
-  code          String   @unique
-  clientId      String
-  userId        String
-  redirectUri   String
-  codeChallenge String // PKCE S256
-  scopes        String[] // granted scopes
-  expiresAt     DateTime
-  used          Boolean  @default(false)
-  createdAt     DateTime @default(now())
+  id                      String   @id @default(cuid())
+  code                    String   @unique
+  clientId                String
+  userId                  String
+  redirectUri             String
+  codeChallenge           String // PKCE S256
+  scopes                  String[] // granted scopes
+  sensitiveConsentVersion Int      @default(0)
+  expiresAt               DateTime
+  used                    Boolean  @default(false)
+  createdAt               DateTime @default(now())
 
   @@index([code])
 }
 
 model McpAccessToken {
-  id        String   @id @default(cuid())
-  tokenHash String   @unique
-  clientId  String
-  userId    String
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  scopes    String[]
-  expiresAt DateTime
-  createdAt DateTime @default(now())
+  id                      String   @id @default(cuid())
+  tokenHash               String   @unique
+  clientId                String
+  userId                  String
+  user                    User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  scopes                  String[]
+  sensitiveConsentVersion Int      @default(0)
+  expiresAt               DateTime
+  createdAt               DateTime @default(now())
 
   @@index([userId])
 }
 
 model McpRefreshToken {
-  id        String   @id @default(cuid())
-  tokenHash String   @unique
-  clientId  String
-  userId    String
-  scopes    String[]
-  expiresAt DateTime
-  createdAt DateTime @default(now())
+  id                      String   @id @default(cuid())
+  tokenHash               String   @unique
+  clientId                String
+  userId                  String
+  scopes                  String[]
+  sensitiveConsentVersion Int      @default(0)
+  expiresAt               DateTime
+  createdAt               DateTime @default(now())
 }
 
 // ── CV Generation ────────────────────────────────────────────────────────────

--- a/public/llm.txt
+++ b/public/llm.txt
@@ -45,6 +45,10 @@ Multi-tenant: each user only sees their own data. Admin users (isAdmin flag) byp
 | GET | /api/applications/:id | session or token | Get single |
 | PATCH | /api/applications/:id | session or token | Update |
 | DELETE | /api/applications/:id | session or token | Delete |
+| GET | /api/applications/:id/submissions | session or token | List immutable submission snapshots; answers are omitted unless `includeAnswers=true` |
+| POST | /api/applications/:id/submissions | session or token | Atomically record answers, compensation, documents, status, follow-up, and timeline event |
+| GET | /api/applications/:id/events | session or token | List append-only application timeline events |
+| POST | /api/applications/:id/events | session or token | Append a timeline event |
 
 ### Contacts (per application)
 | Method | Path | Auth | Description |
@@ -57,9 +61,9 @@ Multi-tenant: each user only sees their own data. Admin users (isAdmin flag) byp
 ### Documents
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
-| GET | /api/documents | session or token | List documents |
+| GET | /api/documents | session or token | List documents; filters: applicationId, documentType, state, submissionId, orphaned, fields, page, pageSize |
 | POST | /api/documents | session or token | Upload (multipart/form-data, field: file; PDF/JPEG/PNG/WEBP up to 10MB) |
-| PATCH | /api/documents/:id | session or token | Update: rename (`{ "originalName": "new.pdf" }`) or update links (`{ "applicationIds": [...] }`) |
+| PATCH | /api/documents/:id | session or token | Rename, update links, or classify lifecycle metadata; submitted document versions are immutable |
 | DELETE | /api/documents/:id | session or token | Delete |
 | GET | /api/documents/:id/file | session or token | Download file |
 
@@ -82,12 +86,25 @@ Multi-tenant: each user only sees their own data. Admin users (isAdmin flag) byp
 `inbound` | `applied` | `interview` | `offer` | `rejected`
 
 ## MCP document tools
-- `list_documents`: list document metadata
+- `list_documents`: filter and paginate document metadata, including lifecycle/submission linkage
 - `get_document`: get document metadata by ID
 - `upload_document_content`: upload PDF/JPEG/PNG/WEBP content up to 10MB using standard base64
 - `download_document_content`: download small files inline as base64; returns a signed URL for larger GCS-backed files
 - `update_document_links`: replace linked application IDs
+- `update_document_metadata`: classify type, state, version, source, and hash
 - `delete_document`: delete document metadata and stored content
+
+## MCP application submission and recall tools
+- `record_application_submission`: atomically preserve exact submitted answers, compensation, document versions, status, follow-up, and event; supports idempotency, dry-run, and optimistic concurrency
+- `list_application_submissions`: list redacted submission summaries
+- `get_application_submission`: owner-scoped sensitive detail with exact answers and documents
+- `get_interview_recall_package`: fetch the JD, exact submissions, timeline, and documents for interview preparation
+- `append_application_note`: concurrency-safe, idempotent note append
+- `record_application_event` / `list_application_events`: append/read the immutable timeline
+- `pipeline_healthcheck`: deterministic follow-up and metadata completeness checks
+- `find_application_by_job_url` / `upsert_application_by_job_url`: canonical URL duplicate prevention
+
+Submission answers, submitted document artifacts, and destructive application deletion are sensitive. MCP OAuth access requires `mcp:tools` for the base toolset and explicit user consent to `mcp:submissions` for those sensitive operations.
 
 ## Example: create application via API token
 ```

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -521,8 +521,8 @@
                 "required": ["type"],
                 "properties": {
                   "type": { "type": "string", "maxLength": 100 },
-                  "idempotencyKey": { "type": ["string", "null"] },
-                  "occurredAt": { "type": "string", "format": "date-time" },
+                  "idempotencyKey": { "type": ["string", "null"], "description": "When supplied, occurredAt is required so retries hash deterministically." },
+                  "occurredAt": { "type": "string", "format": "date-time", "description": "Required when idempotencyKey is supplied." },
                   "metadata": { "type": "object", "additionalProperties": true }
                 }
               }

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -71,6 +71,28 @@
           "followUpAt":     { "type": ["string", "null"],     "format": "date-time" },
           "notes":          { "type": ["string", "null"],     "example": "Had a great first call." },
           "jobDescription": { "type": ["string", "null"],     "example": "We are looking for…" },
+          "canonicalJobUrl": { "type": ["string", "null"], "format": "uri" },
+          "workMode": { "type": ["string", "null"], "enum": ["remote", "hybrid", "onsite", "flexible", null] },
+          "eligibleCountries": { "type": "array", "items": { "type": "string" } },
+          "primaryLocations": { "type": "array", "items": { "type": "string" } },
+          "officeDaysMin": { "type": ["integer", "null"] },
+          "travelPercent": { "type": ["integer", "null"] },
+          "visaSponsorship": { "type": ["boolean", "null"] },
+          "rightToWorkRequired": { "type": ["boolean", "null"] },
+          "timezoneOverlap": { "type": ["string", "null"] },
+          "salaryCurrency": { "type": ["string", "null"] },
+          "salaryPeriod": { "type": ["string", "null"] },
+          "salaryType": { "type": ["string", "null"] },
+          "atsName": { "type": ["string", "null"] },
+          "requisitionId": { "type": ["string", "null"] },
+          "jobCapturedAt": { "type": ["string", "null"], "format": "date-time" },
+          "jobVerifiedAt": { "type": ["string", "null"], "format": "date-time" },
+          "jobPostedAt": { "type": ["string", "null"], "format": "date-time" },
+          "jobClosedAt": { "type": ["string", "null"], "format": "date-time" },
+          "jobContentHash": { "type": ["string", "null"] },
+          "jobLiveness": { "type": ["string", "null"] },
+          "jobSummary": { "type": ["string", "null"] },
+          "currentStage": { "type": ["string", "null"] },
           "createdAt":      { "type": "string",               "format": "date-time" },
           "updatedAt":      { "type": "string",               "format": "date-time" },
           "contacts":       {
@@ -90,11 +112,68 @@
           "originalName": { "type": "string",  "example": "my-resume.pdf" },
           "size":         { "type": "integer", "example": 204800, "description": "File size in bytes." },
           "mimeType":     { "type": "string",  "example": "application/pdf", "enum": ["application/pdf", "image/jpeg", "image/png", "image/webp"] },
+          "documentType": { "type": "string" },
+          "state": { "type": "string", "enum": ["draft", "current", "submitted", "superseded", "historical", "orphaned"] },
+          "version": { "type": "integer", "minimum": 1 },
+          "contentHash": { "type": ["string", "null"] },
+          "source": { "type": ["string", "null"] },
+          "generatedAt": { "type": ["string", "null"], "format": "date-time" },
+          "submittedAt": { "type": ["string", "null"], "format": "date-time" },
+          "submissionId": { "type": ["string", "null"] },
           "uploadedAt":   { "type": "string",  "format": "date-time" },
           "applications": {
             "type": "array",
             "items": { "$ref": "#/components/schemas/ApplicationRef" }
           }
+        }
+      },
+      "SubmissionAnswer": {
+        "type": "object",
+        "required": ["question", "answer"],
+        "properties": {
+          "key": { "type": ["string", "null"] },
+          "question": { "type": "string", "maxLength": 1000 },
+          "answer": { "type": "string", "maxLength": 20000 },
+          "kind": { "type": ["string", "null"] },
+          "sensitive": { "type": "boolean", "default": false }
+        }
+      },
+      "ApplicationSubmission": {
+        "type": "object",
+        "description": "Immutable snapshot of one application submission. Exact answers are sensitive.",
+        "required": ["id", "applicationId", "idempotencyKey", "requestHash", "submittedAt", "documentIds"],
+        "properties": {
+          "id": { "type": "string" },
+          "applicationId": { "type": "string" },
+          "idempotencyKey": { "type": "string" },
+          "requestHash": { "type": "string" },
+          "submittedAt": { "type": "string", "format": "date-time" },
+          "applicationUrl": { "type": ["string", "null"] },
+          "atsName": { "type": ["string", "null"] },
+          "requisitionId": { "type": ["string", "null"] },
+          "language": { "type": ["string", "null"] },
+          "answers": { "type": "array", "items": { "$ref": "#/components/schemas/SubmissionAnswer" } },
+          "candidateSalaryMin": { "type": ["number", "null"] },
+          "candidateSalaryMax": { "type": ["number", "null"] },
+          "candidateSalaryCurrency": { "type": ["string", "null"] },
+          "candidateSalaryPeriod": { "type": ["string", "null"] },
+          "candidateSalaryType": { "type": ["string", "null"] },
+          "candidateSalaryFlexible": { "type": "boolean" },
+          "documentIds": { "type": "array", "items": { "type": "string" } }
+        }
+      },
+      "ApplicationEvent": {
+        "type": "object",
+        "required": ["id", "applicationId", "type", "occurredAt"],
+        "properties": {
+          "id": { "type": "string" },
+          "applicationId": { "type": "string" },
+          "type": { "type": "string" },
+          "idempotencyKey": { "type": ["string", "null"] },
+          "occurredAt": { "type": "string", "format": "date-time" },
+          "source": { "type": ["string", "null"] },
+          "actor": { "type": ["string", "null"] },
+          "metadata": { "type": ["object", "null"], "additionalProperties": true }
         }
       },
       "UserRecord": {
@@ -341,6 +420,119 @@
           "400": { "$ref": "#/components/responses/BadRequest" },
           "401": { "$ref": "#/components/responses/Unauthorized" },
           "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/api/applications/{id}/submissions": {
+      "parameters": [
+        { "name": "id", "in": "path", "required": true, "schema": { "type": "integer", "minimum": 1 } }
+      ],
+      "get": {
+        "operationId": "listApplicationSubmissions",
+        "summary": "List immutable application submission snapshots",
+        "tags": ["Applications"],
+        "security": [{ "BearerAuth": [] }, { "CookieAuth": [] }],
+        "parameters": [
+          { "name": "includeAnswers", "in": "query", "schema": { "type": "boolean", "default": false }, "description": "Include sensitive exact answers." }
+        ],
+        "responses": {
+          "200": {
+            "description": "Submission snapshots.",
+            "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/ApplicationSubmission" } } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      },
+      "post": {
+        "operationId": "recordApplicationSubmission",
+        "summary": "Atomically record an application submission",
+        "description": "Preserves exact answers, compensation, document versions, status, follow-up, and a timeline event. Supports idempotency, dry-run, and optimistic concurrency.",
+        "tags": ["Applications"],
+        "security": [{ "BearerAuth": [] }, { "CookieAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["idempotencyKey", "submittedAt"],
+                "properties": {
+                  "idempotencyKey": { "type": "string", "minLength": 8, "maxLength": 128 },
+                  "submittedAt": { "type": "string", "format": "date-time" },
+                  "followUpAt": { "type": ["string", "null"], "format": "date-time" },
+                  "applicationUrl": { "type": ["string", "null"], "format": "uri" },
+                  "atsName": { "type": ["string", "null"] },
+                  "requisitionId": { "type": ["string", "null"] },
+                  "language": { "type": ["string", "null"] },
+                  "answers": { "type": "array", "items": { "$ref": "#/components/schemas/SubmissionAnswer" } },
+                  "candidateSalaryMin": { "type": ["number", "null"] },
+                  "candidateSalaryMax": { "type": ["number", "null"] },
+                  "candidateSalaryCurrency": { "type": ["string", "null"] },
+                  "candidateSalaryPeriod": { "type": ["string", "null"] },
+                  "candidateSalaryType": { "type": ["string", "null"] },
+                  "candidateSalaryFlexible": { "type": "boolean" },
+                  "documentIds": { "type": "array", "maxItems": 20, "items": { "type": "string" } },
+                  "expectedUpdatedAt": { "type": "string", "format": "date-time" },
+                  "dryRun": { "type": "boolean", "default": false }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "Recorded submission package." },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "409": { "description": "Idempotency or optimistic-concurrency conflict." }
+        }
+      }
+    },
+    "/api/applications/{id}/events": {
+      "parameters": [
+        { "name": "id", "in": "path", "required": true, "schema": { "type": "integer", "minimum": 1 } }
+      ],
+      "get": {
+        "operationId": "listApplicationEvents",
+        "summary": "List append-only application timeline events",
+        "tags": ["Applications"],
+        "security": [{ "BearerAuth": [] }, { "CookieAuth": [] }],
+        "responses": {
+          "200": {
+            "description": "Timeline events.",
+            "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/ApplicationEvent" } } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      },
+      "post": {
+        "operationId": "recordApplicationEvent",
+        "summary": "Append an application timeline event",
+        "tags": ["Applications"],
+        "security": [{ "BearerAuth": [] }, { "CookieAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["type"],
+                "properties": {
+                  "type": { "type": "string", "maxLength": 100 },
+                  "idempotencyKey": { "type": ["string", "null"] },
+                  "occurredAt": { "type": "string", "format": "date-time" },
+                  "metadata": { "type": "object", "additionalProperties": true }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "Created timeline event." },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
           "404": { "$ref": "#/components/responses/NotFound" }
         }
       }

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -132,7 +132,7 @@
         "required": ["question", "answer"],
         "properties": {
           "key": { "type": ["string", "null"] },
-          "question": { "type": "string", "maxLength": 1000 },
+          "question": { "type": "string", "maxLength": 2000 },
           "answer": { "type": "string", "maxLength": 20000 },
           "kind": { "type": ["string", "null"] },
           "sensitive": { "type": "boolean", "default": false }
@@ -426,7 +426,7 @@
     },
     "/api/applications/{id}/submissions": {
       "parameters": [
-        { "name": "id", "in": "path", "required": true, "schema": { "type": "integer", "minimum": 1 } }
+        { "name": "id", "in": "path", "required": true, "schema": { "type": "string", "minLength": 1 } }
       ],
       "get": {
         "operationId": "listApplicationSubmissions",
@@ -491,7 +491,7 @@
     },
     "/api/applications/{id}/events": {
       "parameters": [
-        { "name": "id", "in": "path", "required": true, "schema": { "type": "integer", "minimum": 1 } }
+        { "name": "id", "in": "path", "required": true, "schema": { "type": "string", "minLength": 1 } }
       ],
       "get": {
         "operationId": "listApplicationEvents",


### PR DESCRIPTION
## Summary

- add immutable, idempotent application submission packages with exact answers, compensation, document snapshots and lifecycle events
- extend application, document and pipeline metadata across Prisma/PostgreSQL, Firestore, REST, MCP, OpenAPI and documentation
- preserve submitted artifacts during application deletion and CV regeneration
- add user-scoped concurrency controls, canonical URL uniqueness, optimistic locking and retry-safe Firestore cascades
- protect submission data with explicit `mcp:submissions` consent, versioned OAuth grants and document-level scope enforcement

## Security and integrity

- binds sensitive OAuth consent to user, client, redirect URI, PKCE challenge and requested scopes
- prevents legacy OAuth grants from activating `mcp:submissions` without versioned consent
- locks Prisma application rows for submission recording and destructive cascades
- makes submitted and historical document versions immutable and non-reusable
- orders Firestore document preservation before submission deletion and uses atomic `arrayRemove` to avoid lost concurrent updates
- rejects cross-user application/contact/document operations and deletion-state races
- does not introduce remote URL uploads, avoiding SSRF exposure

## Database and compatibility

- additive migration: `20260713060000_add_application_submission_package`
- adds submission/event tables, application metadata, document lifecycle fields and OAuth sensitive-consent provenance
- legacy applications remain valid; legacy OAuth grants default to consent version 0
- adds Firestore composite indexes and a deterministic per-user canonical-job-URL reservation collection

## Verification

- `npm test` — **181/181 passed**
- `npx tsc --noEmit` — passed
- `npm run lint -- --quiet` — passed, 0 errors
- `npm run build` — passed
- `npx prisma format` — passed
- `npx prisma validate` — passed
- `npx prisma generate` — passed
- `openspec validate --all --strict` — **2/2 passed**
- OpenAPI JSON parse and `git diff --check` — passed
- production dependency audit at critical level — passed, 0 critical findings
- added-line secret scan — no findings

## Environment limitation

A live PostgreSQL migration apply was not run because the host Docker daemon is unavailable. Prisma schema validation/generation and static migration review passed; no runtime migration result is claimed.

## OpenSpec

Change: `preserve-application-submission-package`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added immutable submission packages that preserve answers, compensation expectations, submitted materials, and replay-safe idempotency.
  * Added application timeline event endpoints (list/append) with typed payload validation.
  * Added structured job metadata with canonical job URL duplicate prevention and dry-run/concurrency-safe updates.
  * Expanded MCP and introduced sensitive-consent gating for submission operations.
  * Enhanced document browsing with pagination/filtering and document lifecycle metadata.

* **Bug Fixes**
  * Tightened validation for applications, submissions, events, documents, URLs, dates, salaries, and ratings.
  * Improved document deletion to consistently remove associated storage content and enforce immutability.

* **Documentation**
  * Updated README, REST/MCP descriptions, and OpenAPI/REST schemas, plus added Firestore index configuration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->