### PR TITLE
ci: update setup-node action to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
Small follow-up to remove deprecation warning from Node.js actions by updating actions/setup-node from v4 to v7.\n\nValidation: npm run lint