### PR TITLE
ci: add verified pre-deploy data backups

### DIFF
--- a/.github/workflows/container-smoke.yml
+++ b/.github/workflows/container-smoke.yml
@@ -1,0 +1,48 @@
+name: Container smoke
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "Dockerfile"
+      - "package.json"
+      - "package-lock.json"
+      - "scripts/pre-deploy-backup.mjs"
+      - ".github/workflows/deploy-hetzner.yml"
+      - ".github/workflows/container-smoke.yml"
+  push:
+    branches: [main]
+    paths:
+      - "Dockerfile"
+      - "package.json"
+      - "package-lock.json"
+      - "scripts/pre-deploy-backup.mjs"
+      - ".github/workflows/deploy-hetzner.yml"
+      - ".github/workflows/container-smoke.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  production-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build production image
+        run: docker build --tag nexus-crm:container-smoke .
+
+      - name: Verify backup runtime and PostgreSQL tools
+        run: |
+          docker run --rm \
+            --entrypoint sh \
+            nexus-crm:container-smoke \
+            -ec '
+              command -v pg_dump
+              command -v psql
+              command -v timeout
+              test -r /app/scripts/pre-deploy-backup.mjs
+              test -r /app/node_modules/prisma/build/index.js
+              node /app/scripts/pre-deploy-backup.mjs --help >/dev/null
+              node /app/node_modules/prisma/build/index.js --version >/dev/null
+            '

--- a/.github/workflows/container-smoke.yml
+++ b/.github/workflows/container-smoke.yml
@@ -42,7 +42,7 @@ jobs:
               command -v psql
               command -v timeout
               test -r /app/scripts/pre-deploy-backup.mjs
-              test -r /app/node_modules/prisma/build/index.js
+              test -r /app/prisma-cli/node_modules/prisma/build/index.js
               node /app/scripts/pre-deploy-backup.mjs --help >/dev/null
-              node /app/node_modules/prisma/build/index.js --version >/dev/null
+              node /app/prisma-cli/node_modules/prisma/build/index.js --version >/dev/null
             '

--- a/.github/workflows/deploy-hetzner.yml
+++ b/.github/workflows/deploy-hetzner.yml
@@ -6,11 +6,13 @@ on:
     paths-ignore:
       - ".github/workflows/deploy-hetzner.yml"
       - ".github/workflows/recover-production-db.yml"
+      - ".github/workflows/container-smoke.yml"
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: nexus-production-transition
+  # A newer push must not interrupt a backup or production transition.
+  cancel-in-progress: false
 
 env:
   COOLIFY_APP_DIR: ${{ vars.HETZNER_COOLIFY_APP_DIR }}
@@ -25,6 +27,7 @@ env:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     if: >-
       github.event_name == 'workflow_dispatch' ||
       vars.HETZNER_AUTO_DEPLOY == 'true'
@@ -192,6 +195,72 @@ jobs:
           stamp="$(date +%Y%m%d%H%M%S)"
           backup="docker-compose.yaml.before-${DEPLOY_SHA}-${stamp}"
           cp docker-compose.yaml "${backup}"
+          env_backup=""
+          if [ -f .env ]; then
+            env_backup=".env.before-${DEPLOY_SHA}-${stamp}"
+            cp -p .env "${env_backup}"
+            chmod 600 "${env_backup}"
+          fi
+
+          deployment_committed=0
+          app_stopped=0
+          transition_count_container="nexus-transition-count"
+          transition_backup_container="nexus-transition-backup"
+          transition_migration_container="nexus-transition-migration"
+
+          cleanup_transition_containers() {
+            for container in \
+              "${transition_count_container}" \
+              "${transition_backup_container}" \
+              "${transition_migration_container}"
+            do
+              docker rm -f "${container}" >/dev/null 2>&1 || true
+            done
+          }
+
+          compose_run_bounded() {
+            container_name="$1"
+            timeout_seconds="$2"
+            shift 2
+            docker rm -f "${container_name}" >/dev/null 2>&1 || true
+            if docker compose -f docker-compose.yaml run --rm -T --interactive=false --no-deps \
+              --name "${container_name}" \
+              --entrypoint timeout \
+              "${COOLIFY_SERVICE}" "${timeout_seconds}" "$@"; then
+              run_status=0
+            else
+              run_status=$?
+            fi
+            docker rm -f "${container_name}" >/dev/null 2>&1 || true
+            return "${run_status}"
+          }
+
+          # Kill any bounded transition container left by an interrupted SSH
+          # session before this workflow acquired the shared transition lock.
+          cleanup_transition_containers
+
+          restore_pending_deploy() {
+            rc=$?
+            trap - EXIT
+            cleanup_transition_containers
+            if [ "${deployment_committed}" -ne 1 ]; then
+              echo "Restoring pre-deploy Compose and environment state." >&2
+              cp "${backup}" docker-compose.yaml
+              if [ -n "${env_backup}" ]; then
+                cp -p "${env_backup}" .env
+              fi
+              if [ "${app_stopped}" -eq 1 ]; then
+                if ! docker compose -f docker-compose.yaml up -d "${COOLIFY_SERVICE}"; then
+                  echo "Failed to restart the previous application image." >&2
+                fi
+              fi
+            fi
+            if [ -n "${env_backup}" ]; then
+              rm -f "${env_backup}"
+            fi
+            exit "${rc}"
+          }
+          trap restore_pending_deploy EXIT
 
           python3 - <<'PY'
           import os
@@ -259,10 +328,15 @@ jobs:
           # database work through one-off containers so DATABASE_URL remains in
           # the compose environment and is never printed by GitHub Actions.
           db_count() {
-            docker compose -f docker-compose.yaml run --rm -T --interactive=false --no-deps \
-              --entrypoint sh "${COOLIFY_SERVICE}" \
-              -c 'PG_DATABASE_URL="$(node /app/prisma/libpq-url.mjs)"; exec psql "$PG_DATABASE_URL" --no-psqlrc -v ON_ERROR_STOP=1 -Atc "SELECT COUNT(*) FROM \"Application\";"'
+            compose_run_bounded "${transition_count_container}" 120 \
+              sh -c 'PG_DATABASE_URL="$(node /app/prisma/libpq-url.mjs)"; exec psql "$PG_DATABASE_URL" --no-psqlrc -v ON_ERROR_STOP=1 -Atc "SELECT COUNT(*) FROM \"Application\";"'
           }
+
+          # Quiesce application and MCP writes so the PostgreSQL dump and the
+          # generation-pinned document snapshot share one recovery boundary.
+          app_stopped=1
+          docker compose -f docker-compose.yaml stop --timeout 30 "${COOLIFY_SERVICE}"
+          echo "Production writes quiesced for the recovery snapshot."
 
           count_before="$(db_count)"
           case "${count_before}" in
@@ -274,23 +348,34 @@ jobs:
           echo "Applications before migration: ${count_before}"
 
           backup_dir="${COOLIFY_APP_DIR}/database-backups"
-          database_backup="${backup_dir}/nexus-before-${DEPLOY_SHA}-${stamp}.dump"
           install -m 700 -d "${backup_dir}"
-          umask 077
-          docker compose -f docker-compose.yaml run --rm -T --interactive=false --no-deps \
-            --entrypoint sh "${COOLIFY_SERVICE}" \
-            -c 'PG_DATABASE_URL="$(node /app/prisma/libpq-url.mjs)"; exec pg_dump "$PG_DATABASE_URL" --format=custom --no-owner --no-privileges' \
-            > "${database_backup}"
-          if [ ! -s "${database_backup}" ]; then
-            echo "Database backup failed or produced an empty file." >&2
-            exit 1
-          fi
-          chmod 600 "${database_backup}"
-          echo "Verified pre-migration database backup."
+          backup_id="${stamp}-${DEPLOY_SHA}"
 
-          docker compose -f docker-compose.yaml run --rm -T --interactive=false --no-deps \
-            --entrypoint sh "${COOLIFY_SERVICE}" \
-            -c 'export HOME=/tmp npm_config_cache=/tmp/npm-cache; rm -rf /tmp/prisma-cli; mkdir -p /tmp/prisma-cli; npm install --prefix /tmp/prisma-cli --no-save --no-audit --no-fund prisma@6.19.3; exec /tmp/prisma-cli/node_modules/.bin/prisma migrate deploy --schema=/app/prisma/schema.prisma'
+          # The target image performs the backup in a one-off container while
+          # production writes are quiesced. DATABASE_URL, GCS_BUCKET,
+          # credentials, and optional BACKUP_GCS_* settings are inherited from
+          # the Compose service and never printed by Actions.
+          if docker compose -f docker-compose.yaml run --rm -T --interactive=false --no-deps \
+            --name "${transition_backup_container}" \
+            --user 0:0 \
+            --volume "${backup_dir}:/backups" \
+            --env "BACKUP_ID=${backup_id}" \
+            --env "SOURCE_COMMIT=${DEPLOY_SHA}" \
+            --env "BACKUP_LOCAL_DIR=/backups" \
+            --entrypoint timeout "${COOLIFY_SERVICE}" \
+            1500 node /app/scripts/pre-deploy-backup.mjs; then
+            backup_status=0
+          else
+            backup_status=$?
+          fi
+          docker rm -f "${transition_backup_container}" >/dev/null 2>&1 || true
+          if [ "${backup_status}" -ne 0 ]; then
+            exit "${backup_status}"
+          fi
+          echo "Verified pre-deploy database and document recovery set ${backup_id}."
+
+          compose_run_bounded "${transition_migration_container}" 900 \
+            node /app/node_modules/prisma/build/index.js migrate deploy --schema=/app/prisma/schema.prisma
 
           count_after="$(db_count)"
           if [ "${count_after}" != "${count_before}" ]; then
