### PR TITLE
fix: migrate proxy and disable telemetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,11 @@ on:
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest
+    env:
+      NEXT_TELEMETRY_DISABLED: "1"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/deploy-hetzner.yml
+++ b/.github/workflows/deploy-hetzner.yml
@@ -31,13 +31,15 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       vars.HETZNER_AUTO_DEPLOY == 'true'
+    env:
+      NEXT_TELEMETRY_DISABLED: "1"
 
     permissions:
       contents: read
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Normalize deploy env
         run: |
@@ -48,12 +50,12 @@ jobs:
             >> "$GITHUB_ENV"
 
       - name: Set up QEMU for ARM64 builds
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: arm64
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build ARM64 image in GitHub Actions
         env:
@@ -143,10 +145,13 @@ jobs:
 
           # A previous interrupted deploy may have left the generated compose
           # file invalid. Recover the newest valid snapshot before inspecting it.
-          if ! docker compose -f docker-compose.yaml config --quiet >/dev/null 2>&1; then
+          if ! docker compose -f docker-compose.yaml \
+            config --quiet >/dev/null 2>&1; then
             recovered=""
-            for candidate in $(ls -1t docker-compose.yaml.before-* 2>/dev/null || true); do
-              if docker compose -f "${candidate}" config --quiet >/dev/null 2>&1; then
+            for candidate in $(ls -1t \
+              docker-compose.yaml.before-* 2>/dev/null || true); do
+              if docker compose -f "${candidate}" \
+                config --quiet >/dev/null 2>&1; then
                 cp "${candidate}" docker-compose.yaml
                 recovered="${candidate}"
                 echo "Recovered docker-compose.yaml from ${candidate}."
@@ -154,7 +159,7 @@ jobs:
               fi
             done
             if [ -z "${recovered}" ]; then
-              echo "docker-compose.yaml is invalid and no valid backup exists." >&2
+              echo "docker-compose.yaml is invalid and has no valid backup."
               exit 1
             fi
           fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:22-alpine AS builder
 RUN apk add --no-cache openssl
 WORKDIR /app
+ENV NEXT_TELEMETRY_DISABLED=1
 COPY package*.json ./
 RUN npm ci
 RUN npm install --prefix /tmp/prisma-cli --no-save --no-audit --no-fund prisma@6.19.3
@@ -12,6 +13,7 @@ FROM node:22-alpine AS runner
 RUN apk add --no-cache openssl postgresql-client
 WORKDIR /app
 ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 RUN mkdir -p /app/uploads && chown nextjs:nodejs /app/uploads

--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { NextRequest } from "next/server";
-import { middleware, config } from "../middleware";
+import { proxy, config } from "../proxy";
 
 function makeRequest(url: string, ip = "203.0.113.10") {
   return new NextRequest(url, {
@@ -10,18 +10,18 @@ function makeRequest(url: string, ip = "203.0.113.10") {
   });
 }
 
-describe("middleware", () => {
+describe("proxy", () => {
   it("matches and rate-limits the public share page", () => {
     expect(config.matcher).toContain("/share");
 
     const ip = "203.0.113.77";
     for (let i = 0; i < 30; i++) {
-      const res = middleware(makeRequest("http://localhost/share?code=abc123", ip));
+      const res = proxy(makeRequest("http://localhost/share?code=abc123", ip));
       expect(res.status).not.toBe(429);
       expect(res.headers.get("X-RateLimit-Limit")).toBe("30");
     }
 
-    const blocked = middleware(makeRequest("http://localhost/share?code=abc123", ip));
+    const blocked = proxy(makeRequest("http://localhost/share?code=abc123", ip));
     expect(blocked.status).toBe(429);
   });
 });

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -4,7 +4,11 @@ import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
 
+const baseURL = process.env.BETTER_AUTH_URL || process.env.NEXT_PUBLIC_BETTER_AUTH_URL || "http://localhost:3001";
+
 export const auth = betterAuth({
+  baseURL,
+
   database: prismaAdapter(prisma, {
     provider: "postgresql",
   }),
@@ -14,5 +18,5 @@ export const auth = betterAuth({
       clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
     },
   },
-  trustedOrigins: [process.env.BETTER_AUTH_URL || "http://localhost:3001"],
+  trustedOrigins: [baseURL],
 });

--- a/proxy.ts
+++ b/proxy.ts
@@ -9,7 +9,7 @@ function getClientIp(req: NextRequest): string {
   );
 }
 
-export function middleware(req: NextRequest): NextResponse {
+export function proxy(req: NextRequest): NextResponse {
   const { pathname } = req.nextUrl;
   const ip = getClientIp(req);
 


### PR DESCRIPTION
## Summary\n- Renamed Next.js middleware entrypoint from middleware.ts to proxy.ts and updated the rate-limit test import.\n- Added NEXT_TELEMETRY_DISABLED=1 in CI and Docker build/runtime paths.\n- Updated GitHub Actions steps to newer versions: actions/checkout@v7, docker/setup-qemu-action@v4, docker/setup-buildx-action@v4.\n- Added baseURL to Better Auth config to remove startup base URL warning.\n\n## Validation\n- npm run lint\n- npm run build\n- npm test\n