### PR TITLE
ops: add direct production database recovery

### DIFF
--- a/.github/workflows/deploy-hetzner.yml
+++ b/.github/workflows/deploy-hetzner.yml
@@ -3,6 +3,9 @@ name: Deploy to Hetzner
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - ".github/workflows/deploy-hetzner.yml"
+      - ".github/workflows/recover-production-db.yml"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/recover-production-db.yml
+++ b/.github/workflows/recover-production-db.yml
@@ -1,0 +1,120 @@
+name: Recover Production Database
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: production-database-recovery
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  COOLIFY_APP_DIR: ${{ vars.HETZNER_COOLIFY_APP_DIR }}
+  COOLIFY_APP_DIR_DEFAULT: >-
+    /data/coolify/applications/tj4r2ezipwho1zvjhg78a5wu
+  COOLIFY_SERVICE: ${{ vars.HETZNER_COOLIFY_SERVICE }}
+
+jobs:
+  recover:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Normalize recovery environment
+        run: |
+          set -euo pipefail
+          app_dir="${COOLIFY_APP_DIR:-}"
+          if [ -z "${app_dir}" ]; then
+            app_dir="${COOLIFY_APP_DIR_DEFAULT}"
+          fi
+          echo "COOLIFY_APP_DIR=${app_dir}" >> "${GITHUB_ENV}"
+
+      - name: Configure SSH
+        env:
+          HETZNER_SSH_KEY: ${{ secrets.HETZNER_SSH_KEY }}
+          HETZNER_HOST: ${{ secrets.HETZNER_HOST }}
+          HETZNER_PORT: ${{ secrets.HETZNER_PORT }}
+        run: |
+          set -euo pipefail
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "${HETZNER_SSH_KEY}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          port="${HETZNER_PORT:-22}"
+          ssh-keyscan -p "${port}" -H "${HETZNER_HOST}" >> ~/.ssh/known_hosts
+
+      - name: Back up, migrate, and verify production database
+        env:
+          HETZNER_HOST: ${{ secrets.HETZNER_HOST }}
+          HETZNER_USER: ${{ secrets.HETZNER_USER }}
+          HETZNER_PORT: ${{ secrets.HETZNER_PORT }}
+        run: |
+          set -euo pipefail
+          port="${HETZNER_PORT:-22}"
+          ssh -p "${port}" "${HETZNER_USER}@${HETZNER_HOST}" \
+            "COOLIFY_APP_DIR=$(printf '%q' "${COOLIFY_APP_DIR}") COOLIFY_SERVICE=$(printf '%q' "${COOLIFY_SERVICE:-}") bash -s" <<'REMOTE'
+          set -euo pipefail
+          cd "${COOLIFY_APP_DIR}"
+          docker compose -f docker-compose.yaml config --quiet
+
+          service="${COOLIFY_SERVICE:-}"
+          if [ -z "${service}" ]; then
+            service="$(python3 - <<'PY'
+          from pathlib import Path
+          for line in Path("docker-compose.yaml").read_text().splitlines():
+              stripped = line.strip()
+              if len(line) - len(line.lstrip()) == 4 and stripped.endswith(":"):
+                  print(stripped[:-1])
+                  break
+          PY
+          )"
+          fi
+          if [ -z "${service}" ]; then
+            echo "Could not determine compose service." >&2
+            exit 1
+          fi
+
+          db_count() {
+            docker compose -f docker-compose.yaml run --rm -T --no-deps \
+              --entrypoint sh "${service}" \
+              -c 'PG_DATABASE_URL="$(node -e "const u=new URL(process.env.DATABASE_URL); for (const key of [\"schema\",\"connection_limit\",\"pool_timeout\",\"socket_timeout\",\"pgbouncer\"]) u.searchParams.delete(key); process.stdout.write(u.toString())")"; exec psql "$PG_DATABASE_URL" --no-psqlrc -v ON_ERROR_STOP=1 -Atc "SELECT COUNT(*) FROM \"Application\";"'
+          }
+
+          count_before="$(db_count)"
+          case "${count_before}" in
+            ''|*[!0-9]*)
+              echo "Could not verify the pre-migration application count." >&2
+              exit 1
+              ;;
+          esac
+          echo "Applications before migration: ${count_before}"
+
+          stamp="$(date +%Y%m%d%H%M%S)"
+          backup_dir="${COOLIFY_APP_DIR}/database-backups"
+          database_backup="${backup_dir}/nexus-manual-recovery-${stamp}.dump"
+          install -m 700 -d "${backup_dir}"
+          umask 077
+          docker compose -f docker-compose.yaml run --rm -T --no-deps \
+            --entrypoint sh "${service}" \
+            -c 'PG_DATABASE_URL="$(node -e "const u=new URL(process.env.DATABASE_URL); for (const key of [\"schema\",\"connection_limit\",\"pool_timeout\",\"socket_timeout\",\"pgbouncer\"]) u.searchParams.delete(key); process.stdout.write(u.toString())")"; exec pg_dump "$PG_DATABASE_URL" --format=custom --no-owner --no-privileges' \
+            > "${database_backup}"
+          if [ ! -s "${database_backup}" ]; then
+            echo "Database backup failed or produced an empty file." >&2
+            exit 1
+          fi
+          chmod 600 "${database_backup}"
+          echo "Verified pre-migration database backup."
+
+          docker compose -f docker-compose.yaml run --rm -T --no-deps \
+            --entrypoint sh "${service}" \
+            -c 'exec node /app/node_modules/prisma/build/index.js migrate deploy --schema=/app/prisma/schema.prisma'
+
+          count_after="$(db_count)"
+          if [ "${count_after}" != "${count_before}" ]; then
+            echo "Application count changed during additive migration; refusing activation." >&2
+            exit 1
+          fi
+          echo "Applications after migration: ${count_after}"
+
+          docker compose -f docker-compose.yaml up -d "${service}"
+          docker ps --filter "name=${service}" --format '{{.Names}} {{.Image}} {{.Status}}'
+          REMOTE


### PR DESCRIPTION
Production incident recovery workflow: SSH-only backup, aggregate count, Prisma migration, count verification, and service activation. Also prevents workflow-only recovery commits from starting the expensive ARM64 deploy build. The previous stuck build was cancelled before reaching the server.