### PR TITLE
fix: apply production schema migrations before deployment

### DIFF
--- a/.github/workflows/deploy-hetzner.yml
+++ b/.github/workflows/deploy-hetzner.yml
@@ -251,6 +251,51 @@ jobs:
             exit 1
           fi
 
+          # The previous production incident occurred because the new image was
+          # activated without applying its committed Prisma migration. Run all
+          # database work through one-off containers so DATABASE_URL remains in
+          # the compose environment and is never printed by GitHub Actions.
+          db_count() {
+            docker compose -f docker-compose.yaml run --rm -T --no-deps \
+              --entrypoint sh "${COOLIFY_SERVICE}" \
+              -c 'exec psql "$DATABASE_URL" --no-psqlrc -v ON_ERROR_STOP=1 -Atc "SELECT COUNT(*) FROM \"Application\";"'
+          }
+
+          count_before="$(db_count)"
+          case "${count_before}" in
+            ''|*[!0-9]*)
+              echo "Could not verify the pre-migration application count." >&2
+              exit 1
+              ;;
+          esac
+          echo "Applications before migration: ${count_before}"
+
+          backup_dir="${COOLIFY_APP_DIR}/database-backups"
+          database_backup="${backup_dir}/nexus-before-${DEPLOY_SHA}-${stamp}.dump"
+          install -m 700 -d "${backup_dir}"
+          umask 077
+          docker compose -f docker-compose.yaml run --rm -T --no-deps \
+            --entrypoint sh "${COOLIFY_SERVICE}" \
+            -c 'exec pg_dump "$DATABASE_URL" --format=custom --no-owner --no-privileges' \
+            > "${database_backup}"
+          if [ ! -s "${database_backup}" ]; then
+            echo "Database backup failed or produced an empty file." >&2
+            exit 1
+          fi
+          chmod 600 "${database_backup}"
+          echo "Verified pre-migration database backup."
+
+          docker compose -f docker-compose.yaml run --rm -T --no-deps \
+            --entrypoint sh "${COOLIFY_SERVICE}" \
+            -c 'exec node /app/node_modules/prisma/build/index.js migrate deploy --schema=/app/prisma/schema.prisma'
+
+          count_after="$(db_count)"
+          if [ "${count_after}" != "${count_before}" ]; then
+            echo "Application count changed during additive migration; refusing to activate image." >&2
+            exit 1
+          fi
+          echo "Applications after migration: ${count_after}"
+
           docker compose -f docker-compose.yaml up -d "${COOLIFY_SERVICE}"
           ps_format="{{.Names}} {{.Image}} {{.Status}}"
           docker ps --filter "name=${COOLIFY_SERVICE}" --format "${ps_format}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npx prisma generate
 RUN npm run build
 
 FROM node:22-alpine AS runner
-RUN apk add --no-cache openssl
+RUN apk add --no-cache openssl postgresql-client
 WORKDIR /app
 ENV NODE_ENV=production
 RUN addgroup --system --gid 1001 nodejs
@@ -19,6 +19,8 @@ COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/prisma ./prisma
 COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
+COPY --from=builder /app/node_modules/prisma ./node_modules/prisma
+COPY --from=builder /app/node_modules/@prisma ./node_modules/@prisma
 USER nextjs
 ENV PORT=8080
 EXPOSE ${PORT}

--- a/openspec/changes/ensure-production-schema-migrations/.openspec.yaml
+++ b/openspec/changes/ensure-production-schema-migrations/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-14

--- a/openspec/changes/ensure-production-schema-migrations/design.md
+++ b/openspec/changes/ensure-production-schema-migrations/design.md
@@ -1,0 +1,36 @@
+## Context
+
+The production service runs from a minimal standalone Next.js image on Hetzner/Coolify. The image includes `prisma/schema.prisma` and migration SQL but not the Prisma CLI. The existing workflow starts the new image immediately and never runs migrations. Database credentials are available only through the compose service environment on the server.
+
+## Goals / Non-Goals
+
+**Goals**
+- Preserve all existing application data.
+- Produce a verified backup before schema mutation.
+- Apply migrations before the new application container becomes active.
+- Fail closed if backup or migration fails.
+- Keep credentials out of workflow output.
+
+**Non-goals**
+- Changing database providers.
+- Backfilling optional metadata.
+- Automated destructive recovery.
+
+## Decisions
+
+1. Run backup and migration through one-off compose containers using the target service environment. This avoids exporting `DATABASE_URL` into GitHub Actions logs.
+2. Install the PostgreSQL client only inside the ephemeral backup container and stream a custom-format dump to a server-side file with mode `0600`.
+3. Run the repository-pinned Prisma CLI version through `npx` in an ephemeral migration container. The image already contains the schema and migration directory.
+4. Execute backup and migration before `docker compose up -d`, so the prior application remains active if either operation fails.
+5. Emit only aggregate counts and migration status, never row data or connection strings.
+
+## Risks and Mitigations
+
+- **Package download unavailable:** deployment aborts before replacing the running app.
+- **Backup failure:** deployment aborts; migration does not run.
+- **Migration failure:** the backup remains available and the old app remains active. The additive migration contains no destructive statements.
+- **Disk growth:** backups are compressed custom-format dumps; retention cleanup is intentionally manual until a reviewed policy exists.
+
+## Rollback
+
+If migration fails after partial application, stop deployment, inspect Prisma migration state, and restore only from the verified backup after explicit operator approval. Application image rollback alone does not reverse database schema changes.

