### PR TITLE
fix: isolate production migration CLI

### DIFF
--- a/.github/workflows/deploy-hetzner.yml
+++ b/.github/workflows/deploy-hetzner.yml
@@ -290,7 +290,7 @@ jobs:
 
           docker compose -f docker-compose.yaml run --rm -T --interactive=false --no-deps \
             --entrypoint sh "${COOLIFY_SERVICE}" \
-            -c 'export HOME=/tmp npm_config_cache=/tmp/npm-cache; exec npx --yes prisma@6.19.3 migrate deploy --schema=/app/prisma/schema.prisma'
+            -c 'export HOME=/tmp npm_config_cache=/tmp/npm-cache; rm -rf /tmp/prisma-cli; mkdir -p /tmp/prisma-cli; npm install --prefix /tmp/prisma-cli --no-save --no-audit --no-fund prisma@6.19.3; exec /tmp/prisma-cli/node_modules/.bin/prisma migrate deploy --schema=/app/prisma/schema.prisma'
 
           count_after="$(db_count)"
           if [ "${count_after}" != "${count_before}" ]; then

--- a/.github/workflows/recover-production-db.yml
+++ b/.github/workflows/recover-production-db.yml
@@ -106,7 +106,7 @@ jobs:
 
           docker compose -f docker-compose.yaml run --rm -T --interactive=false --no-deps \
             --entrypoint sh "${service}" \
-            -c 'export HOME=/tmp npm_config_cache=/tmp/npm-cache; exec npx --yes prisma@6.19.3 migrate deploy --schema=/app/prisma/schema.prisma'
+            -c 'export HOME=/tmp npm_config_cache=/tmp/npm-cache; rm -rf /tmp/prisma-cli; mkdir -p /tmp/prisma-cli; npm install --prefix /tmp/prisma-cli --no-save --no-audit --no-fund prisma@6.19.3; exec /tmp/prisma-cli/node_modules/.bin/prisma migrate deploy --schema=/app/prisma/schema.prisma'
 
           count_after="$(db_count)"
           if [ "${count_after}" != "${count_before}" ]; then


### PR DESCRIPTION
`npx` resolved the broken local Prisma package instead of downloading its binary. Install Prisma 6.19.3 into a fresh `/tmp/prisma-cli` prefix and execute that explicit binary. Verified locally that the isolated package installation produces a working CLI. Production still has 26 applications and multiple verified pre-migration backups; no migration has run yet.