### PR TITLE
Alias /mcp connector URL to the canonical /api/mcp route

### DIFF
--- a/lib/__tests__/mcp-url-alias.test.ts
+++ b/lib/__tests__/mcp-url-alias.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import config from "@/next.config";
+
+type Rewrite = { source: string; destination: string };
+
+/**
+ * Regression guard for the `/mcp` connector URL. Discovery metadata is served on
+ * every path, so OAuth succeeds even when a client is registered against `/mcp`;
+ * without an alias the follow-up JSON-RPC POST hit an HTML 404 ("authorized, but
+ * no MCP server was found at the given URL"). The canonical MCP route lives at
+ * `/api/mcp`, so `/mcp` must rewrite there.
+ */
+describe("MCP connector URL alias", () => {
+  it("rewrites /mcp to the canonical /api/mcp route", async () => {
+    const rewritesFn = (config as { rewrites?: () => Promise<Rewrite[] | { beforeFiles?: Rewrite[] }> }).rewrites;
+    expect(typeof rewritesFn).toBe("function");
+
+    const result = await rewritesFn!();
+    const rules: Rewrite[] = Array.isArray(result) ? result : (result.beforeFiles ?? []);
+
+    expect(rules).toContainEqual({ source: "/mcp", destination: "/api/mcp" });
+    expect(rules).toContainEqual({ source: "/mcp/:path*", destination: "/api/mcp/:path*" });
+  });
+});

--- a/next.config.ts
+++ b/next.config.ts
@@ -47,6 +47,18 @@ const nextConfig: NextConfig = {
       },
     ];
   },
+  async rewrites() {
+    return [
+      // Alias the historical `/mcp` connector URL to the canonical MCP route.
+      // Some MCP clients (and existing Claude.ai connectors) were registered
+      // against `/mcp`; discovery metadata is served on every path, so OAuth
+      // succeeds, but the JSON-RPC POST then hit an HTML 404 ("authorized, but
+      // no MCP server was found at the given URL"). Serve the same handler on
+      // both paths so either connector URL works.
+      { source: "/mcp", destination: "/api/mcp" },
+      { source: "/mcp/:path*", destination: "/api/mcp/:path*" },
+    ];
+  },
   async headers() {
     return [
       {


### PR DESCRIPTION
## Problem

After the scope fix in #150, reconnecting still failed — but with a **different** error:

> Your account was authorized, but no MCP server was found at the given URL, or your account has no access to it.

Root cause: the MCP server route only exists at **`/api/mcp`**. There is no `/mcp` route. But the OAuth *discovery* metadata (`/.well-known/oauth-protected-resource/...`) is served on **every** path, so a client (or an existing Claude.ai connector) registered against `https://nexus.vasudev.xyz/mcp`:

1. reads discovery at `/.well-known/oauth-protected-resource/mcp` → valid metadata → **OAuth succeeds** ("authorized"), then
2. POSTs the MCP `initialize` handshake to `/mcp` → **Next.js HTML 404** → "no MCP server was found at the given URL."

Verified against the live server:

| URL | Before |
| --- | --- |
| `POST https://nexus.vasudev.xyz/mcp` | `404` (HTML page) |
| `POST https://nexus.vasudev.xyz/api/mcp` | `401` + `WWW-Authenticate: Bearer …` (working) |

This is the dual-registration hazard (`/mcp` vs `/api/mcp`) that was flagged during the original investigation.

## Change

Add a Next.js rewrite so `/mcp` (and `/mcp/*`) serve the same handler as `/api/mcp`. Both connector URLs now work, eliminating this class of "wrong URL" failure.

Verified against a running dev server: `POST /mcp` now returns the same `401` Bearer challenge as `/api/mcp` instead of a `404`.

## Tests

- Adds a regression test asserting the `/mcp → /api/mcp` rewrite stays configured.
- `npm run lint`, `tsc --noEmit`, and the MCP OAuth test suites all pass.

## Note for the user

This makes the historical `/mcp` connector work, but the recommended connector URL remains `https://nexus.vasudev.xyz/api/mcp`. Completing the "Allow submission access" consent on a fresh connection issues a token carrying `mcp:submissions` (the fix from #150).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjhqCUvgkk3YW9hHURVcxJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjhqCUvgkk3YW9hHURVcxJ)_