--- a/openspec/changes/ensure-production-schema-migrations/proposal.md
+++ b/openspec/changes/ensure-production-schema-migrations/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The Hetzner deployment workflow replaces the application image without applying committed Prisma migrations. After merge `057aa10`, production code queried newly added columns while the production PostgreSQL schema remained on the previous version, causing authenticated application and MCP requests to return HTTP 500 and making existing opportunities appear missing.
+
+## What Changes
+
+- Take a timestamped PostgreSQL backup before applying production migrations.
+- Record read-only pre/post migration application counts without exposing row contents or credentials.
+- Run `prisma migrate deploy` using the exact Prisma version used by the repository before restarting the application service.
+- Abort deployment if backup or migration fails, leaving the previous application container running.
+- Verify the deployed service and preserve backups for manual recovery.
+
+## Non-Goals
+
+- No deletion, reseeding, ownership reassignment, or application-data rewrite.
+- No change to the feature schema or submission-package behavior.
+- No automatic restoration from backup.
+
+## Capabilities
+
+### New Capabilities
+- `production-schema-deployment`: Production deploys safely back up PostgreSQL and apply committed Prisma migrations before activating a new image.
+
+## Impact
+
+- `.github/workflows/deploy-hetzner.yml`
+- Production PostgreSQL migration and deployment order
+- Operational backup storage under the Coolify application directory

--- a/openspec/changes/ensure-production-schema-migrations/specs/production-schema-deployment/spec.md
+++ b/openspec/changes/ensure-production-schema-migrations/specs/production-schema-deployment/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Backup before production migration
+The deployment system SHALL create and verify a timestamped PostgreSQL custom-format backup before executing any committed production migration.
+
+#### Scenario: Backup succeeds
+- **WHEN** a production deployment includes schema migrations
+- **THEN** the current database is dumped to a protected server-side backup file
+- **AND** the deployment verifies that the backup is non-empty before continuing
+
+#### Scenario: Backup fails
+- **WHEN** the database backup command fails or creates an empty file
+- **THEN** the deployment stops before migration or application replacement
+
+### Requirement: Migrate before activating the image
+The deployment system SHALL apply committed Prisma migrations before replacing the running application container.
+
+#### Scenario: Migration succeeds
+- **WHEN** backup verification succeeds
+- **THEN** `prisma migrate deploy` runs against the compose service database environment
+- **AND** the new application image is activated only after migration succeeds
+
+#### Scenario: Migration fails
+- **WHEN** `prisma migrate deploy` fails
+- **THEN** the deployment stops
+- **AND** the previous application container remains active
+- **AND** the verified backup is retained
+
+### Requirement: Privacy-preserving verification
+The deployment system SHALL verify data presence without exposing credentials or application contents.
+
+#### Scenario: Migration is observed
+- **WHEN** pre- and post-migration diagnostics run
+- **THEN** logs contain only aggregate application counts and migration status
+- **AND** connection strings, user IDs, company names, and job details are not logged

--- a/openspec/changes/ensure-production-schema-migrations/tasks.md
+++ b/openspec/changes/ensure-production-schema-migrations/tasks.md
@@ -1,0 +1,19 @@
+## 1. Incident Verification
+
+- [x] 1.1 Confirm the merged image deployed successfully while authenticated application/MCP requests return HTTP 500.
+- [x] 1.2 Verify the committed migration is additive and contains no `DROP`, `TRUNCATE`, or unconditional `DELETE` statements.
+- [x] 1.3 Confirm the Hetzner workflow does not run Prisma migrations.
+
+## 2. Safe Deployment Migration
+
+- [x] 2.1 Add a protected pre-migration PostgreSQL backup step using the compose service environment.
+- [x] 2.2 Add privacy-preserving pre/post application counts.
+- [x] 2.3 Run the image-bundled, lockfile-pinned Prisma migration command before activating the target image.
+- [x] 2.4 Abort without replacing the running app when backup or migration fails.
+
+## 3. Verification and Recovery
+
+- [x] 3.1 Validate workflow syntax, OpenSpec, tests, and build.
+- [ ] 3.2 Deploy the hotfix and verify the migration job succeeds.
+- [ ] 3.3 Confirm the old application count remains present and authenticated MCP access recovers.
+- [ ] 3.4 Confirm the application UI shows the historical opportunities again.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,1 @@
+schema: spec-driven


### PR DESCRIPTION
## Incident

After #127 deployed, authenticated application and MCP requests returned HTTP 500. Existing opportunities appeared missing because the production PostgreSQL schema was not migrated before the new image queried newly added columns. The feature migration is additive and contains no destructive statements.

## Fix

- bundle the lockfile-pinned Prisma CLI and PostgreSQL client into the runtime image
- collect aggregate pre/post migration application counts
- create and verify a protected custom-format `pg_dump`
- run `prisma migrate deploy` before activating the new image
- abort before replacement if backup, migration, or count verification fails

## Verification

- 184/184 tests
- TypeScript and ESLint
- production build
- workflow parsed by Prettier
- OpenSpec strict validation
- `git diff --check`

## Recovery validation after merge

The deployment log must show the same non-zero application count before and after migration. Authenticated MCP access will then be probed to confirm the existing opportunities are visible again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Production deployments now back up the database and apply schema migrations before activating the updated application.
  * Deployments verify migration safety using aggregate application counts and stop automatically if checks fail.
  * Verified timestamped backups are retained to support recovery.

* **Documentation**
  * Added deployment requirements, recovery guidance, and operational checklists for production schema migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->