@@ -300,6 +385,14 @@ jobs:
           echo "Applications after migration: ${count_after}"
 
           docker compose -f docker-compose.yaml up -d "${COOLIFY_SERVICE}"
+          cleanup_transition_containers
+          deployment_committed=1
+          app_stopped=0
+          if [ -n "${env_backup}" ]; then
+            rm -f "${env_backup}"
+            env_backup=""
+          fi
+          trap - EXIT
           ps_format="{{.Names}} {{.Image}} {{.Status}}"
           docker ps --filter "name=${COOLIFY_SERVICE}" --format "${ps_format}"
           REMOTE

--- a/.github/workflows/deploy-hetzner.yml
+++ b/.github/workflows/deploy-hetzner.yml
@@ -375,7 +375,7 @@ jobs:
           echo "Verified pre-deploy database and document recovery set ${backup_id}."
 
           compose_run_bounded "${transition_migration_container}" 900 \
-            node /app/node_modules/prisma/build/index.js migrate deploy --schema=/app/prisma/schema.prisma
+            node /app/prisma-cli/node_modules/prisma/build/index.js migrate deploy --schema=/app/prisma/schema.prisma
 
           count_after="$(db_count)"
           if [ "${count_after}" != "${count_before}" ]; then

--- a/.github/workflows/deploy-hetzner.yml
+++ b/.github/workflows/deploy-hetzner.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 75
     if: >-
       github.event_name == 'workflow_dispatch' ||
       vars.HETZNER_AUTO_DEPLOY == 'true'

--- a/.github/workflows/recover-production-db.yml
+++ b/.github/workflows/recover-production-db.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   recover:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 75
     steps:
       - name: Normalize recovery environment
         run: |

--- a/.github/workflows/recover-production-db.yml
+++ b/.github/workflows/recover-production-db.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: production-database-recovery
+  group: nexus-production-transition
   cancel-in-progress: false
 
 permissions:
@@ -19,6 +19,7 @@ env:
 jobs:
   recover:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Normalize recovery environment
         run: |
@@ -73,10 +74,50 @@ jobs:
             exit 1
           fi
 
+          transition_count_container="nexus-transition-count"
+          transition_backup_container="nexus-transition-backup"
+          transition_migration_container="nexus-transition-migration"
+
+          cleanup_transition_containers() {
+            for container in \
+              "${transition_count_container}" \
+              "${transition_backup_container}" \
+              "${transition_migration_container}"
+            do
+              docker rm -f "${container}" >/dev/null 2>&1 || true
+            done
+          }
+
+          compose_run_bounded() {
+            container_name="$1"
+            timeout_seconds="$2"
+            shift 2
+            docker rm -f "${container_name}" >/dev/null 2>&1 || true
+            if docker compose -f docker-compose.yaml run --rm -T --interactive=false --no-deps \
+              --name "${container_name}" \
+              --entrypoint timeout \
+              "${service}" "${timeout_seconds}" "$@"; then
+              run_status=0
+            else
+              run_status=$?
+            fi
+            docker rm -f "${container_name}" >/dev/null 2>&1 || true
+            return "${run_status}"
+          }
+
+          cleanup_transition_on_exit() {
+            rc=$?
+            trap - EXIT
+            cleanup_transition_containers
+            exit "${rc}"
+          }
+
+          cleanup_transition_containers
+          trap cleanup_transition_on_exit EXIT
+
           db_count() {
-            docker compose -f docker-compose.yaml run --rm -T --interactive=false --no-deps \
-              --entrypoint sh "${service}" \
-              -c 'PG_DATABASE_URL="$(node -e "const u=new URL(process.env.DATABASE_URL); for (const key of [\"schema\",\"connection_limit\",\"pool_timeout\",\"socket_timeout\",\"pgbouncer\"]) u.searchParams.delete(key); process.stdout.write(u.toString())")"; exec psql "$PG_DATABASE_URL" --no-psqlrc -v ON_ERROR_STOP=1 -Atc "SELECT COUNT(*) FROM \"Application\";"'
+            compose_run_bounded "${transition_count_container}" 120 \
+              sh -c 'PG_DATABASE_URL="$(node -e "const u=new URL(process.env.DATABASE_URL); for (const key of [\"schema\",\"connection_limit\",\"pool_timeout\",\"socket_timeout\",\"pgbouncer\"]) u.searchParams.delete(key); process.stdout.write(u.toString())")"; exec psql "$PG_DATABASE_URL" --no-psqlrc -v ON_ERROR_STOP=1 -Atc "SELECT COUNT(*) FROM \"Application\";"'
           }
 
           count_before="$(db_count)"
@@ -93,9 +134,8 @@ jobs:
           database_backup="${backup_dir}/nexus-manual-recovery-${stamp}.dump"
           install -m 700 -d "${backup_dir}"
           umask 077
-          docker compose -f docker-compose.yaml run --rm -T --interactive=false --no-deps \
-            --entrypoint sh "${service}" \
-            -c 'PG_DATABASE_URL="$(node -e "const u=new URL(process.env.DATABASE_URL); for (const key of [\"schema\",\"connection_limit\",\"pool_timeout\",\"socket_timeout\",\"pgbouncer\"]) u.searchParams.delete(key); process.stdout.write(u.toString())")"; exec pg_dump "$PG_DATABASE_URL" --format=custom --no-owner --no-privileges' \
+          compose_run_bounded "${transition_backup_container}" 900 \
+            sh -c 'PG_DATABASE_URL="$(node -e "const u=new URL(process.env.DATABASE_URL); for (const key of [\"schema\",\"connection_limit\",\"pool_timeout\",\"socket_timeout\",\"pgbouncer\"]) u.searchParams.delete(key); process.stdout.write(u.toString())")"; exec pg_dump "$PG_DATABASE_URL" --format=custom --no-owner --no-privileges' \
             > "${database_backup}"
           if [ ! -s "${database_backup}" ]; then
             echo "Database backup failed or produced an empty file." >&2
@@ -104,9 +144,8 @@ jobs:
           chmod 600 "${database_backup}"
           echo "Verified pre-migration database backup."
 
-          docker compose -f docker-compose.yaml run --rm -T --interactive=false --no-deps \
-            --entrypoint sh "${service}" \
-            -c 'export HOME=/tmp npm_config_cache=/tmp/npm-cache; rm -rf /tmp/prisma-cli; mkdir -p /tmp/prisma-cli; npm install --prefix /tmp/prisma-cli --no-save --no-audit --no-fund prisma@6.19.3; exec /tmp/prisma-cli/node_modules/.bin/prisma migrate deploy --schema=/app/prisma/schema.prisma'
+          compose_run_bounded "${transition_migration_container}" 900 \
+            node /app/node_modules/prisma/build/index.js migrate deploy --schema=/app/prisma/schema.prisma
 
           count_after="$(db_count)"
           if [ "${count_after}" != "${count_before}" ]; then
@@ -116,5 +155,7 @@ jobs:
           echo "Applications after migration: ${count_after}"
 
           docker compose -f docker-compose.yaml up -d "${service}"
+          cleanup_transition_containers
+          trap - EXIT
           docker ps --filter "name=${service}" --format '{{.Names}} {{.Image}} {{.Status}}'
           REMOTE

--- a/.github/workflows/recover-production-db.yml
+++ b/.github/workflows/recover-production-db.yml
@@ -145,7 +145,7 @@ jobs:
           echo "Verified pre-migration database backup."
 
           compose_run_bounded "${transition_migration_container}" 900 \
-            node /app/node_modules/prisma/build/index.js migrate deploy --schema=/app/prisma/schema.prisma
+            node /app/prisma-cli/node_modules/prisma/build/index.js migrate deploy --schema=/app/prisma/schema.prisma
 
           count_after="$(db_count)"
           if [ "${count_after}" != "${count_before}" ]; then

