### PR TITLE
Preserve hidden selections during filtered bulk actions

### DIFF
--- a/components/__tests__/application-table.test.tsx
+++ b/components/__tests__/application-table.test.tsx
@@ -72,7 +72,7 @@ describe("ApplicationTable bulk selection", () => {
 					selectedIds={new Set()}
 					onToggleSelect={vi.fn()}
 					onSelectAll={onSelectAll}
-					onClearSelection={vi.fn()}
+					onDeselectAll={vi.fn()}
 				/>,
 			);
 		});
@@ -86,5 +86,42 @@ describe("ApplicationTable bulk selection", () => {
 
 		expect(onSelectAll).toHaveBeenCalledOnce();
 		expect(onSelectAll).toHaveBeenCalledWith([lost]);
+	});
+
+	it("deselects only filtered applications and preserves hidden selections", async () => {
+		const lost = application("lost", "rejected");
+		const hidden = application("hidden", "interview");
+		let selectedIds = new Set([lost.id, hidden.id]);
+		const onDeselectAll = vi.fn((applications: Application[]) => {
+			const next = new Set(selectedIds);
+			for (const application of applications) next.delete(application.id);
+			selectedIds = next;
+		});
+
+		await act(async () => {
+			root.render(
+				<ApplicationTable
+					applications={[lost, hidden]}
+					onEdit={vi.fn()}
+					onDelete={vi.fn()}
+					initialStatusFilter="rejected"
+					selectedIds={selectedIds}
+					onToggleSelect={vi.fn()}
+					onSelectAll={vi.fn()}
+					onDeselectAll={onDeselectAll}
+				/>,
+			);
+		});
+
+		const selectAll = container.querySelector<HTMLInputElement>(
+			'thead input[type="checkbox"]',
+		);
+		if (!selectAll) throw new Error("Select-all checkbox was not rendered");
+
+		await act(async () => selectAll.click());
+
+		expect(onDeselectAll).toHaveBeenCalledOnce();
+		expect(onDeselectAll).toHaveBeenCalledWith([lost]);
+		expect(selectedIds).toEqual(new Set([hidden.id]));
 	});
 });

--- a/components/application-table.tsx
+++ b/components/application-table.tsx
@@ -71,6 +71,8 @@ function FollowUpCell({ date }: { date: string | null }) {
 }
 
 function JobLink({ jobUrl, iconClassName }: { jobUrl: string; iconClassName: string }) {
+  const ta = useTranslations("actions");
+
   return (
     <a
       href={jobUrl}
@@ -78,6 +80,7 @@ function JobLink({ jobUrl, iconClassName }: { jobUrl: string; iconClassName: str
       rel="noopener noreferrer"
       onClick={(event) => event.stopPropagation()}
       title={jobUrl}
+      aria-label={ta("open_job_post")}
       className="shrink-0 text-gray-400 transition-colors hover:text-blue-600 dark:hover:text-blue-400"
     >
       <svg className={iconClassName} fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -241,11 +244,11 @@ interface ApplicationTableProps {
   selectedIds?: Set<string>;
   onToggleSelect?: (id: string) => void;
   onSelectAll?: (applications: Application[]) => void;
-  onClearSelection?: () => void;
+  onDeselectAll?: (applications: Application[]) => void;
   focusedIndex?: number;
 }
 
-export function ApplicationTable({ applications, onEdit, onDelete, onArchive, showArchived, initialStatusFilter, initialSourceFilter, initialGlobalFilter, selectedIds, onToggleSelect, onSelectAll, onClearSelection, focusedIndex }: ApplicationTableProps) {
+export function ApplicationTable({ applications, onEdit, onDelete, onArchive, showArchived, initialStatusFilter, initialSourceFilter, initialGlobalFilter, selectedIds, onToggleSelect, onSelectAll, onDeselectAll, focusedIndex }: ApplicationTableProps) {
   const t = useTranslations("table");
   const ta = useTranslations("actions");
   const tAnalytics = useTranslations("analytics");
@@ -294,7 +297,7 @@ export function ApplicationTable({ applications, onEdit, onDelete, onArchive, sh
                   type="checkbox"
                   checked={allSelected}
                   onChange={() => {
-                    if (allSelected) onClearSelection?.();
+                    if (allSelected) onDeselectAll?.(selectableApplications);
                     else onSelectAll?.(selectableApplications);
                   }}
                   className="rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500 cursor-pointer"

--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -308,7 +308,23 @@ export function Dashboard({ user, shareUrl, initialStatus, initialSource, initia
   }
 
   function selectAll(apps: Application[]) {
-    setSelectedIds(new Set(apps.slice(0, 100).map((a) => a.id)));
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      for (const app of apps) {
+        if (next.has(app.id)) continue;
+        if (next.size >= 100) break;
+        next.add(app.id);
+      }
+      return next;
+    });
+  }
+
+  function deselectAll(apps: Application[]) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      for (const app of apps) next.delete(app.id);
+      return next;
+    });
   }
 
   function clearSelection() {
@@ -555,7 +571,7 @@ export function Dashboard({ user, shareUrl, initialStatus, initialSource, initia
             selectedIds={selectedIds}
             onToggleSelect={toggleSelect}
             onSelectAll={selectAll}
-            onClearSelection={clearSelection}
+            onDeselectAll={deselectAll}
             focusedIndex={focusedIndex}
           />
         ) : (

--- a/messages/de.json
+++ b/messages/de.json
@@ -44,6 +44,7 @@
     "cancel": "Abbrechen",
     "saving": "Speichern...",
     "search": "Suchen...",
+    "open_job_post": "Stellenangebot in neuem Tab öffnen",
     "all_statuses": "Alle Status",
     "archive": "Archiv",
     "unarchive": "Wiederherstellen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -44,6 +44,7 @@
     "cancel": "Cancel",
     "saving": "Saving...",
     "search": "Search...",
+    "open_job_post": "Open listing in a new tab",
     "all_statuses": "All statuses",
     "archive": "Archive",
     "unarchive": "Unarchive",


### PR DESCRIPTION
## Summary
- merge filtered select-all rows into the existing selection instead of replacing hidden selections
- remove only filtered rows when deselecting through the header checkbox
- add regression coverage proving hidden selections survive filtered deselection
- add a localized accessible label to external job-post links

## Context
Addresses the review feedback on #136 without modifying that PR branch directly. This is a stacked PR and should merge into `fix/filtered-bulk-archive` first.

## Verification
- `npm test` — 26 test files, 186 tests passed
- `npx tsc --noEmit` — passed
- `npm run build` — passed
- targeted ESLint — 0 errors (existing TanStack React Compiler compatibility warning)
