### PR TITLE
Style modal scrollbar to match glassmorphic design system

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -51,4 +51,39 @@
   .nexus-chip {
     @apply inline-flex items-center rounded-full border border-slate-200 bg-slate-50 px-2.5 py-1 text-xs font-medium text-slate-600 dark:border-white/8 dark:bg-white/4 dark:text-slate-300;
   }
+
+  .nexus-scroll {
+    scrollbar-width: thin;
+    scrollbar-color: rgb(203 213 225 / 0.5) transparent;
+  }
+
+  .nexus-scroll::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  .nexus-scroll::-webkit-scrollbar-track {
+    background: transparent;
+    margin-block: 4px;
+  }
+
+  .nexus-scroll::-webkit-scrollbar-thumb {
+    background: rgb(203 213 225 / 0.5);
+    border-radius: 9999px;
+  }
+
+  .nexus-scroll::-webkit-scrollbar-thumb:hover {
+    background: rgb(148 163 184 / 0.7);
+  }
+
+  .dark .nexus-scroll {
+    scrollbar-color: rgb(255 255 255 / 0.08) transparent;
+  }
+
+  .dark .nexus-scroll::-webkit-scrollbar-thumb {
+    background: rgb(255 255 255 / 0.08);
+  }
+
+  .dark .nexus-scroll::-webkit-scrollbar-thumb:hover {
+    background: rgb(255 255 255 / 0.18);
+  }
 }

--- a/components/application-modal.tsx
+++ b/components/application-modal.tsx
@@ -380,7 +380,7 @@ export function ApplicationModal({ application, onClose }: ApplicationModalProps
 
   return (
     <div className="fixed inset-0 z-50 flex items-end justify-center bg-slate-950/70 backdrop-blur-md sm:items-center sm:p-4">
-      <div className="w-full max-w-3xl max-h-[95vh] overflow-y-auto rounded-t-[1.75rem] border border-slate-200/80 bg-white/95 shadow-2xl backdrop-blur-xl dark:border-white/8 dark:bg-[#0f1011]/95 sm:max-h-[90vh] sm:rounded-[1.75rem]">
+      <div className="nexus-scroll w-full max-w-3xl max-h-[95vh] overflow-y-auto rounded-t-[1.75rem] border border-slate-200/80 bg-white/95 shadow-2xl backdrop-blur-xl dark:border-white/8 dark:bg-[#0f1011]/95 sm:max-h-[90vh] sm:rounded-[1.75rem]">
         {/* Header */}
         <div className="sticky top-0 z-10 flex items-center justify-between border-b border-slate-200/80 bg-white/90 px-4 py-4 backdrop-blur-xl dark:border-white/8 dark:bg-[#0f1011]/90 sm:px-6">
           <div>


### PR DESCRIPTION
Adds a reusable .nexus-scroll class with thin, rounded, semi-transparent scrollbar styling for both WebKit (Chrome) and Firefox. Applied to the opportunity edit modal to replace the jarring default browser scrollbar.


Claude-Session: https://claude.ai/code/session_01MAe7RWNvagKAaK3GVcDWeG