--- a/.hermes/plans/2026-07-14_055021-pre-deploy-data-backups.md
+++ b/.hermes/plans/2026-07-14_055021-pre-deploy-data-backups.md
@@ -1,0 +1,123 @@
+# Pre-Deploy Database and File Backups Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Make every Nexus CRM production deployment create and verify a Git-commit-addressable PostgreSQL and GCS document recovery set before migrations or application activation.
+
+**Architecture:** A tested Node.js backup program runs inside a one-off target-image Compose container after application writes are quiesced, creates a protected local PostgreSQL custom dump, uploads and verifies it in GCS, snapshots exact document generations into a deduplicated namespace, and publishes a completion manifest last. A protected EXIT trap restores Compose, `.env`, and the previous service on failure; deployment and manual recovery share a bounded, non-cancelling concurrency group.
+
+**Tech Stack:** GitHub Actions, Docker Compose, Node.js 22, PostgreSQL 17 client tools, Google Cloud Storage SDK, Vitest, OpenSpec.
+
+---
+
+## Current context
+
+- `.github/workflows/deploy-hetzner.yml` already creates a server-local PostgreSQL dump immediately before `prisma migrate deploy`.
+- The current step checks only that the dump is non-empty; it does not upload or checksum it.
+- GCS document objects are not included in a pre-deploy recovery set.
+- Deployment concurrency currently permits cancellation of an in-progress deploy and does not coordinate with manual recovery.
+
+## Implementation tasks
+
+### Task 1: Define testable backup naming and URL helpers
+
+**Files:**
+- Create: `scripts/pre-deploy-backup.mjs`
+- Create: `scripts/__tests__/pre-deploy-backup.test.ts`
+
+1. Add failing tests for backup ID validation, Prisma URL sanitization, backup-prefix exclusion, and generation-addressed object names.
+2. Run `npx vitest run scripts/__tests__/pre-deploy-backup.test.ts`; expect failure because exports do not exist.
+3. Implement the pure helpers without network or process side effects.
+4. Rerun the focused tests; expect all to pass.
+
+### Task 2: Implement the fail-closed backup runtime
+
+**Files:**
+- Modify: `scripts/pre-deploy-backup.mjs`
+- Modify: `scripts/__tests__/pre-deploy-backup.test.ts`
+
+1. Add tests for manifest construction and same-bucket exclusion behavior.
+2. Implement PostgreSQL custom dump creation using `pg_dump`, local SHA-256/size calculation, and protected file permissions.
+3. Implement verified database upload to the backup bucket.
+4. Enumerate source GCS objects, pin each source generation, copy missing generation-addressed backups, and verify destination metadata.
+5. Upload and verify `manifest.json` only after every prior operation succeeds.
+6. Ensure errors exit non-zero and do not log credentials or database URLs.
+7. Rerun focused tests and `node scripts/pre-deploy-backup.mjs --help`.
+
+### Task 3: Package required production tooling
+
+**Files:**
+- Modify: `Dockerfile`
+
+1. Install `postgresql-client` in the runner image.
+2. Copy `scripts/pre-deploy-backup.mjs` into `/app/scripts/`.
+3. Build the production image and verify `pg_dump`, `psql`, and the backup script are present.
+
+### Task 4: Make backup a deployment gate
+
+**Files:**
+- Modify: `.github/workflows/deploy-hetzner.yml`
+- Modify: `.github/workflows/recover-production-db.yml`
+- Create: `.github/workflows/container-smoke.yml`
+
+1. Use the shared `nexus-production-transition` concurrency group with cancellation disabled in deployment and manual recovery.
+2. Add bounded job, backup-runtime, and in-container database-operation deadlines with deterministic cleanup of stable transition-container names.
+3. Protect and restore Compose and `.env` through an EXIT trap until target activation succeeds.
+4. Stop the existing application before the database dump and document snapshot to quiesce writes.
+5. Replace the inline local-only dump block with one invocation of `/app/scripts/pre-deploy-backup.mjs` before `prisma migrate deploy`.
+6. Pass only non-secret backup identifiers explicitly; inherit database and GCS configuration from the Compose service environment.
+7. Bind the protected host backup directory to `/backups` for local dump retention.
+8. Keep pre/post migration counts and ensure migration or service activation cannot run after backup failure.
+9. Add a path-scoped container smoke workflow that builds the production image and verifies `pg_dump`, `psql`, and the packaged backup CLI.
+10. Validate workflow YAML and embedded shell syntax.
+
+### Task 5: Document configuration and recovery
+
+**Files:**
+- Create: `docs/operations/pre-deploy-backups.md`
+
+Document:
+- `BACKUP_GCS_BUCKET` and `BACKUP_GCS_PREFIX`.
+- Same-bucket fallback limitations.
+- Backup object layout and manifest fields.
+- Deployment failure behavior.
+- Local and remote retention recommendations.
+- Explicit database/document restore procedure into isolated resources.
+- First-deployment and restore-drill verification checklist.
+
+### Task 6: Validate the complete change
+
+Run:
+
+```bash
+npx vitest run scripts/__tests__/pre-deploy-backup.test.ts
+npm test
+npm run lint
+npm run build
+/opt/data/npm-global/bin/openspec validate add-pre-deploy-data-backups --strict
+```
+
+Then inspect:
+
+```bash
+git diff --check
+git diff --stat origin/main...HEAD
+git status --short
+```
+
+Expected: focused tests, full tests, lint, build, strict OpenSpec validation, and whitespace checks pass.
+
+### Task 7: Publish through a PR
+
+1. Commit with `ci: add pre-deploy data backup gate`.
+2. Push branch `ci/pre-deploy-backups`.
+3. Open a PR against `main` describing the hard gate, same-bucket fallback, validation, and required production configuration.
+4. Monitor all PR checks and automated review comments.
+5. Do not merge or trigger production deployment without explicit user approval.
+
+## Risks and trade-offs
+
+- The same-bucket fallback protects against application mistakes but not total GCP project loss; a dedicated bucket/project remains recommended.
+- The first generation-addressed snapshot transfers every current document and extends deployment downtime; later snapshots reuse unchanged generations.
+- The workflow quiesces Nexus application/API/MCP writes for a coherent database-and-document recovery boundary and restores the previous service on failure.
+- Remote retention must be configured through GCS lifecycle rules; destructive cleanup does not belong in deployment code.

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ RUN apk add --no-cache openssl
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci
+RUN npm install --prefix /tmp/prisma-cli --no-save --no-audit --no-fund prisma@6.19.3
 COPY . .
 RUN npx prisma generate
 RUN npm run build
@@ -21,6 +22,7 @@ COPY --from=builder /app/prisma ./prisma
 COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
 COPY --from=builder /app/node_modules/prisma ./node_modules/prisma
 COPY --from=builder /app/node_modules/@prisma ./node_modules/@prisma
+COPY --from=builder /tmp/prisma-cli ./prisma-cli
 COPY --from=builder /app/scripts/pre-deploy-backup.mjs ./scripts/pre-deploy-backup.mjs
 USER nextjs
 ENV PORT=8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ COPY --from=builder /app/prisma ./prisma
 COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
 COPY --from=builder /app/node_modules/prisma ./node_modules/prisma
 COPY --from=builder /app/node_modules/@prisma ./node_modules/@prisma
+COPY --from=builder /app/scripts/pre-deploy-backup.mjs ./scripts/pre-deploy-backup.mjs
 USER nextjs
 ENV PORT=8080
 EXPOSE ${PORT}

