### PR TITLE
fix: sanitize Prisma URLs for production database tools

### DIFF
--- a/.github/workflows/deploy-hetzner.yml
+++ b/.github/workflows/deploy-hetzner.yml
@@ -258,7 +258,7 @@ jobs:
           db_count() {
             docker compose -f docker-compose.yaml run --rm -T --no-deps \
               --entrypoint sh "${COOLIFY_SERVICE}" \
-              -c 'exec psql "$DATABASE_URL" --no-psqlrc -v ON_ERROR_STOP=1 -Atc "SELECT COUNT(*) FROM \"Application\";"'
+              -c 'PG_DATABASE_URL="$(node /app/prisma/libpq-url.mjs)"; exec psql "$PG_DATABASE_URL" --no-psqlrc -v ON_ERROR_STOP=1 -Atc "SELECT COUNT(*) FROM \"Application\";"'
           }
 
           count_before="$(db_count)"
@@ -276,7 +276,7 @@ jobs:
           umask 077
           docker compose -f docker-compose.yaml run --rm -T --no-deps \
             --entrypoint sh "${COOLIFY_SERVICE}" \
-            -c 'exec pg_dump "$DATABASE_URL" --format=custom --no-owner --no-privileges' \
+            -c 'PG_DATABASE_URL="$(node /app/prisma/libpq-url.mjs)"; exec pg_dump "$PG_DATABASE_URL" --format=custom --no-owner --no-privileges' \
             > "${database_backup}"
           if [ ! -s "${database_backup}" ]; then
             echo "Database backup failed or produced an empty file." >&2

--- a/prisma/libpq-url.mjs
+++ b/prisma/libpq-url.mjs
@@ -1,0 +1,17 @@
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+  throw new Error("DATABASE_URL is required");
+}
+
+const url = new URL(databaseUrl);
+for (const parameter of [
+  "schema",
+  "connection_limit",
+  "pool_timeout",
+  "socket_timeout",
+  "pgbouncer",
+]) {
+  url.searchParams.delete(parameter);
+}
+
+process.stdout.write(url.toString());


### PR DESCRIPTION
## Incident follow-up

The safe recovery deployment aborted before backup or migration because libpq rejects Prisma's `schema=public` URL parameter.

## Fix

- add a small image-bundled URL adapter that removes only Prisma-specific query parameters
- preserve standard PostgreSQL parameters such as `sslmode`
- use the adapted URL only for `psql` and `pg_dump`; Prisma continues to receive the original URL

## Verification

- reproduced the exact failing URL shape
- sanitizer preserves standard PostgreSQL parameters
- workflow syntax/format validation
- TypeScript, ESLint, OpenSpec strict, and diff checks
