### PR TITLE
fix: run complete Prisma CLI during production recovery

### DIFF
--- a/.github/workflows/deploy-hetzner.yml
+++ b/.github/workflows/deploy-hetzner.yml
@@ -290,7 +290,7 @@ jobs:
 
           docker compose -f docker-compose.yaml run --rm -T --interactive=false --no-deps \
             --entrypoint sh "${COOLIFY_SERVICE}" \
-            -c 'exec node /app/node_modules/prisma/build/index.js migrate deploy --schema=/app/prisma/schema.prisma'
+            -c 'export HOME=/tmp npm_config_cache=/tmp/npm-cache; exec npx --yes prisma@6.19.3 migrate deploy --schema=/app/prisma/schema.prisma'
 
           count_after="$(db_count)"
           if [ "${count_after}" != "${count_before}" ]; then

--- a/.github/workflows/recover-production-db.yml
+++ b/.github/workflows/recover-production-db.yml
@@ -106,7 +106,7 @@ jobs:
 
           docker compose -f docker-compose.yaml run --rm -T --interactive=false --no-deps \
             --entrypoint sh "${service}" \
-            -c 'exec node /app/node_modules/prisma/build/index.js migrate deploy --schema=/app/prisma/schema.prisma'
+            -c 'export HOME=/tmp npm_config_cache=/tmp/npm-cache; exec npx --yes prisma@6.19.3 migrate deploy --schema=/app/prisma/schema.prisma'
 
           count_after="$(db_count)"
           if [ "${count_after}" != "${count_before}" ]; then


### PR DESCRIPTION
Recovery reached the verified backup stage with 26 applications intact, then stopped before migration because the image-bundled partial CLI lacked a transitive dependency. Use the exact lockfile version via npx so npm resolves the complete CLI dependency graph. The backup remains intact and no migration ran during the failed attempt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of database schema updates during deployments and production recovery.
  * Standardized migration execution with a consistent Prisma version and temporary cache settings.
  * Existing migration behavior and schema configuration remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->