--- a/docs/operations/pre-deploy-backups.md
+++ b/docs/operations/pre-deploy-backups.md
@@ -1,0 +1,177 @@
+# Nexus CRM pre-deploy backups
+
+Every production deployment is gated by a verified recovery set created after the target image builds and before Prisma migrations or application activation.
+
+## What is protected
+
+Each recovery set contains:
+
+- A PostgreSQL custom-format dump retained on the Hetzner host.
+- The same database dump uploaded to GCS and verified by byte size and SHA-256 metadata.
+- A generation-pinned backup copy of every current document object.
+- A manifest tying the database and document artifacts to the target Git commit.
+
+The manifest is uploaded last. Its verified presence is the completion marker that allows deployment to continue.
+
+## Configuration
+
+The backup process inherits production configuration from the Coolify Compose service. Do not add database URLs or service-account JSON to GitHub Actions secrets for this feature.
+
+| Variable | Required | Default | Purpose |
+|---|---:|---|---|
+| `GCS_BUCKET` | Yes | — | Source bucket containing Nexus documents |
+| `BACKUP_GCS_BUCKET` | No | `GCS_BUCKET` | Dedicated backup destination |
+| `BACKUP_GCS_PREFIX` | No | `_nexus-backups/pre-deploy` | Reserved destination namespace |
+| `BACKUP_TIMEOUT_SECONDS` | No | `1200` | Hard deadline for the complete backup runtime |
+| `GOOGLE_APPLICATION_CREDENTIALS` | Yes | — | Existing mounted GCS credential file |
+
+`BACKUP_ID`, `SOURCE_COMMIT`, and `BACKUP_LOCAL_DIR` are supplied by the deployment workflow.
+
+### Recommended destination
+
+Configure `BACKUP_GCS_BUCKET` as a private bucket in a separate GCP project or administrative boundary. Grant the Nexus backup identity:
+
+- Read access to source document objects and generations.
+- Create/read access to the backup bucket.
+- No public access.
+- No broad project-level permissions.
+
+If `BACKUP_GCS_BUCKET` is absent, the backup uses the source document bucket beneath the reserved prefix. This protects against deployment and application mistakes but does **not** protect against loss of the bucket, GCP project, or its credentials.
+
+## Object layout
+
+```text
+<backup-prefix>/
+├── objects/
+│   └── <source-generation>/
+│       └── <base64url-source-name>
+└── snapshots/
+    └── <UTC timestamp>-<Git SHA>/
+        ├── database.dump
+        └── manifest.json
+```
+
+Document copies are addressed by source generation and encoded source name. An unchanged generation is transferred only once and can be referenced by many deployment manifests.
+
+The manifest records:
+
+- Backup format version and identifier.
+- Target Git commit.
+- Started/completed timestamps.
+- Source and backup bucket names.
+- Database object, local filename, size, and SHA-256.
+- Each source object name, generation, size, CRC32C/MD5 where available, and backup object.
+
+It contains storage identifiers and integrity metadata, not database credentials or document contents.
+
+## Fail-closed deployment behavior
+
+The deployment stops before `prisma migrate deploy` and before target-image activation when any of these operations fail:
+
+- `pg_dump` execution.
+- Non-empty local dump verification.
+- Database upload or remote metadata verification.
+- Source document enumeration.
+- Exact-generation document copy or verification.
+- Manifest publication or remote verification.
+
+Before the dump begins, the workflow marks recovery as required and then stops the Nexus service to quiesce browser, API, and MCP writes. If stopping, backup, or migration fails, an EXIT trap removes any transition containers, restores the previous Compose and `.env` files, and restarts the previous image. Temporary environment snapshots are removed on both success and failure.
+
+Partial objects can remain in the backup namespace, but no completion manifest is published for an incomplete recovery set. The backup runtime has a 20-minute default hard deadline, and deployment/recovery jobs have 45-minute GitHub Actions deadlines. Database-facing one-off containers use stable names and in-container deadlines; each transition removes stale named containers before accessing PostgreSQL.
+
+Deployment and manual production recovery share one concurrency group. New pushes and recovery requests wait instead of overlapping or cancelling a production transition already in progress.
+
+## First deployment checklist
+
+1. Rotate the currently mounted GCS service-account key before using it for backups.
+2. Preferably create and configure a dedicated `BACKUP_GCS_BUCKET`.
+3. Confirm the credential can read the source bucket and create/read backup objects.
+4. Manually dispatch **Deploy to Hetzner**.
+5. Confirm logs show:
+   - PostgreSQL dump creation.
+   - Database upload verification.
+   - Document generation snapshot.
+   - Completion-manifest verification.
+   - Only then Prisma migration and application activation.
+6. Confirm a protected local dump exists under:
+
+   ```text
+   <COOLIFY_APP_DIR>/database-backups/nexus-before-<backup-id>.dump
+   ```
+
+7. Confirm the remote `manifest.json` exists and references the deployed Git SHA.
+8. Confirm Nexus is healthy and an existing document downloads successfully.
+
+## Isolated restore drill
+
+Never test restoration against the production database or source document bucket.
+
+### 1. Select and verify a snapshot
+
+Choose a completed manifest by Git SHA. Verify that:
+
+- `version` is supported.
+- `sourceCommit` is the intended deployment.
+- The database object exists with the manifest's byte size and SHA-256 metadata.
+- Every listed document backup object exists with the recorded size/checksum metadata.
+
+### 2. Restore PostgreSQL
+
+Download `database.dump` into a protected temporary directory, verify SHA-256 locally, and restore it into a newly created isolated PostgreSQL database:
+
+```bash
+createdb nexus_restore_test
+pg_restore \
+  --no-owner \
+  --no-privileges \
+  --exit-on-error \
+  --dbname nexus_restore_test \
+  database.dump
+```
+
+Then verify:
+
+```bash
+npx prisma migrate status
+```
+
+Run read-only row counts and foreign-key checks. Do not print user records, tokens, document contents, or credentials into CI logs.
+
+### 3. Restore documents
+
+Create an isolated restore bucket. For each manifest entry, copy its `backupObject` to the recorded source `name` in the isolated bucket. Pin the backup object's generation when the storage tool supports it.
+
+Verify every restored object's size and CRC32C/MD5 against the manifest. Report missing or mismatched identifiers without downloading or displaying document contents unless required for an authorized checksum test.
+
+### 4. Validate the application
+
+Deploy Nexus in an isolated environment using the restored database and bucket. Verify:
+
+- Login succeeds.
+- Application table and Kanban load.
+- Existing documents download.
+- A new application can be created and updated.
+- One account cannot read another account's applications or documents.
+- MCP/API authentication succeeds.
+
+Record restore duration and results. The backup system should not be considered operational until this drill succeeds.
+
+## Retention
+
+Recommended starting policy:
+
+- Local dumps: retain the most recent 20 successful deployments.
+- Complete remote recovery sets: retain at least 90 days.
+- Monthly recovery points: retain 12 months.
+
+Do not attach a simple age-based deletion rule to the shared `objects/` namespace. A document generation created months ago can still be referenced by the newest manifest. Remote cleanup must be manifest-aware: delete a generation-addressed object only when no retained manifest references it.
+
+Automated destructive cleanup is deliberately outside the deployment path.
+
+## Recovery boundaries
+
+- Application rollback is safe to automate by reactivating the previous image.
+- Database and document restoration is always an explicit operator action.
+- This system does not provide PostgreSQL point-in-time recovery.
+- The same-bucket fallback is not an independent off-site backup.
+- Coolify configuration, OAuth secrets, and IAM recovery require a separate encrypted control-plane runbook.

--- a/docs/operations/pre-deploy-backups.md
+++ b/docs/operations/pre-deploy-backups.md
@@ -77,7 +77,7 @@ The deployment stops before `prisma migrate deploy` and before target-image acti
 
 Before the dump begins, the workflow marks recovery as required and then stops the Nexus service to quiesce browser, API, and MCP writes. If stopping, backup, or migration fails, an EXIT trap removes any transition containers, restores the previous Compose and `.env` files, and restarts the previous image. Temporary environment snapshots are removed on both success and failure.
 
-Partial objects can remain in the backup namespace, but no completion manifest is published for an incomplete recovery set. The backup runtime has a 20-minute default hard deadline, and deployment/recovery jobs have 45-minute GitHub Actions deadlines. Database-facing one-off containers use stable names and in-container deadlines; each transition removes stale named containers before accessing PostgreSQL.
+Partial objects can remain in the backup namespace, but no completion manifest is published for an incomplete recovery set. The backup runtime has a 20-minute default hard deadline, and deployment/recovery jobs have 75-minute GitHub Actions deadlines. Database-facing one-off containers use stable names and in-container deadlines; each transition removes stale named containers before accessing PostgreSQL.
 
 Deployment and manual production recovery share one concurrency group. New pushes and recovery requests wait instead of overlapping or cancelling a production transition already in progress.
 

--- a/openspec/changes/add-pre-deploy-data-backups/.openspec.yaml
+++ b/openspec/changes/add-pre-deploy-data-backups/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-14

--- a/openspec/changes/add-pre-deploy-data-backups/design.md
+++ b/openspec/changes/add-pre-deploy-data-backups/design.md
@@ -58,7 +58,7 @@ After the database upload and all document generation copies verify, the program
 
 ### 7. Serialize and bound every production transition
 
-The deployment and manual recovery workflows share the `nexus-production-transition` concurrency group with cancellation disabled. Both jobs have a 45-minute Actions deadline. Every database-facing one-off container has a stable name, an in-container `timeout` as PID 1, and deterministic host cleanup; a new transition removes any orphan before touching PostgreSQL. The backup runtime also has a configurable hard deadline (20 minutes by default).
+The deployment and manual recovery workflows share the `nexus-production-transition` concurrency group with cancellation disabled. Both jobs have a 75-minute Actions deadline. Every database-facing one-off container has a stable name, an in-container `timeout` as PID 1, and deterministic host cleanup; a new transition removes any orphan before touching PostgreSQL. The backup runtime also has a configurable hard deadline (20 minutes by default).
 
 ### 8. Restore configuration and the old image on pre-activation failure
 

