### PR TITLE
Prevent OAuth scope elevation on refresh token exchange

### DIFF
--- a/app/api/mcp/token/route.ts
+++ b/app/api/mcp/token/route.ts
@@ -131,19 +131,26 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const tokens = await exchangeRefreshToken({
+    // RFC 6749 §6: an optional `scope` on refresh may narrow but never widen the
+    // grant. Pass it through so a client that asks for a scope beyond its grant
+    // is told to re-authorize rather than silently handed a narrower token.
+    const requestedScopes = params.get("scope")?.split(" ").filter(Boolean);
+
+    const result = await exchangeRefreshToken({
       refreshToken,
       clientId,
+      requestedScopes,
     });
 
-    if (!tokens) {
+    if ("error" in result) {
+      // RFC 6749 §5.2: both invalid_grant and invalid_scope are 400 responses.
       return NextResponse.json(
-        { error: "invalid_grant", error_description: "Invalid or expired refresh token" },
+        { error: result.error, error_description: result.error_description },
         { status: 400 }
       );
     }
 
-    return NextResponse.json(tokens, {
+    return NextResponse.json(result, {
       headers: { "Cache-Control": "no-store" },
     });
   }

--- a/lib/__tests__/mcp-oauth-scope-elevation.test.ts
+++ b/lib/__tests__/mcp-oauth-scope-elevation.test.ts
@@ -1,22 +1,53 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createHash } from "node:crypto";
 
+// Minimal row shapes for the in-memory Prisma double.
+type AuthCodeRow = {
+  code: string;
+  clientId: string;
+  userId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  scopes: string[];
+  sensitiveConsentVersion: number;
+  expiresAt: Date;
+  used: boolean;
+  createdAt: Date;
+};
+
+type TokenRow = {
+  id: string;
+  tokenHash: string;
+  clientId: string;
+  userId: string;
+  scopes: string[];
+  sensitiveConsentVersion: number;
+  expiresAt: Date;
+};
+
 // In-memory Prisma double for the MCP OAuth tables. Mirrors the Prisma schema
 // defaults that matter for these flows (McpAuthCode.used defaults to false).
 const store = vi.hoisted(() => ({
-  authCodes: [] as any[],
-  accessTokens: [] as any[],
-  refreshTokens: [] as any[],
+  authCodes: [] as AuthCodeRow[],
+  accessTokens: [] as TokenRow[],
+  refreshTokens: [] as TokenRow[],
 }));
 
 vi.mock("@/lib/prisma", () => ({
   prisma: {
     mcpAuthCode: {
-      create: async ({ data }: any) => {
-        store.authCodes.push({ used: false, createdAt: new Date(), ...data });
-        return data;
+      create: async ({ data }: { data: Partial<AuthCodeRow> & { code: string } }) => {
+        const row: AuthCodeRow = { used: false, createdAt: new Date(), ...data } as AuthCodeRow;
+        store.authCodes.push(row);
+        return row;
       },
-      updateMany: async ({ where, data }: any) => {
+      updateMany: async ({
+        where,
+        data,
+      }: {
+        where: { code: string; clientId: string; redirectUri: string; expiresAt: { gt: Date } };
+        data: Partial<AuthCodeRow>;
+      }) => {
         let count = 0;
         for (const c of store.authCodes) {
           if (
@@ -32,25 +63,27 @@ vi.mock("@/lib/prisma", () => ({
         }
         return { count };
       },
-      findUnique: async ({ where }: any) =>
+      findUnique: async ({ where }: { where: { code: string } }) =>
         store.authCodes.find((c) => c.code === where.code) ?? null,
     },
     mcpAccessToken: {
-      create: async ({ data }: any) => {
-        store.accessTokens.push({ ...data });
-        return data;
+      create: async ({ data }: { data: Omit<TokenRow, "id"> }) => {
+        const row: TokenRow = { id: `at_${store.accessTokens.length}`, ...data };
+        store.accessTokens.push(row);
+        return row;
       },
-      findUnique: async ({ where }: any) =>
+      findUnique: async ({ where }: { where: { tokenHash: string } }) =>
         store.accessTokens.find((t) => t.tokenHash === where.tokenHash) ?? null,
     },
     mcpRefreshToken: {
-      create: async ({ data }: any) => {
-        store.refreshTokens.push({ id: `rt_${store.refreshTokens.length}`, ...data });
-        return data;
+      create: async ({ data }: { data: Omit<TokenRow, "id"> }) => {
+        const row: TokenRow = { id: `rt_${store.refreshTokens.length}`, ...data };
+        store.refreshTokens.push(row);
+        return row;
       },
-      findUnique: async ({ where }: any) =>
+      findUnique: async ({ where }: { where: { tokenHash: string } }) =>
         store.refreshTokens.find((t) => t.tokenHash === where.tokenHash) ?? null,
-      delete: async ({ where }: any) => {
+      delete: async ({ where }: { where: { id: string } }) => {
         const i = store.refreshTokens.findIndex((t) => t.id === where.id);
         if (i >= 0) store.refreshTokens.splice(i, 1);
       },
@@ -70,7 +103,7 @@ function seedRefreshToken(opts: {
   clientId?: string;
 }) {
   store.refreshTokens.push({
-    id: "rt_seed",
+    id: `rt_seed_${store.refreshTokens.length}`,
     tokenHash: sha256(opts.token),
     clientId: opts.clientId ?? "client-1",
     userId: "user-a",
@@ -182,5 +215,40 @@ describe("MCP OAuth scope elevation", () => {
       clientId: "client-1",
     });
     expect("scope" in kept && kept.scope).toBe("mcp:tools mcp:submissions");
+  });
+
+  // Narrowing the issued access token must not burn down the underlying grant:
+  // the rotated refresh token keeps the original scope, so the client can later
+  // re-request the full scope it already consented to.
+  it("preserves the original grant when a narrowed refresh is rotated", async () => {
+    seedRefreshToken({
+      token: "mcp_rt_grant",
+      scopes: ["mcp:tools", "mcp:submissions"],
+      sensitiveConsentVersion: 1,
+    });
+
+    // First refresh narrows to mcp:tools only.
+    const narrowed = await exchangeRefreshToken({
+      refreshToken: "mcp_rt_grant",
+      clientId: "client-1",
+      requestedScopes: ["mcp:tools"],
+    });
+    expect("access_token" in narrowed).toBe(true);
+    if (!("refresh_token" in narrowed)) throw new Error("expected rotated refresh token");
+
+    // The access token is narrowed...
+    const narrowedAccess = store.accessTokens.find(
+      (t) => t.tokenHash === sha256(narrowed.access_token),
+    );
+    expect(narrowedAccess?.scopes).toEqual(["mcp:tools"]);
+
+    // ...but the rotated refresh token still carries the full grant, so a
+    // subsequent refresh can re-request mcp:submissions without re-auth.
+    const reElevated = await exchangeRefreshToken({
+      refreshToken: narrowed.refresh_token,
+      clientId: "client-1",
+      requestedScopes: ["mcp:tools", "mcp:submissions"],
+    });
+    expect("scope" in reElevated && reElevated.scope).toBe("mcp:tools mcp:submissions");
   });
 });

--- a/lib/__tests__/mcp-oauth-scope-elevation.test.ts
+++ b/lib/__tests__/mcp-oauth-scope-elevation.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createHash } from "node:crypto";
+
+// In-memory Prisma double for the MCP OAuth tables. Mirrors the Prisma schema
+// defaults that matter for these flows (McpAuthCode.used defaults to false).
+const store = vi.hoisted(() => ({
+  authCodes: [] as any[],
+  accessTokens: [] as any[],
+  refreshTokens: [] as any[],
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    mcpAuthCode: {
+      create: async ({ data }: any) => {
+        store.authCodes.push({ used: false, createdAt: new Date(), ...data });
+        return data;
+      },
+      updateMany: async ({ where, data }: any) => {
+        let count = 0;
+        for (const c of store.authCodes) {
+          if (
+            c.code === where.code &&
+            c.used === false &&
+            c.expiresAt > where.expiresAt.gt &&
+            c.clientId === where.clientId &&
+            c.redirectUri === where.redirectUri
+          ) {
+            Object.assign(c, data);
+            count++;
+          }
+        }
+        return { count };
+      },
+      findUnique: async ({ where }: any) =>
+        store.authCodes.find((c) => c.code === where.code) ?? null,
+    },
+    mcpAccessToken: {
+      create: async ({ data }: any) => {
+        store.accessTokens.push({ ...data });
+        return data;
+      },
+      findUnique: async ({ where }: any) =>
+        store.accessTokens.find((t) => t.tokenHash === where.tokenHash) ?? null,
+    },
+    mcpRefreshToken: {
+      create: async ({ data }: any) => {
+        store.refreshTokens.push({ id: `rt_${store.refreshTokens.length}`, ...data });
+        return data;
+      },
+      findUnique: async ({ where }: any) =>
+        store.refreshTokens.find((t) => t.tokenHash === where.tokenHash) ?? null,
+      delete: async ({ where }: any) => {
+        const i = store.refreshTokens.findIndex((t) => t.id === where.id);
+        if (i >= 0) store.refreshTokens.splice(i, 1);
+      },
+    },
+  },
+}));
+
+import { createAuthCode, exchangeAuthCode, exchangeRefreshToken } from "../mcp-oauth";
+
+const sha256 = (d: string) => createHash("sha256").update(d).digest("hex");
+const sha256Base64Url = (d: string) => createHash("sha256").update(d).digest("base64url");
+
+function seedRefreshToken(opts: {
+  token: string;
+  scopes: string[];
+  sensitiveConsentVersion: number;
+  clientId?: string;
+}) {
+  store.refreshTokens.push({
+    id: "rt_seed",
+    tokenHash: sha256(opts.token),
+    clientId: opts.clientId ?? "client-1",
+    userId: "user-a",
+    scopes: opts.scopes,
+    sensitiveConsentVersion: opts.sensitiveConsentVersion,
+    expiresAt: new Date(Date.now() + 90 * 24 * 60 * 60 * 1000),
+  });
+}
+
+describe("MCP OAuth scope elevation", () => {
+  beforeEach(() => {
+    store.authCodes.length = 0;
+    store.accessTokens.length = 0;
+    store.refreshTokens.length = 0;
+  });
+
+  // Primary deliverable: a full re-authorization that adds mcp:submissions
+  // (with sensitive-consent version recorded) must issue a token carrying it.
+  it("re-authorization with an added scope issues a token carrying that scope", async () => {
+    const codeVerifier = "code-verifier-for-reauth-flow";
+    const code = await createAuthCode({
+      clientId: "client-1",
+      userId: "user-a",
+      redirectUri: "https://claude.ai/api/mcp/auth_callback",
+      codeChallenge: sha256Base64Url(codeVerifier),
+      scopes: ["mcp:tools", "mcp:submissions"],
+      sensitiveConsentVersion: 1,
+    });
+
+    const tokens = await exchangeAuthCode({
+      code,
+      clientId: "client-1",
+      redirectUri: "https://claude.ai/api/mcp/auth_callback",
+      codeVerifier,
+    });
+
+    expect(tokens && "access_token" in tokens).toBe(true);
+    expect(tokens && "scope" in tokens && tokens.scope).toBe("mcp:tools mcp:submissions");
+
+    // The access token must actually enforce-carry the scope for the resource server.
+    if (tokens && "access_token" in tokens) {
+      const stored = store.accessTokens.find(
+        (t) => t.tokenHash === sha256(tokens.access_token),
+      );
+      expect(stored?.scopes).toEqual(["mcp:tools", "mcp:submissions"]);
+    }
+  });
+
+  // Regression for the root cause: a refresh MUST NOT widen scope. A client
+  // that refreshes a mcp:tools-only grant while asking for mcp:submissions is
+  // told to re-authorize (invalid_scope) instead of silently receiving a narrow
+  // token it mistakes for success.
+  it("rejects a refresh that requests a scope beyond the grant", async () => {
+    seedRefreshToken({ token: "mcp_rt_narrow", scopes: ["mcp:tools"], sensitiveConsentVersion: 0 });
+
+    const result = await exchangeRefreshToken({
+      refreshToken: "mcp_rt_narrow",
+      clientId: "client-1",
+      requestedScopes: ["mcp:tools", "mcp:submissions"],
+    });
+
+    expect("error" in result && result.error).toBe("invalid_scope");
+    // The narrow refresh token must not have been rotated away on a rejected request.
+    expect(store.refreshTokens.some((t) => t.tokenHash === sha256("mcp_rt_narrow"))).toBe(true);
+  });
+
+  // A legacy grant that stored mcp:submissions but predates the consent-version
+  // gate (version 0) is effectively mcp:tools-only, so a refresh asking for
+  // submissions is likewise pushed to re-authorization.
+  it("treats a pre-consent-version submissions grant as narrow on refresh", async () => {
+    seedRefreshToken({
+      token: "mcp_rt_legacy",
+      scopes: ["mcp:tools", "mcp:submissions"],
+      sensitiveConsentVersion: 0,
+    });
+
+    const result = await exchangeRefreshToken({
+      refreshToken: "mcp_rt_legacy",
+      clientId: "client-1",
+      requestedScopes: ["mcp:tools", "mcp:submissions"],
+    });
+
+    expect("error" in result && result.error).toBe("invalid_scope");
+  });
+
+  // Same-scope and omitted-scope refreshes must keep working (no regression).
+  it("allows a refresh that requests the same or a narrower scope", async () => {
+    seedRefreshToken({
+      token: "mcp_rt_full",
+      scopes: ["mcp:tools", "mcp:submissions"],
+      sensitiveConsentVersion: 1,
+    });
+
+    const narrowed = await exchangeRefreshToken({
+      refreshToken: "mcp_rt_full",
+      clientId: "client-1",
+      requestedScopes: ["mcp:tools"],
+    });
+    expect("scope" in narrowed && narrowed.scope).toBe("mcp:tools");
+
+    // A fully-consented grant with no requested scope keeps its full scope.
+    seedRefreshToken({
+      token: "mcp_rt_full_2",
+      scopes: ["mcp:tools", "mcp:submissions"],
+      sensitiveConsentVersion: 1,
+    });
+    const kept = await exchangeRefreshToken({
+      refreshToken: "mcp_rt_full_2",
+      clientId: "client-1",
+    });
+    expect("scope" in kept && kept.scope).toBe("mcp:tools mcp:submissions");
+  });
+});

--- a/lib/mcp-oauth.ts
+++ b/lib/mcp-oauth.ts
@@ -202,23 +202,47 @@ export async function exchangeAuthCode(params: {
 
 // ── Refresh Token ────────────────────────────────────────────────────────────
 
+export type RefreshTokenResult =
+  | { access_token: string; refresh_token: string; token_type: string; expires_in: number; scope: string }
+  | { error: "invalid_grant" | "invalid_scope"; error_description: string };
+
 export async function exchangeRefreshToken(params: {
   refreshToken: string;
   clientId: string;
-}): Promise<{ access_token: string; refresh_token: string; token_type: string; expires_in: number; scope: string } | null> {
+  requestedScopes?: string[];
+}): Promise<RefreshTokenResult> {
   const hash = sha256(params.refreshToken);
   const stored = await prisma.mcpRefreshToken.findUnique({
     where: { tokenHash: hash },
   });
 
-  if (!stored) return null;
-  if (stored.expiresAt < new Date()) return null;
-  if (stored.clientId !== params.clientId) return null;
+  if (!stored) return { error: "invalid_grant", error_description: "Invalid or expired refresh token" };
+  if (stored.expiresAt < new Date()) return { error: "invalid_grant", error_description: "Invalid or expired refresh token" };
+  if (stored.clientId !== params.clientId) return { error: "invalid_grant", error_description: "Invalid or expired refresh token" };
+
+  const grantedScopes = effectiveMcpScopes(stored.scopes, stored.sensitiveConsentVersion);
+
+  // OAuth 2.1 / RFC 6749 §6: a refresh request MAY narrow scope but MUST NOT
+  // widen it. A client that needs a scope beyond the stored grant (e.g. it now
+  // wants mcp:submissions on a mcp:tools-only grant) must run a full
+  // authorization so the user can re-consent — it cannot acquire the scope by
+  // refreshing. Reject the widening attempt with invalid_scope instead of
+  // silently returning the narrow scope, which a client reads as success and
+  // which leaves later calls failing with insufficient_scope.
+  let issuedScopes = grantedScopes;
+  if (params.requestedScopes && params.requestedScopes.length > 0) {
+    const beyondGrant = params.requestedScopes.filter((scope) => !grantedScopes.includes(scope));
+    if (beyondGrant.length > 0) {
+      return {
+        error: "invalid_scope",
+        error_description: `Requested scope exceeds the granted scope (${beyondGrant.join(" ")}); re-authorization is required to obtain it`,
+      };
+    }
+    issuedScopes = params.requestedScopes;
+  }
 
   // Rotate: delete old refresh token, issue new pair
   await prisma.mcpRefreshToken.delete({ where: { id: stored.id } });
-
-  const grantedScopes = effectiveMcpScopes(stored.scopes, stored.sensitiveConsentVersion);
   const newAccessToken = generateToken("mcp_at");
   const newRefreshToken = generateToken("mcp_rt");
 
@@ -227,7 +251,7 @@ export async function exchangeRefreshToken(params: {
       tokenHash: sha256(newAccessToken),
       clientId: stored.clientId,
       userId: stored.userId,
-      scopes: grantedScopes,
+      scopes: issuedScopes,
       sensitiveConsentVersion: stored.sensitiveConsentVersion,
       expiresAt: new Date(Date.now() + ACCESS_TOKEN_TTL_MS),
     },
@@ -238,7 +262,7 @@ export async function exchangeRefreshToken(params: {
       tokenHash: sha256(newRefreshToken),
       clientId: stored.clientId,
       userId: stored.userId,
-      scopes: grantedScopes,
+      scopes: issuedScopes,
       sensitiveConsentVersion: stored.sensitiveConsentVersion,
       expiresAt: new Date(Date.now() + REFRESH_TOKEN_TTL_MS),
     },
@@ -249,7 +273,7 @@ export async function exchangeRefreshToken(params: {
     refresh_token: newRefreshToken,
     token_type: "Bearer",
     expires_in: Math.floor(ACCESS_TOKEN_TTL_MS / 1000),
-    scope: grantedScopes.join(" "),
+    scope: issuedScopes.join(" "),
   };
 }
 

--- a/lib/mcp-oauth.ts
+++ b/lib/mcp-oauth.ts
@@ -262,7 +262,11 @@ export async function exchangeRefreshToken(params: {
       tokenHash: sha256(newRefreshToken),
       clientId: stored.clientId,
       userId: stored.userId,
-      scopes: issuedScopes,
+      // Narrowing applies only to the issued access token. The rotated refresh
+      // token must preserve the original grant (RFC 6749 §6) so a later refresh
+      // that omits `scope` — or re-requests the full scope the user already
+      // consented to — is not permanently burned down to the narrowed set.
+      scopes: stored.scopes,
       sensitiveConsentVersion: stored.sensitiveConsentVersion,
       expiresAt: new Date(Date.now() + REFRESH_TOKEN_TTL_MS),
     },


### PR DESCRIPTION
## Summary
This PR implements OAuth 2.1 / RFC 6749 §6 compliance to prevent scope elevation during refresh token exchanges. Previously, the refresh endpoint could silently issue tokens with narrower scopes than requested without informing the client, leading to failed API calls. Now, any attempt to request a scope beyond the originally granted scope is explicitly rejected with an `invalid_scope` error, forcing the client to perform a full re-authorization.

## Key Changes

- **Enhanced `exchangeRefreshToken()` function**: 
  - Added optional `requestedScopes` parameter to accept scope narrowing requests
  - Implements scope validation: rejects requests that attempt to widen the granted scope
  - Returns a new `RefreshTokenResult` union type that includes error responses (`invalid_scope` and `invalid_grant`)
  - Properly handles legacy grants (pre-consent-version) by treating them as narrow grants

- **Updated `/api/mcp/token` endpoint**:
  - Extracts and passes the optional `scope` parameter from refresh requests to `exchangeRefreshToken()`
  - Handles both error and success responses from the refresh function
  - Returns appropriate HTTP 400 responses for both `invalid_grant` and `invalid_scope` errors per RFC 6749 §5.2

- **Comprehensive test coverage**:
  - Added 186-line test suite with in-memory Prisma mocks
  - Tests full re-authorization flow with scope elevation
  - Validates rejection of scope widening on refresh
  - Ensures legacy pre-consent-version grants are treated as narrow
  - Confirms same-scope and narrower refreshes continue to work

## Implementation Details

The fix leverages the existing `effectiveMcpScopes()` function to determine the actual granted scope (accounting for consent version gates), then validates that any requested scopes are a subset of the granted scopes. If a client attempts to request `mcp:submissions` on a grant that only includes `mcp:tools`, the request is rejected rather than silently returning a narrower token that the client would misinterpret as success.

https://claude.ai/code/session_01QjhqCUvgkk3YW9hHURVcxJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refresh requests can now request a narrower set of permissions while preserving the original authorization.
  * OAuth responses now provide clearer error details for invalid refresh tokens and unsupported permission requests.

* **Bug Fixes**
  * Prevented refresh flows from granting permissions beyond those originally approved.
  * Preserved compatibility for older authorization grants and prevented invalid refresh tokens from being rotated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->