--- a/openspec/changes/add-pre-deploy-data-backups/design.md
+++ b/openspec/changes/add-pre-deploy-data-backups/design.md
@@ -1,0 +1,94 @@
+## Context
+
+Nexus deploys an ARM64 image through GitHub Actions and activates it through a Coolify-generated Compose project on the Hetzner host. The workflow already creates a protected local PostgreSQL custom dump before Prisma migrations, but the dump remains in the application directory and documents in GCS are not represented in the same recovery point. Production documents are immutable UUID-named objects in GCS; their metadata and ownership live in PostgreSQL.
+
+The backup must run with the target image's tooling while application and MCP writes are quiesced, then guarantee that the previous Compose/environment state and image are restored on any pre-activation failure. It must use the Compose service environment so database and GCS credentials are never copied into GitHub Actions logs.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Produce one transactionally coherent recovery set by quiescing application writes across the database dump and document-generation snapshot.
+- Keep a local PostgreSQL custom dump and verify an uploaded GCS copy.
+- Preserve the exact GCS generations visible at snapshot time without retransferring unchanged generations on every deployment.
+- Publish the manifest last so its presence is the completion marker.
+- Fail closed before migration or container replacement.
+- Work with the current GCS bucket immediately while supporting a dedicated backup bucket through configuration.
+- Keep implementation behavior unit-testable without production credentials.
+
+**Non-Goals:**
+
+- Automatic database restoration or rollback.
+- Point-in-time recovery/WAL archiving.
+- Automatic GCS lifecycle or Object Lock configuration.
+- Backing up OAuth/API secrets or the Coolify control plane.
+- Pausing writes during the snapshot.
+
+## Decisions
+
+### 1. Run one backup program inside a one-off target-image container
+
+The workflow invokes `node /app/scripts/pre-deploy-backup.mjs` through `docker compose run --no-deps` after the image and Compose file validate but before migration. The container inherits the production database URL, GCS bucket, and mounted credential file without exposing their values to GitHub Actions.
+
+Alternative considered: implement all operations inline in workflow YAML. Rejected because inline JavaScript and shell would be hard to test and maintain.
+
+### 2. Add PostgreSQL client tooling to the runner image
+
+The runtime image installs `postgresql-client`, ensuring `pg_dump` and `psql` exist for both the backup gate and existing migration verification. This removes dependence on accidental base-image contents.
+
+Alternative considered: run a separate PostgreSQL image. Rejected because resolving the private Coolify network and transferring credentials would add complexity and increase secret-handling risk.
+
+### 3. Retain a local dump and upload the same bytes remotely
+
+`pg_dump --format=custom --no-owner --no-privileges` writes to a bind-mounted protected backup directory. The program calculates SHA-256 and size, uploads the dump, reads remote metadata back, and refuses to continue on mismatch. The local file remains available for fast operator-led recovery.
+
+### 4. Snapshot GCS by immutable source generation
+
+The backup enumerates source objects and records each generation. Each generation is copied to `<backup-prefix>/objects/<generation>/<original-name>`. Existing destinations are reused, so unchanged object generations are deduplicated across deployments. When source and backup buckets are the same, the reserved backup prefix is excluded from enumeration.
+
+Alternative considered: copy every object into a timestamped directory. Rejected because storage would grow by the full bucket size on every deployment.
+
+### 5. Publish a manifest as the atomic completion marker
+
+After the database upload and all document generation copies verify, the program uploads `snapshots/<backup-id>/manifest.json`. The manifest contains the commit, timestamps, database checksum/size/object, document source generations and backup object names, plus aggregate counts. A deployment is permitted only when the program exits successfully after reading the manifest metadata back.
+
+### 6. Support dedicated and same-bucket destinations
+
+`BACKUP_GCS_BUCKET` selects a dedicated destination. If absent, the document `GCS_BUCKET` is used with `_nexus-backups/pre-deploy` as the default reserved prefix. This makes the gate deployable with current infrastructure while documenting that a separately controlled bucket is the desired production configuration.
+
+### 7. Serialize and bound every production transition
+
+The deployment and manual recovery workflows share the `nexus-production-transition` concurrency group with cancellation disabled. Both jobs have a 45-minute Actions deadline. Every database-facing one-off container has a stable name, an in-container `timeout` as PID 1, and deterministic host cleanup; a new transition removes any orphan before touching PostgreSQL. The backup runtime also has a configurable hard deadline (20 minutes by default).
+
+### 8. Restore configuration and the old image on pre-activation failure
+
+Before rewriting Compose or `.env`, the workflow creates protected snapshots and installs an EXIT trap. Until the new image is successfully activated, any failure restores both files and restarts the previous service if it was stopped. The temporary `.env` snapshot is removed on both success and failure.
+
+### 9. Quiesce writes for a coherent recovery boundary
+
+After preflight checks, the workflow stops the existing application service before counting rows, dumping PostgreSQL, or enumerating GCS. This prevents application, browser, API, and MCP writes from creating database/document mismatches. The service is restarted from the previous configuration on failure or replaced by the new image after successful backup and migration.
+
+## Risks / Trade-offs
+
+- **Same-bucket fallback shares a failure domain with source documents** → clearly label it as baseline protection and support a dedicated destination without code changes.
+- **Writes outside the Nexus service could violate snapshot consistency** → serialize the manual recovery workflow and restrict direct database/bucket writers operationally; the restore drill verifies all manifest references.
+- **Backup downtime increases with first-time document volume** → exact consistency requires quiescing writes; generation-addressed deduplication makes later snapshots incremental and the hard timeout restores the previous service on stalls.
+- **No automatic retention cleanup** → document lifecycle rules and keep deletion out of the deploy path to avoid destructive mistakes.
+- **A backup manifest can reveal object names** → backup buckets remain private and the manifest records storage identifiers, not document contents or user data.
+- **Installing PostgreSQL tooling increases image size** → accepted to guarantee production backup and migration commands exist.
+
+## Migration Plan
+
+1. Merge workflow-only changes without triggering automatic deployment because the workflow path is ignored.
+2. Configure `BACKUP_GCS_BUCKET` in Coolify when an independent bucket is available; otherwise use the protected same-bucket fallback.
+3. Manually dispatch the deployment workflow.
+4. Verify logs show a non-empty local dump, remote database verification, document snapshot count, and manifest verification before migration begins.
+5. Verify the new application becomes healthy and existing documents download successfully.
+6. Perform a test restore into an isolated database and verify one document from the manifest.
+
+Rollback is application-only: reactivate the previous image. Database or document restoration remains an explicit operator action using the manifest; deployment never restores automatically.
+
+## Open Questions
+
+- Which independent GCS project/bucket should become the long-term `BACKUP_GCS_BUCKET`?
+- What lifecycle policy should be applied to local dumps and remote snapshot manifests after the first verified restore drill?

--- a/openspec/changes/add-pre-deploy-data-backups/proposal.md
+++ b/openspec/changes/add-pre-deploy-data-backups/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+The production deployment currently creates only a server-local PostgreSQL dump immediately before Prisma migrations. It does not protect GCS documents, verify an off-host database copy, or bind both data sets to the Git commit being deployed, so a server or storage incident can leave the pre-deployment recovery point incomplete.
+
+## What Changes
+
+- Replace the local-only database dump step with one fail-closed pre-deployment backup command that protects PostgreSQL and document objects before migrations or application activation.
+- Retain the protected local PostgreSQL custom-format dump and upload a verified copy to the configured GCS backup location.
+- Snapshot every current GCS document generation into a deduplicated backup object namespace and publish an immutable manifest for the target Git commit.
+- Permit a dedicated `BACKUP_GCS_BUCKET`; fall back to the document bucket with a reserved backup prefix when a separate bucket is not yet configured.
+- Quiesce application and MCP writes while PostgreSQL and GCS generations are captured, then restart the previous service on any pre-activation failure.
+- Restore the previous Compose and `.env` state when backup, migration, or activation fails.
+- Abort deployment if the database dump, remote upload, document snapshot, manifest publication, or verification fails.
+- Serialize deployment and manual production recovery through one non-cancelling concurrency group.
+- Bound jobs and backup operations with explicit timeouts.
+- Document restore boundaries, configuration, retention expectations, and validation procedures.
+
+## Capabilities
+
+### New Capabilities
+
+- `pre-deploy-data-backup`: Commit-addressable, fail-closed PostgreSQL and GCS document backups executed before production migration and activation.
+
+### Modified Capabilities
+
+None. The repository has no archived production-deployment capability spec; the previous local-dump behavior exists only in an active historical change and is superseded by the new capability.
+
+## Impact
+
+- `.github/workflows/deploy-hetzner.yml`
+- `.github/workflows/recover-production-db.yml`
+- `.github/workflows/container-smoke.yml`
+- `Dockerfile`
+- New backup runtime and focused unit tests under `scripts/`
+- New operational recovery documentation under `docs/operations/`
+- Repository-local OpenSpec artifacts
+- Production GCS storage usage; no application API or database schema changes

--- a/openspec/changes/add-pre-deploy-data-backups/specs/pre-deploy-data-backup/spec.md
+++ b/openspec/changes/add-pre-deploy-data-backups/specs/pre-deploy-data-backup/spec.md
@@ -1,0 +1,104 @@
+## ADDED Requirements
+
+### Requirement: Pre-deployment recovery set
+The production deployment system SHALL create one commit-addressable recovery set containing PostgreSQL data and current document object generations before applying migrations or activating the target image.
+
+#### Scenario: Recovery set succeeds
+- **WHEN** a production image has built and the deployment is ready to mutate production
+- **THEN** the system creates and verifies the database and document backups
+- **AND** publishes a manifest associated with the target Git commit before migration begins
+
+#### Scenario: Recovery set fails
+- **WHEN** any database dump, upload, document copy, or verification operation fails
+- **THEN** the deployment stops before database migration or application activation
+- **AND** restores the previous Compose and environment files
+- **AND** restarts the previous production image when writes were quiesced
+
+### Requirement: Coherent database and document boundary
+The production deployment system SHALL quiesce Nexus application and MCP writes before creating the database dump and document-generation snapshot, and SHALL keep writes quiesced until backup, migration, and activation succeed or the previous service is restored.
+
+#### Scenario: Snapshot begins
+- **WHEN** preflight validation succeeds
+- **THEN** the existing Nexus service is stopped before the database dump or document enumeration begins
+
+#### Scenario: Snapshot or migration fails
+- **WHEN** an operation fails after the existing service was stopped
+- **THEN** the deployment restores the pre-deploy configuration
+- **AND** attempts to restart the previous production image before exiting with failure
+
+### Requirement: Verified PostgreSQL backup
+The backup system SHALL produce a PostgreSQL custom-format dump, retain a protected local copy, upload the same bytes to the configured backup bucket, and verify remote size before reporting success.
+
+#### Scenario: Database backup is valid
+- **WHEN** `pg_dump` exits successfully and produces non-empty output
+- **THEN** the system calculates and records its SHA-256 checksum and byte size
+- **AND** confirms the uploaded object's size matches the local dump
+
+#### Scenario: Database dump is empty
+- **WHEN** the database dump is absent or zero bytes
+- **THEN** no successful manifest is published
+- **AND** deployment is aborted
+
+### Requirement: Generation-addressed document snapshot
+The backup system SHALL snapshot each current source document generation into a generation-addressed backup object and exclude the reserved backup namespace when source and destination are the same bucket.
+
+#### Scenario: Unchanged document generation already exists
+- **WHEN** a generation-addressed backup object already exists
+- **THEN** the system reuses it without retransferring the document
+- **AND** includes it in the new deployment manifest
+
+#### Scenario: Document changes during backup
+- **WHEN** a listed document receives a new generation while backup is running
+- **THEN** the system copies or references the exact generation that was enumerated
+- **AND** records that source generation in the manifest
+
+### Requirement: Verified completion manifest
+The backup system SHALL publish the snapshot manifest only after all database and document artifacts have been verified, and SHALL verify the remote manifest before exiting successfully.
+
+#### Scenario: Complete manifest
+- **WHEN** all artifacts have been created and verified
+- **THEN** the manifest records the backup identifier, Git commit, timestamps, database checksum and size, and every document source generation and backup object
+- **AND** its verified presence authorizes deployment to continue
+
+#### Scenario: Partial backup
+- **WHEN** one or more required artifacts are incomplete
+- **THEN** the completion manifest is not published
+- **AND** deployment remains blocked
+
+### Requirement: Backup destination configuration
+The backup system SHALL use `BACKUP_GCS_BUCKET` when configured and SHALL otherwise use the source document bucket under a reserved backup prefix.
+
+#### Scenario: Dedicated backup bucket configured
+- **WHEN** `BACKUP_GCS_BUCKET` is present
+- **THEN** database, document, and manifest artifacts are written to that bucket
+
+#### Scenario: Dedicated bucket absent
+- **WHEN** `BACKUP_GCS_BUCKET` is absent but `GCS_BUCKET` is configured
+- **THEN** the system writes artifacts beneath the reserved prefix in the source bucket
+- **AND** excludes that prefix from document enumeration
+
+### Requirement: Serialized production transitions
+All workflows that mutate the Nexus production database or Compose deployment SHALL share one non-cancelling concurrency group.
+
+#### Scenario: New revision arrives during backup
+- **WHEN** a deployment is performing its pre-deployment backup and another revision is pushed
+- **THEN** the active deployment continues to a clean terminal state
+- **AND** the newer deployment waits for the concurrency group
+
+#### Scenario: Manual recovery overlaps a deployment
+- **WHEN** the manual production recovery workflow is requested while deployment is active
+- **THEN** the recovery waits in the same concurrency group
+- **AND** cannot modify the production database concurrently
+
+### Requirement: Bounded production transitions
+Production deployment and recovery jobs SHALL have a finite job deadline, and the backup runtime SHALL terminate with failure after a configurable hard timeout.
+
+#### Scenario: Backup operation stalls
+- **WHEN** database or GCS backup work exceeds the configured hard timeout
+- **THEN** the backup process exits unsuccessfully
+- **AND** the workflow restores the previous production configuration and service
+
+#### Scenario: SSH is interrupted during a one-off database operation
+- **WHEN** a deployment or recovery SSH session ends while a database-facing container is running
+- **THEN** the container's in-container timeout bounds its remaining lifetime
+- **AND** the next production transition removes any stale named transition container before accessing PostgreSQL

--- a/openspec/changes/add-pre-deploy-data-backups/tasks.md
+++ b/openspec/changes/add-pre-deploy-data-backups/tasks.md
@@ -1,0 +1,36 @@
+## 1. Backup Runtime
+
+- [x] 1.1 Add failing unit tests for backup identifiers, database URL normalization, reserved-prefix exclusion, and generation-addressed object names.
+- [x] 1.2 Implement the pure backup naming and URL helper functions and make focused tests pass.
+- [x] 1.3 Implement protected PostgreSQL custom-dump creation with non-empty, size, SHA-256, and permissions checks.
+- [x] 1.4 Implement verified database-dump upload to the configured GCS backup destination.
+- [x] 1.5 Implement exact-generation document enumeration, deduplicated copy, and destination verification.
+- [x] 1.6 Implement manifest construction, publish-last behavior, and remote manifest verification.
+- [x] 1.7 Ensure all failure paths exit non-zero without logging credentials or database URLs.
+
+## 2. Runtime Packaging and Deployment Gate
+
+- [x] 2.1 Install PostgreSQL client tools and copy the backup runtime into the production image.
+- [x] 2.2 Disable cancellation of in-progress production deployments.
+- [x] 2.3 Replace the local-only dump block with the unified backup runtime before Prisma migration.
+- [x] 2.4 Bind the protected host backup directory and pass commit-addressable backup metadata without exposing secrets.
+- [x] 2.5 Preserve pre/post migration count checks and fail-closed ordering before application activation.
+- [x] 2.6 Add a path-scoped production-container smoke workflow for the backup CLI and PostgreSQL tools.
+- [x] 2.7 Restore Compose, `.env`, and the previous image on every pre-activation failure.
+- [x] 2.8 Quiesce application and MCP writes across the database and document snapshot.
+- [x] 2.9 Share a non-cancelling concurrency group with manual recovery and add bounded deadlines.
+- [x] 2.10 Bound and deterministically clean every database-facing one-off transition container.
+
+## 3. Operations Documentation
+
+- [x] 3.1 Document dedicated-bucket configuration and same-bucket fallback behavior.
+- [x] 3.2 Document backup layout, manifest fields, retention expectations, and security boundaries.
+- [x] 3.3 Document isolated database-and-document restore and verification procedures.
+
+## 4. Validation and Delivery
+
+- [x] 4.1 Run focused backup-runtime unit tests.
+- [x] 4.2 Run the complete test suite, lint, and production build.
+- [ ] 4.3 Validate workflow YAML/embedded shell and verify required tools in the built image.
+- [x] 4.4 Run strict OpenSpec validation and repository diff/whitespace checks.
+- [ ] 4.5 Commit and push the implementation branch, open the pull request, and monitor CI plus automated review feedback.

--- a/scripts/__tests__/pre-deploy-backup.test.ts
+++ b/scripts/__tests__/pre-deploy-backup.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildBackupObjectName,
+  buildManifest,
+  normalizeDatabaseUrl,
+  normalizePrefix,
+  parseTimeoutSeconds,
+  redactPostgresUrls,
+  shouldIncludeSourceObject,
+  validateBackupId,
+} from "../pre-deploy-backup.mjs";
+
+describe("validateBackupId", () => {
+  it("accepts a timestamp and full Git SHA", () => {
+    expect(
+      validateBackupId(
+        "20260714055021-b4776266f9f0997268584c9f8f4493acc227e7ea",
+      ),
+    ).toBe(
+      "20260714055021-b4776266f9f0997268584c9f8f4493acc227e7ea",
+    );
+  });
+
+  it.each([
+    "",
+    "latest",
+    "20260714055021-main",
+    "../../production",
+    "20260714055021-b477626/extra",
+  ])("rejects unsafe or non-addressable ID %j", (value) => {
+    expect(() => validateBackupId(value)).toThrow(/backup id/i);
+  });
+});
+
+describe("normalizeDatabaseUrl", () => {
+  it("removes Prisma-only query parameters and preserves libpq options", () => {
+    const result = normalizeDatabaseUrl(
+      "postgresql://user:secret@db:5432/nexus?schema=public&connection_limit=5&pool_timeout=10&socket_timeout=20&pgbouncer=true&sslmode=require&application_name=nexus",
+    );
+
+    expect(result).toBe(
+      "postgresql://user:secret@db:5432/nexus?sslmode=require&application_name=nexus",
+    );
+  });
+
+  it("rejects non-PostgreSQL URLs", () => {
+    expect(() => normalizeDatabaseUrl("https://example.com/database")).toThrow(
+      /postgres/i,
+    );
+  });
+});
+
+describe("redactPostgresUrls", () => {
+  it("removes PostgreSQL credentials from command errors", () => {
+    expect(
+      redactPostgresUrls(
+        "pg_dump failed for postgresql://user:password@db:5432/nexus?sslmode=require",
+      ),
+    ).toBe("pg_dump failed for [REDACTED_DATABASE_URL]");
+  });
+});
+
+describe("parseTimeoutSeconds", () => {
+  it("uses a bounded default", () => {
+    expect(parseTimeoutSeconds(undefined)).toBe(1200);
+  });
+
+  it("accepts an explicit positive timeout", () => {
+    expect(parseTimeoutSeconds("900")).toBe(900);
+  });
+
+  it.each(["0", "-1", "1.5", "not-a-number"])(
+    "rejects invalid timeout %j",
+    (value) => {
+      expect(() => parseTimeoutSeconds(value)).toThrow(/timeout/i);
+    },
+  );
+});
+
+describe("backup object naming", () => {
+  it("normalizes a configured prefix", () => {
+    expect(normalizePrefix("/_nexus-backups/pre-deploy///")).toBe(
+      "_nexus-backups/pre-deploy",
+    );
+  });
+
+  it("rejects an empty prefix", () => {
+    expect(() => normalizePrefix("///")).toThrow(/prefix/i);
+  });
+
+  it("uses source generation and an encoded source name", () => {
+    expect(
+      buildBackupObjectName(
+        "_nexus-backups/pre-deploy",
+        "1741000000000000",
+        "folder/document 1.pdf",
+      ),
+    ).toBe(
+      "_nexus-backups/pre-deploy/objects/1741000000000000/Zm9sZGVyL2RvY3VtZW50IDEucGRm",
+    );
+  });
+
+  it("excludes the reserved namespace only for a same-bucket backup", () => {
+    const prefix = "_nexus-backups/pre-deploy";
+    expect(
+      shouldIncludeSourceObject(
+        "_nexus-backups/pre-deploy/snapshots/old/manifest.json",
+        true,
+        prefix,
+      ),
+    ).toBe(false);
+    expect(
+      shouldIncludeSourceObject(
+        "_nexus-backups/pre-deployable/document.pdf",
+        true,
+        prefix,
+      ),
+    ).toBe(true);
+    expect(
+      shouldIncludeSourceObject(
+        "_nexus-backups/pre-deploy/snapshots/old/manifest.json",
+        false,
+        prefix,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("buildManifest", () => {
+  it("creates a commit-addressable manifest without secrets", () => {
+    const manifest = buildManifest({
+      backupId: "20260714055021-b4776266f9f0997268584c9f8f4493acc227e7ea",
+      sourceCommit: "b4776266f9f0997268584c9f8f4493acc227e7ea",
+      startedAt: "2026-07-14T05:50:21.000Z",
+      completedAt: "2026-07-14T05:51:21.000Z",
+      sourceBucket: "source-documents",
+      backupBucket: "backup-data",
+      database: {
+        object: "prefix/snapshots/id/database.dump",
+        localFile: "nexus-before-id.dump",
+        bytes: 1234,
+        sha256: "a".repeat(64),
+      },
+      documents: [
+        {
+          name: "document.pdf",
+          generation: "1741000000000000",
+          bytes: 42,
+          crc32c: "AAAAAA==",
+          md5Hash: "BBBBBB==",
+          backupObject: "prefix/objects/1741000000000000/ZG9jdW1lbnQucGRm",
+        },
+      ],
+    });
+
+    expect(manifest.version).toBe(1);
+    expect(manifest.sourceCommit).toBe(
+      "b4776266f9f0997268584c9f8f4493acc227e7ea",
+    );
+    expect(manifest.database.sha256).toHaveLength(64);
+    expect(manifest.documents.count).toBe(1);
+    expect(manifest.documents.totalBytes).toBe(42);
+    expect(JSON.stringify(manifest)).not.toContain("secret");
+  });
+});

--- a/scripts/pre-deploy-backup.mjs
+++ b/scripts/pre-deploy-backup.mjs
@@ -1,0 +1,398 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { spawn } from "node:child_process";
+import { chmod, mkdir, open, stat } from "node:fs/promises";
+import { createReadStream } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { Storage } from "@google-cloud/storage";
+
+const DEFAULT_PREFIX = "_nexus-backups/pre-deploy";
+const PRISMA_ONLY_QUERY_PARAMETERS = [
+  "schema",
+  "connection_limit",
+  "pool_timeout",
+  "socket_timeout",
+  "pgbouncer",
+];
+
+export function validateBackupId(value) {
+  if (!/^[0-9]{14}-[0-9a-f]{7,40}$/.test(value ?? "")) {
+    throw new Error(
+      "Backup ID must be a UTC YYYYMMDDHHMMSS timestamp and Git SHA",
+    );
+  }
+  return value;
+}
+
+export function normalizeDatabaseUrl(value) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("DATABASE_URL must be a valid PostgreSQL URL");
+  }
+
+  if (!["postgres:", "postgresql:"].includes(url.protocol)) {
+    throw new Error("DATABASE_URL must use the PostgreSQL protocol");
+  }
+
+  for (const key of PRISMA_ONLY_QUERY_PARAMETERS) {
+    url.searchParams.delete(key);
+  }
+  return url.toString();
+}
+
+export function redactPostgresUrls(value) {
+  return value.replace(
+    /\bpostgres(?:ql)?:\/\/[^\s'"`]+/gi,
+    "[REDACTED_DATABASE_URL]",
+  );
+}
+
+export function parseTimeoutSeconds(value) {
+  if (value === undefined || value === "") return 1200;
+  if (!/^\d+$/.test(value)) {
+    throw new Error("Backup timeout must be a positive integer in seconds");
+  }
+  const seconds = Number(value);
+  if (!Number.isSafeInteger(seconds) || seconds <= 0) {
+    throw new Error("Backup timeout must be a positive integer in seconds");
+  }
+  return seconds;
+}
+
+export function normalizePrefix(value = DEFAULT_PREFIX) {
+  const prefix = value.replace(/^\/+|\/+$/g, "");
+  if (!prefix) {
+    throw new Error("Backup prefix must not be empty");
+  }
+  return prefix;
+}
+
+export function buildBackupObjectName(prefix, generation, sourceName) {
+  if (!/^\d+$/.test(generation ?? "")) {
+    throw new Error("Source object generation must be numeric");
+  }
+  if (!sourceName) {
+    throw new Error("Source object name must not be empty");
+  }
+  const encodedName = Buffer.from(sourceName, "utf8").toString("base64url");
+  return `${normalizePrefix(prefix)}/objects/${generation}/${encodedName}`;
+}
+
+export function shouldIncludeSourceObject(name, sameBucket, prefix) {
+  if (!sameBucket) return true;
+  const normalized = normalizePrefix(prefix);
+  return name !== normalized && !name.startsWith(`${normalized}/`);
+}
+
+export function buildManifest({
+  backupId,
+  sourceCommit,
+  startedAt,
+  completedAt,
+  sourceBucket,
+  backupBucket,
+  database,
+  documents,
+}) {
+  const totalBytes = documents.reduce(
+    (total, document) => total + document.bytes,
+    0,
+  );
+  return {
+    version: 1,
+    backupId,
+    sourceCommit,
+    startedAt,
+    completedAt,
+    sourceBucket,
+    backupBucket,
+    database,
+    documents: {
+      count: documents.length,
+      totalBytes,
+      objects: documents,
+    },
+  };
+}
+
+async function sha256File(filePath) {
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(filePath)) {
+    hash.update(chunk);
+  }
+  return hash.digest("hex");
+}
+
+async function runPgDump(databaseUrl, outputPath) {
+  const handle = await open(outputPath, "wx", 0o600);
+  let stderr = "";
+  try {
+    const child = spawn(
+      "pg_dump",
+      [
+        databaseUrl,
+        "--format=custom",
+        "--no-owner",
+        "--no-privileges",
+      ],
+      { stdio: ["ignore", handle.fd, "pipe"] },
+    );
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+      if (stderr.length < 16_384) stderr += chunk;
+    });
+
+    const exitCode = await new Promise((resolve, reject) => {
+      child.once("error", reject);
+      child.once("close", resolve);
+    });
+    if (exitCode !== 0) {
+      const detail = redactPostgresUrls(stderr.trim());
+      throw new Error(
+        `pg_dump failed with exit code ${exitCode}${detail ? `: ${detail}` : ""}`,
+      );
+    }
+  } finally {
+    await handle.close();
+  }
+
+  const metadata = await stat(outputPath);
+  if (!metadata.isFile() || metadata.size === 0) {
+    throw new Error("Database backup failed or produced an empty file");
+  }
+  await chmod(outputPath, 0o600);
+  return {
+    bytes: metadata.size,
+    sha256: await sha256File(outputPath),
+  };
+}
+
+async function verifyObject(file, expected) {
+  const [metadata] = await file.getMetadata();
+  const actualSize = Number(metadata.size);
+  if (actualSize !== expected.bytes) {
+    throw new Error(
+      `Backup object ${file.name} has size ${actualSize}, expected ${expected.bytes}`,
+    );
+  }
+  if (expected.crc32c && metadata.crc32c !== expected.crc32c) {
+    throw new Error(`Backup object ${file.name} has an unexpected CRC32C`);
+  }
+  if (expected.md5Hash && metadata.md5Hash !== expected.md5Hash) {
+    throw new Error(`Backup object ${file.name} has an unexpected MD5 hash`);
+  }
+  if (
+    expected.sha256 &&
+    metadata.metadata?.sha256 !== expected.sha256
+  ) {
+    throw new Error(`Backup object ${file.name} has an unexpected SHA-256`);
+  }
+  return metadata;
+}
+
+async function uploadDatabase(bucket, localPath, objectName, database) {
+  const destination = bucket.file(objectName);
+  const [exists] = await destination.exists();
+  if (!exists) {
+    await bucket.upload(localPath, {
+      destination: objectName,
+      resumable: false,
+      preconditionOpts: { ifGenerationMatch: 0 },
+      metadata: {
+        contentType: "application/octet-stream",
+        metadata: { sha256: database.sha256 },
+      },
+    });
+  }
+  await verifyObject(destination, database);
+}
+
+async function snapshotDocuments({
+  sourceBucket,
+  backupBucket,
+  sameBucket,
+  prefix,
+}) {
+  const [sourceFiles] = await sourceBucket.getFiles();
+  const documents = [];
+
+  for (const sourceFile of sourceFiles) {
+    if (!shouldIncludeSourceObject(sourceFile.name, sameBucket, prefix)) {
+      continue;
+    }
+
+    const [sourceMetadata] = await sourceFile.getMetadata();
+    const generation = String(sourceMetadata.generation ?? "");
+    const bytes = Number(sourceMetadata.size);
+    if (!generation || !Number.isSafeInteger(bytes) || bytes < 0) {
+      throw new Error(`Source object ${sourceFile.name} has invalid metadata`);
+    }
+
+    const backupObject = buildBackupObjectName(
+      prefix,
+      generation,
+      sourceFile.name,
+    );
+    const destination = backupBucket.file(backupObject);
+    const expected = {
+      bytes,
+      crc32c: sourceMetadata.crc32c,
+      md5Hash: sourceMetadata.md5Hash,
+    };
+    const [exists] = await destination.exists();
+    if (!exists) {
+      const sourceGeneration = sourceBucket.file(sourceFile.name, { generation });
+      await sourceGeneration.copy(destination, {
+        preconditionOpts: { ifGenerationMatch: 0 },
+      });
+    }
+    await verifyObject(destination, expected);
+
+    documents.push({
+      name: sourceFile.name,
+      generation,
+      bytes,
+      crc32c: sourceMetadata.crc32c ?? null,
+      md5Hash: sourceMetadata.md5Hash ?? null,
+      backupObject,
+    });
+  }
+
+  return documents.sort((left, right) =>
+    left.name.localeCompare(right.name) ||
+    left.generation.localeCompare(right.generation),
+  );
+}
+
+async function publishManifest(bucket, objectName, manifest) {
+  const payload = Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+  const file = bucket.file(objectName);
+  const [exists] = await file.exists();
+  if (exists) {
+    throw new Error(`Completion manifest already exists: ${objectName}`);
+  }
+  await file.save(payload, {
+    resumable: false,
+    preconditionOpts: { ifGenerationMatch: 0 },
+    contentType: "application/json",
+  });
+  await verifyObject(file, { bytes: payload.length });
+}
+
+function printHelp() {
+  process.stdout.write(`Usage: node scripts/pre-deploy-backup.mjs\n\nRequired environment:\n  BACKUP_ID       UTC timestamp plus Git SHA\n  SOURCE_COMMIT   Git commit being deployed\n  DATABASE_URL    Production PostgreSQL URL\n  GCS_BUCKET      Source document bucket\n\nOptional environment:\n  BACKUP_GCS_BUCKET      Dedicated destination bucket\n  BACKUP_GCS_PREFIX      Destination prefix\n  BACKUP_LOCAL_DIR       Local dump directory (default: /backups)\n  BACKUP_TIMEOUT_SECONDS Hard deadline (default: 1200)\n`);
+}
+
+async function runBackup() {
+  const startedAt = new Date().toISOString();
+  const backupId = validateBackupId(process.env.BACKUP_ID);
+  const sourceCommit = process.env.SOURCE_COMMIT ?? "";
+  if (!/^[0-9a-f]{40}$/.test(sourceCommit)) {
+    throw new Error("SOURCE_COMMIT must be a full Git SHA");
+  }
+  if (!backupId.endsWith(`-${sourceCommit}`)) {
+    throw new Error("BACKUP_ID must end with SOURCE_COMMIT");
+  }
+
+  const sourceBucketName = process.env.GCS_BUCKET;
+  if (!sourceBucketName) {
+    throw new Error("GCS_BUCKET is required for document backup");
+  }
+  const backupBucketName = process.env.BACKUP_GCS_BUCKET || sourceBucketName;
+  const prefix = normalizePrefix(
+    process.env.BACKUP_GCS_PREFIX || DEFAULT_PREFIX,
+  );
+  const localDirectory = process.env.BACKUP_LOCAL_DIR || "/backups";
+  const databaseUrl = normalizeDatabaseUrl(process.env.DATABASE_URL);
+
+  await mkdir(localDirectory, { recursive: true, mode: 0o700 });
+  await chmod(localDirectory, 0o700);
+  const localFileName = `nexus-before-${backupId}.dump`;
+  const localPath = path.join(localDirectory, localFileName);
+
+  console.error(`[backup] creating PostgreSQL dump for ${backupId}`);
+  const database = await runPgDump(databaseUrl, localPath);
+
+  const storage = new Storage();
+  const sourceBucket = storage.bucket(sourceBucketName);
+  const backupBucket = storage.bucket(backupBucketName);
+  const snapshotPrefix = `${prefix}/snapshots/${backupId}`;
+  const databaseObject = `${snapshotPrefix}/database.dump`;
+
+  console.error(`[backup] uploading and verifying ${localFileName}`);
+  await uploadDatabase(backupBucket, localPath, databaseObject, database);
+
+  console.error("[backup] snapshotting document object generations");
+  const documents = await snapshotDocuments({
+    sourceBucket,
+    backupBucket,
+    sameBucket: sourceBucketName === backupBucketName,
+    prefix,
+  });
+
+  const completedAt = new Date().toISOString();
+  const manifest = buildManifest({
+    backupId,
+    sourceCommit,
+    startedAt,
+    completedAt,
+    sourceBucket: sourceBucketName,
+    backupBucket: backupBucketName,
+    database: {
+      object: databaseObject,
+      localFile: localFileName,
+      bytes: database.bytes,
+      sha256: database.sha256,
+    },
+    documents,
+  });
+  const manifestObject = `${snapshotPrefix}/manifest.json`;
+
+  console.error("[backup] publishing verified completion manifest");
+  await publishManifest(backupBucket, manifestObject, manifest);
+
+  process.stdout.write(
+    `${JSON.stringify({
+      backupId,
+      databaseBytes: database.bytes,
+      databaseSha256: database.sha256,
+      documentCount: documents.length,
+      manifestObject,
+      verified: true,
+    })}\n`,
+  );
+}
+
+async function main() {
+  if (process.argv.includes("--help")) {
+    printHelp();
+    return;
+  }
+
+  const timeoutSeconds = parseTimeoutSeconds(process.env.BACKUP_TIMEOUT_SECONDS);
+  const timeout = setTimeout(() => {
+    console.error(
+      `[backup] failed: exceeded hard timeout of ${timeoutSeconds} seconds`,
+    );
+    process.exit(124);
+  }, timeoutSeconds * 1000);
+
+  try {
+    await runBackup();
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(process.argv[1]).href : "";
+if (import.meta.url === invokedPath) {
+  main().catch((error) => {
+    console.error(`[backup] failed: ${error.message}`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary

- gate every Hetzner deployment on a verified PostgreSQL and GCS document recovery set
- quiesce Nexus writes so the database dump and generation-pinned document snapshot share one coherent boundary
- restore the previous Compose, `.env`, and application image on any pre-activation failure
- retain a protected local custom-format dump and upload a checksum-bound remote copy
- snapshot exact GCS object generations into a deduplicated namespace and publish the completion manifest last
- serialize deployment and manual recovery in one non-cancelling production-transition group
- add bounded backup/job deadlines and a path-scoped production-container smoke check
- add OpenSpec artifacts, an implementation plan, and a restore/retention runbook

## Backup behavior

The target image performs the backup in a one-off container after the existing Nexus service is stopped. It inherits `DATABASE_URL`, `GCS_BUCKET`, credentials, and optional `BACKUP_GCS_*` settings from Coolify; GitHub Actions receives no database or GCS secrets.

Deployment aborts before Prisma migration or target-image activation if any dump, upload, document copy, metadata check, or manifest verification fails. The EXIT trap restores the previous Compose/environment files and restarts the previous image.

A dedicated `BACKUP_GCS_BUCKET` is recommended. Until configured, the runtime uses `_nexus-backups/pre-deploy` in the document bucket and excludes that namespace from source enumeration.

## Validation

- `npm test` — 204 tests passed across 26 files
- `npm run lint` — 0 errors; 3 existing warnings
- `npm run build` — passed
- backup-specific tests — 20 passed
- deploy, recovery, and container workflows parsed as YAML
- embedded deployment and recovery shell passed `bash -n`
- Docker Compose `stop --timeout` CLI compatibility verified
- `openspec validate add-pre-deploy-data-backups --strict` — passed
- `git diff --check` — passed
- independent review findings on rollback, snapshot consistency, concurrency, and timeouts were addressed

The local environment has no Docker daemon. The new `Container smoke` PR check builds the production image and verifies `pg_dump`, `psql`, the packaged backup script, and its CLI entrypoint.

## Before merge/deploy

- rotate the currently mounted long-lived GCS service-account key
- preferably configure a private dedicated `BACKUP_GCS_BUCKET`
- expect a brief maintenance window while writes are quiesced; the first document snapshot is the longest
- after merge, verify the first recovery manifest and perform the isolated restore drill in `docs/operations/pre-deploy-backups.md`
