### PR TITLE
Add first-class application event timelines

### DIFF
--- a/app/activity/page.tsx
+++ b/app/activity/page.tsx
@@ -1,0 +1,9 @@
+import { redirect } from "next/navigation";
+import { ActivityFeed } from "@/components/activity-feed";
+import { requireAuth } from "@/lib/session";
+
+export default async function ActivityPage() {
+  const session = await requireAuth();
+  if (!session) redirect("/login");
+  return <ActivityFeed user={session.user} />;
+}

--- a/app/api/applications/[id]/__tests__/route.test.ts
+++ b/app/api/applications/[id]/__tests__/route.test.ts
@@ -50,6 +50,47 @@ describe("PATCH /api/applications/:id event-first boundaries", () => {
     expect(mocks.updateApplication).toHaveBeenCalledWith("1", "owner-1", expect.not.objectContaining({ notes: expect.anything() }));
   });
 
+  it("rejects non-string summaries instead of coercing them", async () => {
+    const response = await PATCH(request({ notes: { text: "not a summary" } }), context);
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "notes_invalid" });
+    expect(mocks.updateApplication).not.toHaveBeenCalled();
+  });
+
+  it("reports malformed lifecycle dates as invalid input", async () => {
+    const response = await PATCH(request({ appliedAt: "not-a-date" }), context);
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_lifecycle_date",
+      fields: ["appliedAt"],
+    });
+    expect(mocks.updateApplication).not.toHaveBeenCalled();
+  });
+
+  it("rejects impossible civil lifecycle dates instead of normalizing them", async () => {
+    const response = await PATCH(request({ appliedAt: "2026-02-30" }), context);
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_lifecycle_date",
+      fields: ["appliedAt"],
+    });
+    expect(mocks.updateApplication).not.toHaveBeenCalled();
+  });
+
+  it("accepts an unchanged date-only lifecycle value for a stored timestamp", async () => {
+    mocks.getApplication.mockResolvedValueOnce({
+      ...current,
+      appliedAt: new Date("2026-07-01T12:30:00.000Z"),
+    });
+    const response = await PATCH(request({ company: "Acme 2", appliedAt: "2026-07-01" }), context);
+    expect(response.status).toBe(200);
+    expect(mocks.updateApplication).toHaveBeenCalledWith(
+      "1",
+      "owner-1",
+      expect.not.objectContaining({ appliedAt: expect.anything() }),
+    );
+  });
+
   it("rejects direct lifecycle changes that would bypass immutable history", async () => {
     const response = await PATCH(request({ status: "offer" }), context);
     expect(response.status).toBe(409);

--- a/app/api/applications/[id]/__tests__/route.test.ts
+++ b/app/api/applications/[id]/__tests__/route.test.ts
@@ -1,0 +1,65 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getApplication: vi.fn(),
+  updateApplication: vi.fn(),
+  requireAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({ getDb: () => ({ getApplication: mocks.getApplication, updateApplication: mocks.updateApplication }) }));
+vi.mock("@/lib/session", () => ({ requireAuth: mocks.requireAuth }));
+
+import { PATCH } from "../route";
+
+const current = {
+  id: "1",
+  userId: "owner-1",
+  company: "Acme",
+  role: "Engineer",
+  status: "interview",
+  currentStage: "technical",
+  appliedAt: new Date("2026-07-01T00:00:00.000Z"),
+  lastContact: new Date("2026-07-20T00:00:00.000Z"),
+  followUpAt: new Date("2026-07-30T00:00:00.000Z"),
+  notes: "x".repeat(10_001),
+  updatedAt: new Date("2026-07-24T08:00:00.000Z"),
+};
+
+function request(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/applications/1", {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const context = { params: Promise.resolve({ id: "1" }) };
+
+describe("PATCH /api/applications/:id event-first boundaries", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.requireAuth.mockResolvedValue({ userId: "owner-1" });
+    mocks.getApplication.mockResolvedValue(current);
+    mocks.updateApplication.mockImplementation(async (_id, _userId, update) => ({ ...current, ...update }));
+  });
+
+  it("allows unrelated edits while preserving an unchanged oversized legacy summary", async () => {
+    const response = await PATCH(request({ company: "Acme 2", notes: current.notes }), context);
+    expect(response.status).toBe(200);
+    expect(mocks.updateApplication).toHaveBeenCalledWith("1", "owner-1", expect.not.objectContaining({ notes: expect.anything() }));
+  });
+
+  it("rejects direct lifecycle changes that would bypass immutable history", async () => {
+    const response = await PATCH(request({ status: "offer" }), context);
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({ error: "lifecycle_event_required", fields: ["status"] });
+    expect(mocks.updateApplication).not.toHaveBeenCalled();
+  });
+
+  it("omits unchanged lifecycle fields from the mutable update", async () => {
+    const response = await PATCH(request({ company: "Acme 2", status: "interview", currentStage: "technical" }), context);
+    expect(response.status).toBe(200);
+    expect(mocks.updateApplication).toHaveBeenCalledWith("1", "owner-1", expect.not.objectContaining({ status: expect.anything(), currentStage: expect.anything() }));
+  });
+});

--- a/app/api/applications/[id]/events/__tests__/route.test.ts
+++ b/app/api/applications/[id]/events/__tests__/route.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 
-const { mockRecordApplicationEvent, mockListApplicationEventsFiltered, mockGetApplication, mockRequireAuth } = vi.hoisted(() => ({
+const { mockRecordApplicationEvent, mockListApplicationEvents, mockListApplicationEventsFiltered, mockGetApplication, mockRequireAuth } = vi.hoisted(() => ({
   mockRecordApplicationEvent: vi.fn(),
+  mockListApplicationEvents: vi.fn(),
   mockListApplicationEventsFiltered: vi.fn(),
   mockGetApplication: vi.fn(),
   mockRequireAuth: vi.fn(),
@@ -11,6 +12,7 @@ const { mockRecordApplicationEvent, mockListApplicationEventsFiltered, mockGetAp
 vi.mock("@/lib/db", () => ({
   getDb: () => ({
     recordApplicationEvent: mockRecordApplicationEvent,
+    listApplicationEvents: mockListApplicationEvents,
     listApplicationEventsFiltered: mockListApplicationEventsFiltered,
     getApplication: mockGetApplication,
   }),
@@ -48,9 +50,17 @@ describe("GET /api/applications/:id/events", () => {
     }));
   });
 
+  it("preserves the legacy bare-array response without query parameters", async () => {
+    mockListApplicationEvents.mockResolvedValue([{ id: "event-1" }]);
+    const response = await GET(new NextRequest("http://localhost/api/applications/app-1/events"), params);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual([{ id: "event-1" }]);
+  });
+
   it("sanitizes unexpected query failures", async () => {
     mockListApplicationEventsFiltered.mockRejectedValueOnce(new Error("postgres://secret-internal-detail"));
-    const response = await GET(new NextRequest("http://localhost/api/applications/app-1/events"), params);
+    const response = await GET(new NextRequest("http://localhost/api/applications/app-1/events?limit=20"), params);
     expect(response.status).toBe(500);
     await expect(response.json()).resolves.toEqual({ error: "event_query_failed" });
   });

--- a/app/api/applications/[id]/events/__tests__/route.test.ts
+++ b/app/api/applications/[id]/events/__tests__/route.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockRecordApplicationEvent, mockListApplicationEventsFiltered, mockGetApplication, mockRequireAuth } = vi.hoisted(() => ({
+  mockRecordApplicationEvent: vi.fn(),
+  mockListApplicationEventsFiltered: vi.fn(),
+  mockGetApplication: vi.fn(),
+  mockRequireAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  getDb: () => ({
+    recordApplicationEvent: mockRecordApplicationEvent,
+    listApplicationEventsFiltered: mockListApplicationEventsFiltered,
+    getApplication: mockGetApplication,
+  }),
+}));
+vi.mock("@/lib/session", () => ({ requireAuth: mockRequireAuth }));
+
+import { GET, POST } from "../route";
+
+const params = { params: Promise.resolve({ id: "app-1" }) };
+function request(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/applications/app-1/events", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("GET /api/applications/:id/events", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAuth.mockResolvedValue({ userId: "user-1", user: { email: "owner@example.com" } });
+    mockGetApplication.mockResolvedValue({ id: "app-1" });
+  });
+
+  it("returns an owner-scoped cursor page in the requested order", async () => {
+    mockListApplicationEventsFiltered.mockResolvedValue({ items: [{ id: "event-1" }], nextCursor: "next" });
+    const response = await GET(new NextRequest("http://localhost/api/applications/app-1/events?limit=20&order=oldest&cursor=eyJ2ZXJzaW9uIjoxLCJvY2N1cnJlZEF0IjoiMjAyNi0wNy0yNFQwOTowMDowMC4wMDBaIiwiaWQiOiIxIn0"), params);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ items: [{ id: "event-1" }], nextCursor: "next" });
+    expect(mockListApplicationEventsFiltered).toHaveBeenCalledWith("user-1", expect.objectContaining({
+      applicationId: "app-1",
+      order: "oldest",
+      limit: 20,
+      cursor: { version: 1, occurredAt: "2026-07-24T09:00:00.000Z", id: "1" },
+    }));
+  });
+
+  it("returns 404 without querying events when the application is not owned", async () => {
+    mockGetApplication.mockResolvedValue(null);
+    const response = await GET(new NextRequest("http://localhost/api/applications/app-1/events"), params);
+    expect(response.status).toBe(404);
+    expect(mockListApplicationEventsFiltered).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/applications/:id/events", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAuth.mockResolvedValue({ userId: "user-1", user: { email: "owner@example.com" } });
+  });
+
+  it("rejects unknown event types before persistence", async () => {
+    const response = await POST(request({ type: "anything_goes" }), params);
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "event_type_invalid" });
+    expect(mockRecordApplicationEvent).not.toHaveBeenCalled();
+  });
+
+  it("routes submission events through the atomic submission workflow", async () => {
+    const response = await POST(request({ type: "application_submitted" }), params);
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "submission_event_requires_submission_workflow" });
+    expect(mockRecordApplicationEvent).not.toHaveBeenCalled();
+  });
+
+  it("requires a stable occurrence time for idempotent commands", async () => {
+    const response = await POST(request({ type: "stage_changed", idempotencyKey: "stable-key", metadata: { toStage: "screen" } }), params);
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "occurred_at_required_for_idempotency" });
+  });
+
+  it("normalizes and records a canonical command with REST provenance", async () => {
+    mockRecordApplicationEvent.mockResolvedValue({
+      event: { id: "event-1" },
+      application: { id: "app-1", updatedAt: new Date("2026-07-24T10:00:00Z") },
+      replayed: false,
+    });
+    const response = await POST(request({
+      type: "interview_scheduled",
+      occurredAt: "2026-07-24T09:00:00Z",
+      idempotencyKey: "schedule-key",
+      expectedUpdatedAt: "2026-07-23T09:00:00Z",
+      metadata: { interviewType: "technical", scheduledAt: "2026-07-28T12:30:00Z" },
+    }), params);
+    expect(response.status).toBe(201);
+    expect(mockRecordApplicationEvent).toHaveBeenCalledWith("app-1", "user-1", expect.objectContaining({
+      type: "interview_scheduled",
+      source: "rest",
+      actor: "owner@example.com",
+      contactId: null,
+      outcome: null,
+      metadata: expect.objectContaining({ scheduledAt: "2026-07-28T12:30:00.000Z" }),
+    }));
+  });
+
+  it("marks idempotent replay responses", async () => {
+    mockRecordApplicationEvent.mockResolvedValue({ event: { id: "event-1" }, application: { id: "app-1" }, replayed: true });
+    const response = await POST(request({
+      type: "stage_changed",
+      occurredAt: "2026-07-24T09:00:00Z",
+      idempotencyKey: "stage-key",
+      metadata: { toStage: "screen" },
+    }), params);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("X-Idempotent-Replay")).toBe("true");
+  });
+
+  it("maps stale projections and idempotency conflicts to 409", async () => {
+    mockRecordApplicationEvent.mockRejectedValue(new Error("conflict"));
+    const response = await POST(request({ type: "application_rejected", occurredAt: "2026-07-24T09:00:00Z" }), params);
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({ error: "conflict" });
+  });
+});

--- a/app/api/applications/[id]/events/__tests__/route.test.ts
+++ b/app/api/applications/[id]/events/__tests__/route.test.ts
@@ -48,6 +48,13 @@ describe("GET /api/applications/:id/events", () => {
     }));
   });
 
+  it("sanitizes unexpected query failures", async () => {
+    mockListApplicationEventsFiltered.mockRejectedValueOnce(new Error("postgres://secret-internal-detail"));
+    const response = await GET(new NextRequest("http://localhost/api/applications/app-1/events"), params);
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ error: "event_query_failed" });
+  });
+
   it("returns 404 without querying events when the application is not owned", async () => {
     mockGetApplication.mockResolvedValue(null);
     const response = await GET(new NextRequest("http://localhost/api/applications/app-1/events"), params);
@@ -116,6 +123,17 @@ describe("POST /api/applications/:id/events", () => {
     }), params);
     expect(response.status).toBe(200);
     expect(response.headers.get("X-Idempotent-Replay")).toBe("true");
+  });
+
+  it("sanitizes unexpected write failures", async () => {
+    mockRecordApplicationEvent.mockRejectedValueOnce(new Error("postgres://secret-internal-detail"));
+    const response = await POST(request({
+      type: "stage_changed",
+      occurredAt: "2026-07-24T09:00:00Z",
+      metadata: { toStage: "screen" },
+    }), params);
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ error: "event_failed" });
   });
 
   it("maps stale projections and idempotency conflicts to 409", async () => {

--- a/app/api/applications/[id]/events/route.ts
+++ b/app/api/applications/[id]/events/route.ts
@@ -35,7 +35,11 @@ export async function GET(
     return NextResponse.json({ error: "event_query_invalid" }, { status: 400 });
   }
   try {
-    return NextResponse.json(await db.listApplicationEventsFiltered(auth.userId, filter));
+    if (!request.nextUrl.searchParams.size) {
+      return NextResponse.json(await db.listApplicationEvents(id, auth.userId));
+    }
+    const page = await db.listApplicationEventsFiltered(auth.userId, filter);
+    return NextResponse.json(page);
   } catch {
     return NextResponse.json({ error: "event_query_failed" }, { status: 500 });
   }

--- a/app/api/applications/[id]/events/route.ts
+++ b/app/api/applications/[id]/events/route.ts
@@ -3,6 +3,17 @@ import { getDb } from "@/lib/db";
 import { requireAuth } from "@/lib/session";
 import { parseApplicationEventCommand, parseEventQuery } from "@/lib/applications/events";
 
+const WRITE_ERROR_CODES = new Set([
+  "not_found",
+  "conflict",
+  "idempotency_conflict",
+  "application_deleting",
+  "contact_not_found",
+  "document_not_found",
+  "submission_not_found",
+  "verification_failed",
+]);
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
@@ -17,12 +28,16 @@ export async function GET(
   const values: Record<string, unknown> = Object.fromEntries(request.nextUrl.searchParams.entries());
   const allTypes = request.nextUrl.searchParams.getAll("type");
   if (allTypes.length) values.types = allTypes;
+  let filter;
   try {
-    const filter = parseEventQuery({ ...values, applicationId: id });
+    filter = parseEventQuery({ ...values, applicationId: id });
+  } catch {
+    return NextResponse.json({ error: "event_query_invalid" }, { status: 400 });
+  }
+  try {
     return NextResponse.json(await db.listApplicationEventsFiltered(auth.userId, filter));
-  } catch (error) {
-    const code = error instanceof Error ? error.message : "event_query_invalid";
-    return NextResponse.json({ error: code }, { status: 400 });
+  } catch {
+    return NextResponse.json({ error: "event_query_failed" }, { status: 500 });
   }
 }
 
@@ -68,12 +83,15 @@ export async function POST(
       headers: result.replayed ? { "X-Idempotent-Replay": "true" } : undefined,
     });
   } catch (error) {
-    const code = error instanceof Error ? error.message : "event_failed";
+    const rawCode = error instanceof Error ? error.message : "";
+    const code = WRITE_ERROR_CODES.has(rawCode) ? rawCode : "event_failed";
     const status = code === "not_found"
       ? 404
-      : code === "conflict" || code.includes("idempotency") || code === "application_deleting"
+      : code === "conflict" || code === "idempotency_conflict" || code === "application_deleting"
         ? 409
-        : 400;
+        : code === "event_failed" || code === "verification_failed"
+          ? 500
+          : 400;
     return NextResponse.json({ error: code }, { status });
   }
 }

--- a/app/api/applications/[id]/events/route.ts
+++ b/app/api/applications/[id]/events/route.ts
@@ -1,10 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import { requireAuth } from "@/lib/session";
-import {
-  requireOccurredAtForIdempotency,
-  validateEventMetadata,
-} from "@/lib/applications/submission";
+import { parseApplicationEventCommand, parseEventQuery } from "@/lib/applications/events";
 
 export async function GET(
   request: NextRequest,
@@ -13,12 +10,19 @@ export async function GET(
   const auth = await requireAuth();
   if (!auth) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   const { id } = await params;
-  const rawLimit = Number(request.nextUrl.searchParams.get("limit") ?? 100);
-  const limit = Number.isInteger(rawLimit) ? Math.max(1, Math.min(500, rawLimit)) : 100;
+  const db = getDb();
+  const application = await db.getApplication(id, auth.userId);
+  if (!application) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const values: Record<string, unknown> = Object.fromEntries(request.nextUrl.searchParams.entries());
+  const allTypes = request.nextUrl.searchParams.getAll("type");
+  if (allTypes.length) values.types = allTypes;
   try {
-    return NextResponse.json(await getDb().listApplicationEvents(id, auth.userId, limit));
-  } catch {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+    const filter = parseEventQuery({ ...values, applicationId: id });
+    return NextResponse.json(await db.listApplicationEventsFiltered(auth.userId, filter));
+  } catch (error) {
+    const code = error instanceof Error ? error.message : "event_query_invalid";
+    return NextResponse.json({ error: code }, { status: 400 });
   }
 }
 
@@ -35,39 +39,41 @@ export async function POST(
   } catch {
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
-  const type = String(body.type ?? "").trim().slice(0, 100);
-  if (!type) return NextResponse.json({ error: "type is required" }, { status: 400 });
-  const occurredAt = body.occurredAt ? new Date(String(body.occurredAt)) : new Date();
-  if (Number.isNaN(occurredAt.getTime())) {
-    return NextResponse.json({ error: "occurredAt must be a valid ISO timestamp" }, { status: 400 });
-  }
-  const idempotencyKey = body.idempotencyKey == null
-    ? undefined
-    : String(body.idempotencyKey).trim();
-  if (idempotencyKey && (idempotencyKey.length < 8 || idempotencyKey.length > 128)) {
-    return NextResponse.json({ error: "idempotencyKey must contain 8-128 characters" }, { status: 400 });
-  }
+  let command;
   try {
-    requireOccurredAtForIdempotency(idempotencyKey, body.occurredAt as string | undefined);
+    command = parseApplicationEventCommand({
+      type: body.type,
+      occurredAt: body.occurredAt,
+      idempotencyKey: body.idempotencyKey,
+      expectedUpdatedAt: body.expectedUpdatedAt,
+      metadata: body.metadata,
+      source: "rest",
+      actor: auth.user.email,
+    });
   } catch (error) {
+    const code = error instanceof Error ? error.message : "event_invalid";
+    return NextResponse.json({ error: code }, { status: 400 });
+  }
+  if (command.type === "application_submitted") {
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : "invalid_idempotent_event" },
+      { error: "submission_event_requires_submission_workflow" },
       { status: 400 },
     );
   }
+
   try {
-    const event = await getDb().createApplicationEvent(id, auth.userId, {
-      type,
-      occurredAt,
-      source: "rest",
-      actor: auth.user.email,
-      idempotencyKey,
-      metadata: validateEventMetadata(body.metadata),
+    const result = await getDb().recordApplicationEvent(id, auth.userId, command);
+    return NextResponse.json(result, {
+      status: result.replayed ? 200 : 201,
+      headers: result.replayed ? { "X-Idempotent-Replay": "true" } : undefined,
     });
-    return NextResponse.json(event, { status: 201 });
   } catch (error) {
     const code = error instanceof Error ? error.message : "event_failed";
-    const status = code === "not_found" ? 404 : code.includes("idempotency") ? 409 : 400;
+    const status = code === "not_found"
+      ? 404
+      : code === "conflict" || code.includes("idempotency") || code === "application_deleting"
+        ? 409
+        : 400;
     return NextResponse.json({ error: code }, { status });
   }
 }

--- a/app/api/applications/[id]/route.ts
+++ b/app/api/applications/[id]/route.ts
@@ -3,6 +3,7 @@ import { getDb } from "@/lib/db";
 import { requireAuth } from "@/lib/session";
 import { normalizeStatus, normalizeSource, COMPANY_SIZE_OPTIONS, INCOMING_SOURCE_OPTIONS } from "@/types";
 import { parseStructuredApplicationMetadata } from "@/lib/applications/metadata";
+import { validateApplicationSummary } from "@/lib/applications/events";
 
 const VALID_COMPANY_SIZES = COMPANY_SIZE_OPTIONS.map((o) => o.value) as string[];
 const VALID_INCOMING_SOURCES = INCOMING_SOURCE_OPTIONS as readonly string[];
@@ -46,6 +47,9 @@ export async function PATCH(
   }
 
   const { id } = await params;
+  const db = getDb();
+  const current = await db.getApplication(id, auth.userId);
+  if (!current) return NextResponse.json({ error: "not_found" }, { status: 404 });
   const body = await request.json();
   const { company, role, status, appliedAt, lastContact, followUpAt, notes, jobDescription, source, remote, salaryMin, salaryMax, rating, jobUrl, resumeId, archivedAt, companySize, salaryBandMentioned, triageQuality, triageReason, incomingSource, autoRejected, autoRejectReason } = body;
 
@@ -69,7 +73,11 @@ export async function PATCH(
   }
 
   let structuredMetadata;
+  let validatedNotes: string | null | undefined;
+  const rawNotes = notes === undefined ? undefined : notes === null || notes === "" ? null : String(notes);
+  const notesChanged = notes !== undefined && rawNotes !== current.notes;
   try {
+    validatedNotes = notesChanged ? validateApplicationSummary(rawNotes) : undefined;
     structuredMetadata = parseStructuredApplicationMetadata(body as Record<string, unknown>);
   } catch (error) {
     return NextResponse.json(
@@ -86,21 +94,29 @@ export async function PATCH(
     }
   }
 
+  const sameDate = (raw: unknown, existing: Date | null) => {
+    const next = raw === null || raw === "" ? null : new Date(String(raw));
+    return next === null ? existing === null : !Number.isNaN(next.getTime()) && next.getTime() === existing?.getTime();
+  };
+  const lifecycleFields: string[] = [];
+  if (status !== undefined && normalizeStatus(status) !== current.status) lifecycleFields.push("status");
+  if (appliedAt !== undefined && !sameDate(appliedAt, current.appliedAt)) lifecycleFields.push("appliedAt");
+  if (lastContact !== undefined && !sameDate(lastContact, current.lastContact)) lifecycleFields.push("lastContact");
+  if (followUpAt !== undefined && !sameDate(followUpAt, current.followUpAt)) lifecycleFields.push("followUpAt");
+  if (structuredMetadata.currentStage !== undefined && structuredMetadata.currentStage !== current.currentStage) {
+    lifecycleFields.push("currentStage");
+  }
+  if (lifecycleFields.length) {
+    return NextResponse.json({ error: "lifecycle_event_required", fields: lifecycleFields }, { status: 409 });
+  }
+  const nonLifecycleMetadata = { ...structuredMetadata };
+  delete nonLifecycleMetadata.currentStage;
+
   try {
-    const application = await getDb().updateApplication(id, auth.userId, {
+    const application = await db.updateApplication(id, auth.userId, {
     ...(company !== undefined && { company: String(company).slice(0, 255) }),
     ...(role !== undefined && { role: String(role).slice(0, 255) }),
-    ...(status !== undefined && { status: normalizeStatus(status) }),
-    ...(appliedAt !== undefined && {
-      appliedAt: appliedAt ? new Date(appliedAt) : null,
-    }),
-    ...(lastContact !== undefined && {
-      lastContact: lastContact ? new Date(lastContact) : null,
-    }),
-    ...(followUpAt !== undefined && {
-      followUpAt: followUpAt ? new Date(followUpAt) : null,
-    }),
-    ...(notes !== undefined && { notes: notes ? String(notes).slice(0, 10000) : null }),
+    ...(notesChanged && { notes: validatedNotes }),
     ...(jobDescription !== undefined && {
       jobDescription: jobDescription ? String(jobDescription).slice(0, 50000) : null,
     }),
@@ -139,7 +155,7 @@ export async function PATCH(
     ...(archivedAt !== undefined && {
       archivedAt: archivedAt ? new Date(archivedAt) : null,
     }),
-    ...structuredMetadata,
+    ...nonLifecycleMetadata,
     ...(expectedUpdatedAt !== undefined && {
       expectedUpdatedAt,
     }),

--- a/app/api/applications/[id]/route.ts
+++ b/app/api/applications/[id]/route.ts
@@ -4,6 +4,7 @@ import { requireAuth } from "@/lib/session";
 import { normalizeStatus, normalizeSource, COMPANY_SIZE_OPTIONS, INCOMING_SOURCE_OPTIONS } from "@/types";
 import { parseStructuredApplicationMetadata } from "@/lib/applications/metadata";
 import { validateApplicationSummary } from "@/lib/applications/events";
+import { parseLocalCalendarDate } from "@/lib/applications/local-calendar";
 
 const VALID_COMPANY_SIZES = COMPANY_SIZE_OPTIONS.map((o) => o.value) as string[];
 const VALID_INCOMING_SOURCES = INCOMING_SOURCE_OPTIONS as readonly string[];
@@ -74,7 +75,7 @@ export async function PATCH(
 
   let structuredMetadata;
   let validatedNotes: string | null | undefined;
-  const rawNotes = notes === undefined ? undefined : notes === null || notes === "" ? null : String(notes);
+  const rawNotes: unknown = notes === undefined ? undefined : notes === null || notes === "" ? null : notes;
   const notesChanged = notes !== undefined && rawNotes !== current.notes;
   try {
     validatedNotes = notesChanged ? validateApplicationSummary(rawNotes) : undefined;
@@ -94,10 +95,29 @@ export async function PATCH(
     }
   }
 
-  const sameDate = (raw: unknown, existing: Date | null) => {
-    const next = raw === null || raw === "" ? null : new Date(String(raw));
-    return next === null ? existing === null : !Number.isNaN(next.getTime()) && next.getTime() === existing?.getTime();
+  const parseLifecycleDate = (raw: unknown): Date | null | "invalid" => {
+    if (raw === null || raw === "") return null;
+    if (typeof raw !== "string") return "invalid";
+    return parseLocalCalendarDate(raw) ?? "invalid";
   };
+  const sameDate = (raw: unknown, existing: Date | null) => {
+    const next = parseLifecycleDate(raw);
+    if (next === "invalid") return false;
+    if (next === null) return existing === null;
+    if (next.getTime() === existing?.getTime()) return true;
+    return /^\d{4}-\d{2}-\d{2}$/.test(raw as string)
+      && raw === existing?.toISOString().slice(0, 10);
+  };
+  const lifecycleDates = { appliedAt, lastContact, followUpAt };
+  const invalidLifecycleFields = Object.entries(lifecycleDates)
+    .filter(([, raw]) => raw !== undefined && parseLifecycleDate(raw) === "invalid")
+    .map(([field]) => field);
+  if (invalidLifecycleFields.length) {
+    return NextResponse.json(
+      { error: "invalid_lifecycle_date", fields: invalidLifecycleFields },
+      { status: 400 },
+    );
+  }
   const lifecycleFields: string[] = [];
   if (status !== undefined && normalizeStatus(status) !== current.status) lifecycleFields.push("status");
   if (appliedAt !== undefined && !sameDate(appliedAt, current.appliedAt)) lifecycleFields.push("appliedAt");

--- a/app/api/applications/route.ts
+++ b/app/api/applications/route.ts
@@ -4,6 +4,7 @@ import { requireAuth } from "@/lib/session";
 import { normalizeStatus, normalizeSource, COMPANY_SIZE_OPTIONS, INCOMING_SOURCE_OPTIONS } from "@/types";
 import { resolveAppliedAtForCreate } from "@/lib/applications/defaults";
 import { parseStructuredApplicationMetadata } from "@/lib/applications/metadata";
+import { validateApplicationSummary } from "@/lib/applications/events";
 
 const VALID_COMPANY_SIZES = COMPANY_SIZE_OPTIONS.map((o) => o.value) as string[];
 const VALID_INCOMING_SOURCES = INCOMING_SOURCE_OPTIONS as readonly string[];
@@ -84,7 +85,9 @@ export async function POST(request: NextRequest) {
   }
 
   let structuredMetadata;
+  let validatedNotes: string | null;
   try {
+    validatedNotes = validateApplicationSummary(notes);
     structuredMetadata = parseStructuredApplicationMetadata(body as Record<string, unknown>);
   } catch (error) {
     return NextResponse.json(
@@ -101,7 +104,7 @@ export async function POST(request: NextRequest) {
       appliedAt: resolveAppliedAtForCreate(status || "inbound", appliedAt),
       lastContact: lastContact ? new Date(lastContact) : null,
       followUpAt: followUpAt ? new Date(followUpAt) : null,
-      notes: notes ? String(notes).slice(0, 10000) : null,
+      notes: validatedNotes,
       jobDescription: jobDescription ? String(jobDescription).slice(0, 50000) : null,
       source: normalizeSource(source),
       remote: !!remote,

--- a/app/api/email/scanned/route.ts
+++ b/app/api/email/scanned/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/session";
 import { prisma } from "@/lib/prisma";
 import { normalizeStatus } from "@/types";
+import { recordEmailLifecycleTransition } from "@/lib/email/application-events";
 
 /**
  * GET /api/email/scanned — list scanned emails for the current user
@@ -120,9 +121,13 @@ export async function PATCH(req: NextRequest): Promise<NextResponse> {
       const currentRank = statusOrder[existing.status] ?? -1;
       const isProgression = status === "rejected" || (newRank > currentRank && currentRank >= 0);
       if (isProgression && existing.status !== "rejected") {
-        await prisma.application.update({
-          where: { id: existing.id },
-          data: { status, eventVersion: { increment: 1 } },
+        await recordEmailLifecycleTransition({
+          applicationId: existing.id,
+          userId: auth.userId,
+          status,
+          occurredAt: email.receivedAt,
+          scannedEmailId: email.id,
+          expectedUpdatedAt: existing.updatedAt,
         });
       }
     } else {

--- a/app/api/email/scanned/route.ts
+++ b/app/api/email/scanned/route.ts
@@ -122,7 +122,7 @@ export async function PATCH(req: NextRequest): Promise<NextResponse> {
       if (isProgression && existing.status !== "rejected") {
         await prisma.application.update({
           where: { id: existing.id },
-          data: { status },
+          data: { status, eventVersion: { increment: 1 } },
         });
       }
     } else {

--- a/app/api/email/scanned/route.ts
+++ b/app/api/email/scanned/route.ts
@@ -2,7 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/session";
 import { prisma } from "@/lib/prisma";
 import { normalizeStatus } from "@/types";
-import { recordEmailLifecycleTransition } from "@/lib/email/application-events";
+import {
+  createEmailApplicationWithLifecycle,
+  recordEmailLifecycleTransition,
+} from "@/lib/email/application-events";
 
 /**
  * GET /api/email/scanned — list scanned emails for the current user
@@ -131,17 +134,14 @@ export async function PATCH(req: NextRequest): Promise<NextResponse> {
         });
       }
     } else {
-      const app = await prisma.application.create({
-        data: {
-          userId: auth.userId,
-          company,
-          role,
-          status,
-          source: "email",
-          appliedAt: email.receivedAt,
-        },
+      appId = await createEmailApplicationWithLifecycle({
+        userId: auth.userId,
+        company,
+        role,
+        status,
+        occurredAt: email.receivedAt,
+        scannedEmailId: email.id,
       });
-      appId = app.id;
     }
 
     await prisma.scannedEmail.update({

--- a/app/api/events/__tests__/route.test.ts
+++ b/app/api/events/__tests__/route.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockListApplicationEventsFiltered, mockRequireAuth } = vi.hoisted(() => ({
+  mockListApplicationEventsFiltered: vi.fn(),
+  mockRequireAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  getDb: () => ({ listApplicationEventsFiltered: mockListApplicationEventsFiltered }),
+}));
+vi.mock("@/lib/session", () => ({ requireAuth: mockRequireAuth }));
+
+import { GET } from "../route";
+
+describe("GET /api/events", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAuth.mockResolvedValue({ userId: "user-1", user: { email: "owner@example.com" } });
+    mockListApplicationEventsFiltered.mockResolvedValue({ items: [], nextCursor: null });
+  });
+
+  it("parses owner-scoped activity filters and pagination", async () => {
+    const response = await GET(new NextRequest("http://localhost/api/events?company=Acme&type=stage_changed&type=interview_scheduled&occurredAfter=2026-07-01T00%3A00%3A00Z&source=mcp&limit=25"));
+    expect(response.status).toBe(200);
+    expect(mockListApplicationEventsFiltered).toHaveBeenCalledWith("user-1", expect.objectContaining({
+      company: "Acme",
+      types: ["stage_changed", "interview_scheduled"],
+      source: "mcp",
+      order: "newest",
+      limit: 25,
+    }));
+  });
+
+  it("rejects malformed filters without querying storage", async () => {
+    const response = await GET(new NextRequest("http://localhost/api/events?type=not-real"));
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "event_query_invalid" });
+    expect(mockListApplicationEventsFiltered).not.toHaveBeenCalled();
+  });
+
+  it("requires authentication", async () => {
+    mockRequireAuth.mockResolvedValue(null);
+    const response = await GET(new NextRequest("http://localhost/api/events"));
+    expect(response.status).toBe(401);
+  });
+});

--- a/app/api/events/__tests__/route.test.ts
+++ b/app/api/events/__tests__/route.test.ts
@@ -1,13 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
-const { mockListApplicationEventsFiltered, mockRequireAuth } = vi.hoisted(() => ({
+const { mockGetApplication, mockListApplicationEventsFiltered, mockRequireAuth } = vi.hoisted(() => ({
+  mockGetApplication: vi.fn(),
   mockListApplicationEventsFiltered: vi.fn(),
   mockRequireAuth: vi.fn(),
 }));
 
 vi.mock("@/lib/db", () => ({
-  getDb: () => ({ listApplicationEventsFiltered: mockListApplicationEventsFiltered }),
+  getDb: () => ({
+    getApplication: mockGetApplication,
+    listApplicationEventsFiltered: mockListApplicationEventsFiltered,
+  }),
 }));
 vi.mock("@/lib/session", () => ({ requireAuth: mockRequireAuth }));
 
@@ -16,7 +20,12 @@ import { GET } from "../route";
 describe("GET /api/events", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockRequireAuth.mockResolvedValue({ userId: "user-1", user: { email: "owner@example.com" } });
+    mockRequireAuth.mockResolvedValue({
+      userId: "user-1",
+      readScopeUserId: "user-1",
+      user: { email: "owner@example.com" },
+    });
+    mockGetApplication.mockResolvedValue({ id: "app-1", userId: "user-1" });
     mockListApplicationEventsFiltered.mockResolvedValue({ items: [], nextCursor: null });
   });
 
@@ -30,6 +39,33 @@ describe("GET /api/events", () => {
       order: "newest",
       limit: 25,
     }));
+  });
+
+  it("uses the selected application's owner for admin timeline reads", async () => {
+    mockRequireAuth.mockResolvedValue({
+      userId: "admin-1",
+      readScopeUserId: null,
+      user: { email: "admin@example.com", isAdmin: true },
+    });
+    mockGetApplication.mockResolvedValue({ id: "app-2", userId: "owner-2" });
+
+    const response = await GET(new NextRequest("http://localhost/api/events?applicationId=app-2"));
+
+    expect(response.status).toBe(200);
+    expect(mockGetApplication).toHaveBeenCalledWith("app-2", null);
+    expect(mockListApplicationEventsFiltered).toHaveBeenCalledWith(
+      "owner-2",
+      expect.objectContaining({ applicationId: "app-2" }),
+    );
+  });
+
+  it("does not query events when the application is outside the read scope", async () => {
+    mockGetApplication.mockResolvedValue(null);
+
+    const response = await GET(new NextRequest("http://localhost/api/events?applicationId=app-2"));
+
+    expect(response.status).toBe(404);
+    expect(mockListApplicationEventsFiltered).not.toHaveBeenCalled();
   });
 
   it("rejects malformed filters without querying storage", async () => {

--- a/app/api/events/__tests__/route.test.ts
+++ b/app/api/events/__tests__/route.test.ts
@@ -39,6 +39,13 @@ describe("GET /api/events", () => {
     expect(mockListApplicationEventsFiltered).not.toHaveBeenCalled();
   });
 
+  it("sanitizes unexpected storage failures", async () => {
+    mockListApplicationEventsFiltered.mockRejectedValueOnce(new Error("postgres://secret-internal-detail"));
+    const response = await GET(new NextRequest("http://localhost/api/events"));
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ error: "event_query_failed" });
+  });
+
   it("requires authentication", async () => {
     mockRequireAuth.mockResolvedValue(null);
     const response = await GET(new NextRequest("http://localhost/api/events"));

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -17,7 +17,14 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: "event_query_invalid" }, { status: 400 });
   }
   try {
-    return NextResponse.json(await getDb().listApplicationEventsFiltered(auth.userId, filter));
+    const db = getDb();
+    let ownerUserId = auth.userId;
+    if (filter.applicationId) {
+      const application = await db.getApplication(filter.applicationId, auth.readScopeUserId);
+      if (!application) return NextResponse.json({ error: "Not found" }, { status: 404 });
+      ownerUserId = application.userId;
+    }
+    return NextResponse.json(await db.listApplicationEventsFiltered(ownerUserId, filter));
   } catch {
     return NextResponse.json({ error: "event_query_failed" }, { status: 500 });
   }

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { parseEventQuery } from "@/lib/applications/events";
+import { getDb } from "@/lib/db";
+import { requireAuth } from "@/lib/session";
+
+export async function GET(request: NextRequest) {
+  const auth = await requireAuth();
+  if (!auth) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const values: Record<string, unknown> = Object.fromEntries(request.nextUrl.searchParams.entries());
+  const allTypes = request.nextUrl.searchParams.getAll("type");
+  if (allTypes.length) values.types = allTypes;
+  try {
+    const filter = parseEventQuery(values);
+    return NextResponse.json(await getDb().listApplicationEventsFiltered(auth.userId, filter));
+  } catch (error) {
+    const code = error instanceof Error ? error.message : "event_query_invalid";
+    return NextResponse.json({ error: code }, { status: 400 });
+  }
+}

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -10,11 +10,15 @@ export async function GET(request: NextRequest) {
   const values: Record<string, unknown> = Object.fromEntries(request.nextUrl.searchParams.entries());
   const allTypes = request.nextUrl.searchParams.getAll("type");
   if (allTypes.length) values.types = allTypes;
+  let filter;
   try {
-    const filter = parseEventQuery(values);
+    filter = parseEventQuery(values);
+  } catch {
+    return NextResponse.json({ error: "event_query_invalid" }, { status: 400 });
+  }
+  try {
     return NextResponse.json(await getDb().listApplicationEventsFiltered(auth.userId, filter));
-  } catch (error) {
-    const code = error instanceof Error ? error.message : "event_query_invalid";
-    return NextResponse.json({ error: code }, { status: 400 });
+  } catch {
+    return NextResponse.json({ error: "event_query_failed" }, { status: 500 });
   }
 }

--- a/app/api/mcp/__tests__/events.test.ts
+++ b/app/api/mcp/__tests__/events.test.ts
@@ -117,6 +117,26 @@ describe("MCP application event contracts", () => {
     expect(mocks.updateApplication).not.toHaveBeenCalled();
   });
 
+  it("does not let duplicate-safe upserts bypass stage events", async () => {
+    mocks.findApplicationByCanonicalJobUrl.mockResolvedValue({
+      id: "app-1",
+      status: "inbound",
+      currentStage: "sourced",
+    });
+    const result = await client.callTool({
+      name: "upsert_application_by_job_url",
+      arguments: {
+        company: "Acme",
+        role: "Engineer",
+        jobUrl: "https://example.com/jobs/1",
+        currentStage: "screening",
+      },
+    });
+    expect(result.isError).toBe(true);
+    expect(text(result)).toMatchObject({ error: { code: "lifecycle_event_required" } });
+    expect(mocks.updateApplication).not.toHaveBeenCalled();
+  });
+
   it("rejects lifecycle changes through update_application", async () => {
     const result = await client.callTool({
       name: "update_application",
@@ -132,7 +152,9 @@ describe("MCP application event contracts", () => {
       arguments: { applicationId: "app-1", type: "application_submitted" },
     });
     expect(result.isError).toBe(true);
-    expect(textValue(result)).toContain("Input validation error");
+    expect(text(result)).toMatchObject({
+      error: { code: "submission_event_requires_submission_workflow" },
+    });
     expect(mocks.recordApplicationEvent).not.toHaveBeenCalled();
   });
 });

--- a/app/api/mcp/__tests__/events.test.ts
+++ b/app/api/mcp/__tests__/events.test.ts
@@ -6,6 +6,8 @@ const mocks = vi.hoisted(() => ({
   recordApplicationEvent: vi.fn(),
   listApplicationEventsFiltered: vi.fn(),
   getApplication: vi.fn(),
+  findApplicationByCanonicalJobUrl: vi.fn(),
+  updateApplication: vi.fn(),
 }));
 
 vi.mock("@/lib/db", () => ({
@@ -13,6 +15,8 @@ vi.mock("@/lib/db", () => ({
     recordApplicationEvent: mocks.recordApplicationEvent,
     listApplicationEventsFiltered: mocks.listApplicationEventsFiltered,
     getApplication: mocks.getApplication,
+    findApplicationByCanonicalJobUrl: mocks.findApplicationByCanonicalJobUrl,
+    updateApplication: mocks.updateApplication,
   }),
 }));
 vi.mock("@/lib/prisma", () => ({ prisma: {} }));
@@ -23,19 +27,19 @@ vi.mock("@/lib/documents/service", () => ({ deleteDocumentWithContent: vi.fn() }
 
 import { createMcpServer } from "../route";
 
-const auth = {
+const auth = (scopes = ["mcp:tools"]) => ({
   userId: "owner-1",
   readScopeUserId: "owner-1",
   user: { id: "owner-1", name: "Owner", email: "owner@example.com", image: null, isAdmin: false },
   authType: "mcp_oauth" as const,
-  scopes: ["mcp:tools"],
-};
+  scopes,
+});
 
 let client: Client;
 let server: ReturnType<typeof createMcpServer>;
 
-async function connect() {
-  server = createMcpServer(auth);
+async function connect(scopes?: string[]) {
+  server = createMcpServer(auth(scopes));
   client = new Client({ name: "event-contract-test", version: "1.0.0" });
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
@@ -95,6 +99,22 @@ describe("MCP application event contracts", () => {
     expect(mocks.listApplicationEventsFiltered).toHaveBeenCalledWith("owner-1", expect.objectContaining({
       applicationId: "app-1", order: "oldest", limit: 20,
     }));
+  });
+
+  it("does not let duplicate-safe upserts bypass lifecycle events", async () => {
+    mocks.findApplicationByCanonicalJobUrl.mockResolvedValue({ id: "app-1", status: "inbound" });
+    const result = await client.callTool({
+      name: "upsert_application_by_job_url",
+      arguments: {
+        company: "Acme",
+        role: "Engineer",
+        jobUrl: "https://example.com/jobs/1",
+        status: "offer",
+      },
+    });
+    expect(result.isError).toBe(true);
+    expect(text(result)).toMatchObject({ error: { code: "lifecycle_event_required" } });
+    expect(mocks.updateApplication).not.toHaveBeenCalled();
   });
 
   it("rejects lifecycle changes through update_application", async () => {

--- a/app/api/mcp/__tests__/events.test.ts
+++ b/app/api/mcp/__tests__/events.test.ts
@@ -1,0 +1,118 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  recordApplicationEvent: vi.fn(),
+  listApplicationEventsFiltered: vi.fn(),
+  getApplication: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  getDb: () => ({
+    recordApplicationEvent: mocks.recordApplicationEvent,
+    listApplicationEventsFiltered: mocks.listApplicationEventsFiltered,
+    getApplication: mocks.getApplication,
+  }),
+}));
+vi.mock("@/lib/prisma", () => ({ prisma: {} }));
+vi.mock("@/lib/cv/generate", () => ({ generateAndStoreCv: vi.fn() }));
+vi.mock("@/lib/documents/download", () => ({ downloadDocumentContent: vi.fn() }));
+vi.mock("@/lib/documents/upload", () => ({ uploadDocumentContent: vi.fn(), MAX_DOCUMENT_BASE64_SIZE: 1_000_000 }));
+vi.mock("@/lib/documents/service", () => ({ deleteDocumentWithContent: vi.fn() }));
+
+import { createMcpServer } from "../route";
+
+const auth = {
+  userId: "owner-1",
+  readScopeUserId: "owner-1",
+  user: { id: "owner-1", name: "Owner", email: "owner@example.com", image: null, isAdmin: false },
+  authType: "mcp_oauth" as const,
+  scopes: ["mcp:tools"],
+};
+
+let client: Client;
+let server: ReturnType<typeof createMcpServer>;
+
+async function connect() {
+  server = createMcpServer(auth);
+  client = new Client({ name: "event-contract-test", version: "1.0.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+}
+
+function textValue(result: Awaited<ReturnType<Client["callTool"]>>) {
+  const content = (result as { content: Array<{ type: string; text?: string }> }).content;
+  const item = content[0];
+  if (item?.type !== "text" || typeof item.text !== "string") throw new Error("expected text content");
+  return item.text;
+}
+
+function text(result: Awaited<ReturnType<Client["callTool"]>>) {
+  return JSON.parse(textValue(result)) as Record<string, unknown>;
+}
+
+describe("MCP application event contracts", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await connect();
+  });
+
+  afterEach(async () => {
+    await client.close();
+    await server.close();
+  });
+
+  it("records a typed event with MCP provenance and controlled replay output", async () => {
+    mocks.recordApplicationEvent.mockResolvedValue({ event: { id: "event-1" }, application: { id: "app-1" }, replayed: false });
+    const result = await client.callTool({
+      name: "record_application_event",
+      arguments: {
+        applicationId: "app-1",
+        type: "stage_changed",
+        occurredAt: "2026-07-24T09:00:00.000Z",
+        idempotencyKey: "stage-key",
+        metadata: { toStage: "technical" },
+      },
+    });
+    expect(result.isError).not.toBe(true);
+    expect(text(result)).toMatchObject({ event: { id: "event-1" }, replayed: false });
+    expect(mocks.recordApplicationEvent).toHaveBeenCalledWith("app-1", "owner-1", expect.objectContaining({
+      type: "stage_changed",
+      source: "mcp",
+      actor: "owner@example.com",
+    }));
+  });
+
+  it("lists an owner-scoped cursor page in deterministic order", async () => {
+    mocks.getApplication.mockResolvedValue({ id: "app-1" });
+    mocks.listApplicationEventsFiltered.mockResolvedValue({ items: [{ id: "event-1" }], nextCursor: null });
+    const result = await client.callTool({
+      name: "list_application_events",
+      arguments: { applicationId: "app-1", order: "oldest", limit: 20 },
+    });
+    expect(text(result)).toEqual({ items: [{ id: "event-1" }], nextCursor: null });
+    expect(mocks.listApplicationEventsFiltered).toHaveBeenCalledWith("owner-1", expect.objectContaining({
+      applicationId: "app-1", order: "oldest", limit: 20,
+    }));
+  });
+
+  it("rejects lifecycle changes through update_application", async () => {
+    const result = await client.callTool({
+      name: "update_application",
+      arguments: { id: "app-1", status: "offer" },
+    });
+    expect(result.isError).toBe(true);
+    expect(text(result)).toMatchObject({ error: { code: "lifecycle_event_required", fields: ["status"] } });
+  });
+
+  it("does not expose the workflow-reserved submission event through the generic tool", async () => {
+    const result = await client.callTool({
+      name: "record_application_event",
+      arguments: { applicationId: "app-1", type: "application_submitted" },
+    });
+    expect(result.isError).toBe(true);
+    expect(textValue(result)).toContain("Input validation error");
+    expect(mocks.recordApplicationEvent).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -15,7 +15,6 @@ import {
 import { parseStructuredApplicationMetadata } from "@/lib/applications/metadata";
 import {
   APPLICATION_EVENT_TYPES,
-  RECORDABLE_APPLICATION_EVENT_TYPES,
   parseApplicationEventCommand,
   parseEventQuery,
 } from "@/lib/applications/events";
@@ -103,6 +102,7 @@ const EVENT_ERROR_CODES = new Set([
   "submission_not_found",
   "verification_failed",
   "event_query_invalid",
+  "submission_event_requires_submission_workflow",
 ]);
 
 function controlledErrorCode(error: unknown, allowed: Set<string>, fallback: string): string {
@@ -521,7 +521,7 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
     "Atomically append a canonical immutable application event and update the current-state projection when the event changes lifecycle state.",
     {
       applicationId: z.string().min(1),
-      type: z.enum(RECORDABLE_APPLICATION_EVENT_TYPES),
+      type: z.enum(APPLICATION_EVENT_TYPES),
       idempotencyKey: z.string().min(8).max(128).optional(),
       occurredAt: z.string().datetime().optional(),
       expectedUpdatedAt: z.string().datetime().optional(),
@@ -664,10 +664,18 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
         const db = getDb();
         const existing = await db.findApplicationByCanonicalJobUrl(auth.userId, canonicalJobUrl);
         const metadata = parseStructuredApplicationMetadata(args as unknown as Record<string, unknown>);
-        const updateExisting = (application: { id: string; status: string }) => {
+        const assertNoLifecycleUpdate = (application: { status: string; currentStage?: string | null }) => {
           if (args.status !== undefined && args.status !== application.status) {
             throw new Error("lifecycle_event_required");
           }
+          if (metadata.currentStage !== undefined && metadata.currentStage !== application.currentStage) {
+            throw new Error("lifecycle_event_required");
+          }
+        };
+        const updateExisting = (application: { id: string; status: string; currentStage?: string | null }) => {
+          assertNoLifecycleUpdate(application);
+          const mutableMetadata = { ...metadata };
+          delete mutableMetadata.currentStage;
           return db.updateApplication(application.id, auth.userId, {
             company: args.company,
             role: args.role,
@@ -681,10 +689,11 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
             ...(args.resumeId !== undefined && { resumeId: args.resumeId }),
             jobUrl: args.jobUrl,
             canonicalJobUrl,
-            ...metadata,
+            ...mutableMetadata,
           });
         };
         if (args.dryRun) {
+          if (existing) assertNoLifecycleUpdate(existing);
           return {
             content: [{
               type: "text",

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -10,11 +10,15 @@ import { resolveAppliedAtForCreate } from "@/lib/applications/defaults";
 import {
   canonicalizeJobUrl,
   computeApplicationHealth,
-  requireOccurredAtForIdempotency,
-  validateEventMetadata,
   validateSubmissionAnswers,
 } from "@/lib/applications/submission";
 import { parseStructuredApplicationMetadata } from "@/lib/applications/metadata";
+import {
+  APPLICATION_EVENT_TYPES,
+  RECORDABLE_APPLICATION_EVENT_TYPES,
+  parseApplicationEventCommand,
+  parseEventQuery,
+} from "@/lib/applications/events";
 import { submissionPolicyTransportSchema } from "@/lib/applications/submission-transport";
 import { verifyMcpAccessToken } from "@/lib/mcp-oauth";
 import { generateAndStoreCv } from "@/lib/cv/generate";
@@ -82,6 +86,22 @@ const SUBMISSION_ERROR_CODES = new Set([
   "verification_failed",
 ]);
 
+const EVENT_ERROR_CODES = new Set([
+  "event_type_invalid",
+  "event_metadata_invalid",
+  "event_metadata_too_large",
+  "event_occurred_at_invalid",
+  "occurred_at_required_for_idempotency",
+  "idempotency_key_invalid",
+  "idempotency_conflict",
+  "invalid_expected_updated_at",
+  "not_found",
+  "conflict",
+  "application_deleting",
+  "verification_failed",
+  "event_query_invalid",
+]);
+
 function controlledErrorCode(error: unknown, allowed: Set<string>, fallback: string): string {
   if (!(error instanceof Error)) return fallback;
   return allowed.has(error.message) ? error.message : fallback;
@@ -136,7 +156,7 @@ async function authenticateFromRequest(
 
 // ── MCP server factory ──────────────────────────────────────────────────────
 
-function createMcpServer(auth: SessionAuthResult): McpServer {
+export function createMcpServer(auth: SessionAuthResult): McpServer {
   const server = new McpServer(
     { name: "nexus-crm", version: "1.0.0" },
     {
@@ -203,7 +223,7 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
         .describe("Date applied (ISO 8601)"),
       lastContact: z.string().datetime().nullable().optional().describe("Last contact timestamp"),
       followUpAt: z.string().datetime().nullable().optional().describe("Follow-up timestamp"),
-      notes: z.string().optional().describe("Free-text notes"),
+      notes: z.string().max(10_000).optional().describe("Compact current-state summary"),
       jobDescription: z
         .string()
         .optional()
@@ -226,7 +246,7 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
         appliedAt: resolveAppliedAtForCreate(args.status || "inbound", args.appliedAt),
         lastContact: args.lastContact ? new Date(args.lastContact) : null,
         followUpAt: args.followUpAt ? new Date(args.followUpAt) : null,
-        notes: args.notes?.slice(0, 10000) ?? null,
+        notes: args.notes ?? null,
         jobDescription: args.jobDescription?.slice(0, 50000) ?? null,
         source: args.source?.slice(0, 100) ?? null,
         remote: args.remote ?? false,
@@ -245,7 +265,7 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
 
   server.tool(
     "update_application",
-    "Update an existing application. Supports linking a Reactive Resume via resumeId.",
+    "Update non-lifecycle application fields. Use record_application_event for status, stage, contact, follow-up, and submission changes.",
     {
       id: z.string().describe("Application ID"),
       company: z.string().optional().describe("Company name"),
@@ -257,7 +277,7 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
       appliedAt: z.string().nullable().optional().describe("Date applied (ISO 8601)"),
       lastContact: z.string().nullable().optional().describe("Last contact date"),
       followUpAt: z.string().nullable().optional().describe("Follow-up date"),
-      notes: z.string().nullable().optional().describe("Free-text notes"),
+      notes: z.string().max(10_000).nullable().optional().describe("Compact current-state summary"),
       jobDescription: z.string().nullable().optional().describe("Job description"),
       source: z.string().nullable().optional().describe("Source"),
       remote: z.boolean().optional().describe("Remote position?"),
@@ -271,6 +291,14 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
       ...structuredApplicationToolFields,
     },
     async ({ id, ...data }) => {
+      const lifecycleFields = ["status", "appliedAt", "lastContact", "followUpAt", "currentStage"]
+        .filter((field) => (data as Record<string, unknown>)[field] !== undefined);
+      if (lifecycleFields.length) {
+        return {
+          content: [{ type: "text", text: JSON.stringify({ error: { code: "lifecycle_event_required", fields: lifecycleFields } }) }],
+          isError: true,
+        };
+      }
       try {
         const update: Record<string, unknown> = {};
         if (data.company !== undefined) update.company = data.company.slice(0, 255);
@@ -282,7 +310,7 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
           update.lastContact = data.lastContact ? new Date(data.lastContact) : null;
         if (data.followUpAt !== undefined)
           update.followUpAt = data.followUpAt ? new Date(data.followUpAt) : null;
-        if (data.notes !== undefined) update.notes = data.notes?.slice(0, 10000) ?? null;
+        if (data.notes !== undefined) update.notes = data.notes ?? null;
         if (data.jobDescription !== undefined)
           update.jobDescription = data.jobDescription?.slice(0, 50000) ?? null;
         if (data.source !== undefined) update.source = data.source?.slice(0, 100) ?? null;
@@ -453,7 +481,7 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
 
   server.tool(
     "append_application_note",
-    "Append a note without a read-modify-write race and add an immutable note_added timeline event.",
+    "Record an immutable note_added timeline event without changing the compact application summary.",
     {
       applicationId: z.string().min(1),
       note: z.string().trim().min(1).max(5000),
@@ -463,19 +491,19 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
     },
     async (args) => {
       try {
-        const result = await getDb().appendApplicationNote(
+        const command = parseApplicationEventCommand({
+          type: "note_added",
+          idempotencyKey: args.idempotencyKey,
+          expectedUpdatedAt: args.expectedUpdatedAt,
+          occurredAt: args.occurredAt,
+          source: "mcp",
+          actor: auth.user.email,
+          metadata: { note: args.note },
+        });
+        const result = await getDb().recordApplicationEvent(
           args.applicationId,
           auth.userId,
-          args.note,
-          {
-            type: "note_added",
-            idempotencyKey: args.idempotencyKey,
-            expectedUpdatedAt: args.expectedUpdatedAt ? new Date(args.expectedUpdatedAt) : undefined,
-            occurredAt: new Date(args.occurredAt),
-            source: "mcp",
-            actor: auth.user.email,
-            metadata: {},
-          },
+          command,
         );
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       } catch (error) {
@@ -487,29 +515,30 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
 
   server.tool(
     "record_application_event",
-    "Append an immutable owner-scoped application timeline event.",
+    "Atomically append a canonical immutable application event and update the current-state projection when the event changes lifecycle state.",
     {
       applicationId: z.string().min(1),
-      type: z.string().trim().min(1).max(100),
+      type: z.enum(RECORDABLE_APPLICATION_EVENT_TYPES),
       idempotencyKey: z.string().min(8).max(128).optional(),
       occurredAt: z.string().datetime().optional(),
-      metadata: z.record(z.union([z.string(), z.number(), z.boolean(), z.null()])).optional(),
+      expectedUpdatedAt: z.string().datetime().optional(),
+      metadata: z.record(z.unknown()).optional(),
     },
     async (args) => {
-      if (args.type === "application_submitted" && !canAccessSubmissions) return submissionScopeError();
       try {
-        requireOccurredAtForIdempotency(args.idempotencyKey, args.occurredAt);
-        const event = await getDb().createApplicationEvent(args.applicationId, auth.userId, {
+        const command = parseApplicationEventCommand({
           type: args.type,
           idempotencyKey: args.idempotencyKey,
-          occurredAt: args.occurredAt ? new Date(args.occurredAt) : new Date(),
+          occurredAt: args.occurredAt,
+          expectedUpdatedAt: args.expectedUpdatedAt,
           source: "mcp",
           actor: auth.user.email,
-          metadata: validateEventMetadata(args.metadata),
+          metadata: args.metadata,
         });
-        return { content: [{ type: "text", text: JSON.stringify(event, null, 2) }] };
+        const result = await getDb().recordApplicationEvent(args.applicationId, auth.userId, command);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       } catch (error) {
-        const code = error instanceof Error ? error.message : "event_failed";
+        const code = controlledErrorCode(error, EVENT_ERROR_CODES, "event_failed");
         return { content: [{ type: "text", text: JSON.stringify({ error: { code } }) }], isError: true };
       }
     },
@@ -517,18 +546,53 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
 
   server.tool(
     "list_application_events",
-    "List immutable timeline events for an application, newest first.",
+    "List an owner-scoped immutable application timeline with deterministic cursor pagination.",
     {
       applicationId: z.string().min(1),
-      limit: z.number().int().min(1).max(500).default(100),
+      cursor: z.string().optional(),
+      order: z.enum(["newest", "oldest"]).default("newest"),
+      limit: z.number().int().min(1).max(100).default(50),
     },
-    async ({ applicationId, limit }) => {
-      if (!canAccessSubmissions) return submissionScopeError();
+    async ({ applicationId, cursor, order, limit }) => {
       try {
-        const events = await getDb().listApplicationEvents(applicationId, auth.userId, limit);
-        return { content: [{ type: "text", text: JSON.stringify(events, null, 2) }] };
-      } catch {
-        return { content: [{ type: "text", text: "Application not found or access denied" }], isError: true };
+        const db = getDb();
+        const application = await db.getApplication(applicationId, auth.userId);
+        if (!application) throw new Error("not_found");
+        const filter = parseEventQuery({ applicationId, cursor, order, limit });
+        const page = await db.listApplicationEventsFiltered(auth.userId, filter);
+        return { content: [{ type: "text", text: JSON.stringify(page, null, 2) }] };
+      } catch (error) {
+        const code = controlledErrorCode(error, EVENT_ERROR_CODES, "event_query_failed");
+        return { content: [{ type: "text", text: JSON.stringify({ error: { code } }) }], isError: true };
+      }
+    },
+  );
+
+  server.tool(
+    "list_application_activity",
+    "List the authenticated owner's application activity across all applications with canonical filters and deterministic cursor pagination.",
+    {
+      applicationId: z.string().min(1).optional(),
+      company: z.string().max(255).optional(),
+      types: z.array(z.enum(APPLICATION_EVENT_TYPES)).max(APPLICATION_EVENT_TYPES.length).optional(),
+      occurredAfter: z.string().datetime().optional(),
+      occurredBefore: z.string().datetime().optional(),
+      source: z.string().max(255).optional(),
+      actor: z.string().max(255).optional(),
+      contactId: z.string().max(255).optional(),
+      outcome: z.string().max(255).optional(),
+      cursor: z.string().optional(),
+      order: z.enum(["newest", "oldest"]).default("newest"),
+      limit: z.number().int().min(1).max(100).default(50),
+    },
+    async (args) => {
+      try {
+        const filter = parseEventQuery(args);
+        const page = await getDb().listApplicationEventsFiltered(auth.userId, filter);
+        return { content: [{ type: "text", text: JSON.stringify(page, null, 2) }] };
+      } catch (error) {
+        const code = controlledErrorCode(error, EVENT_ERROR_CODES, "event_query_failed");
+        return { content: [{ type: "text", text: JSON.stringify({ error: { code } }) }], isError: true };
       }
     },
   );
@@ -717,7 +781,7 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
             appliedAt: z.string().nullable().optional().describe("Date applied (ISO 8601)"),
             lastContact: z.string().nullable().optional().describe("Last contact date"),
             followUpAt: z.string().nullable().optional().describe("Follow-up date"),
-            notes: z.string().nullable().optional().describe("Free-text notes"),
+            notes: z.string().max(10_000).nullable().optional().describe("Compact current-state summary"),
             jobDescription: z.string().nullable().optional().describe("Job description"),
             source: z.string().nullable().optional().describe("Source"),
             remote: z.boolean().optional().describe("Remote position?"),
@@ -743,7 +807,7 @@ function createMcpServer(auth: SessionAuthResult): McpServer {
           appliedAt: item.appliedAt !== undefined ? (item.appliedAt ? new Date(item.appliedAt) : null) : undefined,
           lastContact: item.lastContact !== undefined ? (item.lastContact ? new Date(item.lastContact) : null) : undefined,
           followUpAt: item.followUpAt !== undefined ? (item.followUpAt ? new Date(item.followUpAt) : null) : undefined,
-          notes: item.notes !== undefined ? (item.notes?.slice(0, 10000) ?? null) : undefined,
+          notes: item.notes !== undefined ? (item.notes ?? null) : undefined,
           jobDescription: item.jobDescription !== undefined ? (item.jobDescription?.slice(0, 50000) ?? null) : undefined,
           source: item.source !== undefined ? (item.source?.slice(0, 100) ?? null) : undefined,
           remote: item.remote,

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -98,6 +98,9 @@ const EVENT_ERROR_CODES = new Set([
   "not_found",
   "conflict",
   "application_deleting",
+  "contact_not_found",
+  "document_not_found",
+  "submission_not_found",
   "verification_failed",
   "event_query_invalid",
 ]);
@@ -507,7 +510,7 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
         );
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       } catch (error) {
-        const code = error instanceof Error ? error.message : "append_failed";
+        const code = controlledErrorCode(error, EVENT_ERROR_CODES, "append_failed");
         return { content: [{ type: "text", text: JSON.stringify({ error: { code } }) }], isError: true };
       }
     },
@@ -661,22 +664,26 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
         const db = getDb();
         const existing = await db.findApplicationByCanonicalJobUrl(auth.userId, canonicalJobUrl);
         const metadata = parseStructuredApplicationMetadata(args as unknown as Record<string, unknown>);
-        const updateExisting = (applicationId: string) => db.updateApplication(applicationId, auth.userId, {
-          company: args.company,
-          role: args.role,
-          ...(args.status !== undefined && { status: args.status }),
-          ...(args.notes !== undefined && { notes: args.notes }),
-          ...(args.jobDescription !== undefined && { jobDescription: args.jobDescription }),
-          ...(args.source !== undefined && { source: args.source }),
-          ...(args.remote !== undefined && { remote: args.remote }),
-          ...(args.salaryMin !== undefined && { salaryMin: args.salaryMin }),
-          ...(args.salaryMax !== undefined && { salaryMax: args.salaryMax }),
-          ...(args.rating !== undefined && { rating: args.rating }),
-          ...(args.resumeId !== undefined && { resumeId: args.resumeId }),
-          jobUrl: args.jobUrl,
-          canonicalJobUrl,
-          ...metadata,
-        });
+        const updateExisting = (application: { id: string; status: string }) => {
+          if (args.status !== undefined && args.status !== application.status) {
+            throw new Error("lifecycle_event_required");
+          }
+          return db.updateApplication(application.id, auth.userId, {
+            company: args.company,
+            role: args.role,
+            ...(args.notes !== undefined && { notes: args.notes }),
+            ...(args.jobDescription !== undefined && { jobDescription: args.jobDescription }),
+            ...(args.source !== undefined && { source: args.source }),
+            ...(args.remote !== undefined && { remote: args.remote }),
+            ...(args.salaryMin !== undefined && { salaryMin: args.salaryMin }),
+            ...(args.salaryMax !== undefined && { salaryMax: args.salaryMax }),
+            ...(args.rating !== undefined && { rating: args.rating }),
+            ...(args.resumeId !== undefined && { resumeId: args.resumeId }),
+            jobUrl: args.jobUrl,
+            canonicalJobUrl,
+            ...metadata,
+          });
+        };
         if (args.dryRun) {
           return {
             content: [{
@@ -691,7 +698,7 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
           };
         }
         if (existing) {
-          const application = await updateExisting(existing.id);
+          const application = await updateExisting(existing);
           return { content: [{ type: "text", text: JSON.stringify({ operation: "updated", application }, null, 2) }] };
         }
         const status = args.status ?? "inbound";
@@ -722,7 +729,7 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
           if (code !== "canonical_job_url_conflict") throw error;
           const concurrent = await db.findApplicationByCanonicalJobUrl(auth.userId, canonicalJobUrl);
           if (!concurrent) throw error;
-          application = await updateExisting(concurrent.id);
+          application = await updateExisting(concurrent);
           operation = "updated";
         }
         return { content: [{ type: "text", text: JSON.stringify({ operation, application }, null, 2) }] };

--- a/components/__tests__/activity-feed.test.tsx
+++ b/components/__tests__/activity-feed.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import messages from "../../messages/en.json";
+
+vi.mock("../app-header", () => ({ AppHeader: () => <header>Header</header> }));
+
+import { ActivityFeed } from "../activity-feed";
+
+const user = { id: "owner", email: "owner@example.com", name: "Owner", image: null, isAdmin: false };
+
+function renderFeed() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <QueryClientProvider client={queryClient}><ActivityFeed user={user} /></QueryClientProvider>
+    </NextIntlClientProvider>,
+  );
+}
+
+function event(id: string, company: string) {
+  return {
+    id,
+    applicationId: id,
+    type: "stage_changed",
+    occurredAt: "2026-07-24T09:00:00.000Z",
+    source: "rest",
+    actor: "owner@example.com",
+    contactId: null,
+    outcome: null,
+    metadata: { toStage: "technical" },
+    application: { id, company, role: "Engineer" },
+  };
+}
+
+describe("ActivityFeed", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("filters, links, and incrementally loads owner activity", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ items: [event("1", "Acme")], nextCursor: "next" }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ items: [event("2", "Beta")], nextCursor: null }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ items: [event("3", "Filtered Co")], nextCursor: null }), { status: 200 }));
+    const userEventApi = userEvent.setup();
+    renderFeed();
+
+    const acme = await screen.findByRole("link", { name: /Acme — Engineer/ });
+    expect(acme.getAttribute("href")).toBe("/applications/1");
+    await userEventApi.click(screen.getByRole("button", { name: "Load more" }));
+    expect(await screen.findByText("Beta — Engineer")).toBeTruthy();
+
+    await userEventApi.type(screen.getByLabelText("Company"), "Filtered Co");
+    await userEventApi.selectOptions(screen.getByLabelText("Order"), "oldest");
+    await userEventApi.click(screen.getByRole("button", { name: "Apply filters" }));
+    expect(await screen.findByText("Filtered Co — Engineer")).toBeTruthy();
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+    expect(String(fetchMock.mock.calls[2][0])).toContain("company=Filtered+Co");
+    expect(String(fetchMock.mock.calls[2][0])).toContain("order=oldest");
+  });
+
+  it("shows an empty state without implying history was deleted", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(JSON.stringify({ items: [], nextCursor: null }), { status: 200 }));
+    renderFeed();
+    expect(await screen.findByText("No events match these filters. Your history has not been deleted.")).toBeTruthy();
+  });
+
+  it("shows a controlled localized error state", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(JSON.stringify({ error: "internal details" }), { status: 500 }));
+    renderFeed();
+    expect((await screen.findByRole("alert")).textContent).toBe("Could not load activity.");
+  });
+});

--- a/components/__tests__/application-timeline.test.tsx
+++ b/components/__tests__/application-timeline.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import messages from "../../messages/en.json";
+import { ApplicationTimeline } from "../application-timeline";
+
+function renderTimeline(onProjectionUpdated = vi.fn()) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <QueryClientProvider client={queryClient}>
+        <ApplicationTimeline
+          applicationId="42"
+          expectedUpdatedAt="2026-07-24T08:00:00.000Z"
+          onProjectionUpdated={onProjectionUpdated}
+        />
+      </QueryClientProvider>
+    </NextIntlClientProvider>,
+  );
+  return onProjectionUpdated;
+}
+
+describe("ApplicationTimeline", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders immutable history without leaking internal request hashes", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      items: [{
+        id: "event-1",
+        applicationId: "42",
+        type: "stage_changed",
+        occurredAt: "2026-07-24T09:00:00.000Z",
+        source: "mcp",
+        actor: "owner@example.com",
+        metadata: { fromStage: "screen", toStage: "technical", requestHash: "secret" },
+      }],
+      nextCursor: null,
+    }), { status: 200 }));
+
+    renderTimeline();
+    expect(await screen.findByText("Stage changed")).toBeTruthy();
+    expect(screen.getByText("Previous stage: screen")).toBeTruthy();
+    expect(screen.queryByText(/secret/)).toBeNull();
+  });
+
+  it("loads more pages and switches deterministic order", async () => {
+    const pageEvent = (id: string, type: string) => ({
+      id, applicationId: "42", type,
+      occurredAt: "2026-07-24T09:00:00.000Z",
+      createdAt: "2026-07-24T09:00:01.000Z",
+      source: "rest", actor: null, contactId: null, outcome: null, metadata: {},
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ items: [pageEvent("1", "stage_changed")], nextCursor: "next" }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ items: [pageEvent("2", "feedback_received")], nextCursor: null }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ items: [pageEvent("3", "offer_received")], nextCursor: null }), { status: 200 }));
+    const user = userEvent.setup();
+    renderTimeline();
+    await screen.findByText("Stage changed");
+    await user.click(screen.getByRole("button", { name: "Load more" }));
+    expect(await screen.findByText("Feedback received")).toBeTruthy();
+    await user.selectOptions(screen.getByLabelText("Timeline order"), "oldest");
+    expect(await screen.findByText("Offer received")).toBeTruthy();
+    expect(String(fetchMock.mock.calls[1][0])).toContain("cursor=next");
+    expect(String(fetchMock.mock.calls[2][0])).toContain("order=oldest");
+  });
+
+  it("records a typed event with an optimistic precondition", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ items: [], nextCursor: null }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ application: { updatedAt: "2026-07-24T09:01:00.000Z" } }), { status: 201 }))
+      .mockResolvedValue(new Response(JSON.stringify({ items: [], nextCursor: null }), { status: 200 }));
+    const onProjectionUpdated = renderTimeline();
+    const user = userEvent.setup();
+
+    await screen.findByText(/No timeline events yet/);
+    await user.click(screen.getByRole("button", { name: "Record activity" }));
+    await user.type(screen.getByLabelText("New stage"), "technical_interview");
+    fireEvent.submit(screen.getByRole("button", { name: "Record event" }).closest("form")!);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+    const [, request] = fetchMock.mock.calls[1];
+    const body = JSON.parse(String((request as RequestInit).body));
+    expect(body).toMatchObject({
+      type: "stage_changed",
+      expectedUpdatedAt: "2026-07-24T08:00:00.000Z",
+      metadata: { toStage: "technical_interview" },
+    });
+    expect(body.idempotencyKey).toMatch(/^ui-/);
+    expect(onProjectionUpdated).toHaveBeenCalledWith("2026-07-24T09:01:00.000Z");
+  });
+});

--- a/components/__tests__/application-timeline.test.tsx
+++ b/components/__tests__/application-timeline.test.tsx
@@ -49,6 +49,38 @@ describe("ApplicationTimeline", () => {
     expect(screen.queryByText(/secret/)).toBeNull();
   });
 
+  it("uses safe fallbacks, an explicit metadata allowlist, and exact entity targets", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      items: [{
+        id: "event-future",
+        applicationId: "42",
+        type: "future_private_event",
+        occurredAt: "2026-07-24T09:00:00.000Z",
+        createdAt: "2026-07-24T09:00:01.000Z",
+        source: "rest",
+        actor: null,
+        contactId: "contact-1",
+        outcome: null,
+        metadata: {
+          note: "Visible note",
+          privatePolicyBlob: "must-not-render",
+          documentId: "document-1",
+          submissionId: "submission-1",
+        },
+      }],
+      nextCursor: null,
+    }), { status: 200 }));
+
+    renderTimeline();
+    expect(await screen.findByText("Unknown event (future_private_event)")).toBeTruthy();
+    expect(screen.getByText("Timeline note: Visible note")).toBeTruthy();
+    expect(screen.queryByText(/must-not-render/)).toBeNull();
+    expect(screen.getByRole("link", { name: "Contact contact-1" }).getAttribute("href")).toBe("#contact-contact-1");
+    expect(screen.getByRole("link", { name: "Document document-1" }).getAttribute("href")).toBe("/documents#document-document-1");
+    expect(screen.queryByRole("link", { name: "Submission submission-1" })).toBeNull();
+    expect(screen.getByText("Submission submission-1")).toBeTruthy();
+  });
+
   it("loads more pages and switches deterministic order", async () => {
     const pageEvent = (id: string, type: string) => ({
       id, applicationId: "42", type,

--- a/components/__tests__/application-timeline.test.tsx
+++ b/components/__tests__/application-timeline.test.tsx
@@ -8,20 +8,25 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import messages from "../../messages/en.json";
 import { ApplicationTimeline } from "../application-timeline";
 
-function renderTimeline(onProjectionUpdated = vi.fn()) {
+function renderTimeline(onProjectionUpdated = vi.fn(), disabled = false) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
-  render(
+  const view = (isDisabled: boolean) => (
     <NextIntlClientProvider locale="en" messages={messages}>
       <QueryClientProvider client={queryClient}>
         <ApplicationTimeline
           applicationId="42"
           expectedUpdatedAt="2026-07-24T08:00:00.000Z"
+          disabled={isDisabled}
           onProjectionUpdated={onProjectionUpdated}
         />
       </QueryClientProvider>
-    </NextIntlClientProvider>,
+    </NextIntlClientProvider>
   );
-  return onProjectionUpdated;
+  const result = render(view(disabled));
+  return {
+    onProjectionUpdated,
+    rerenderWithDisabled: (isDisabled: boolean) => result.rerender(view(isDisabled)),
+  };
 }
 
 describe("ApplicationTimeline", () => {
@@ -108,7 +113,7 @@ describe("ApplicationTimeline", () => {
       .mockResolvedValueOnce(new Response(JSON.stringify({ items: [], nextCursor: null }), { status: 200 }))
       .mockResolvedValueOnce(new Response(JSON.stringify({ application: { updatedAt: "2026-07-24T09:01:00.000Z" } }), { status: 201 }))
       .mockResolvedValue(new Response(JSON.stringify({ items: [], nextCursor: null }), { status: 200 }));
-    const onProjectionUpdated = renderTimeline();
+    const { onProjectionUpdated } = renderTimeline();
     const user = userEvent.setup();
 
     await screen.findByText(/No timeline events yet/);
@@ -126,5 +131,22 @@ describe("ApplicationTimeline", () => {
     });
     expect(body.idempotencyKey).toMatch(/^ui-/);
     expect(onProjectionUpdated).toHaveBeenCalledWith("2026-07-24T09:01:00.000Z");
+  });
+
+  it("does not submit an open event editor after parent edits become dirty", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ items: [], nextCursor: null }), { status: 200 }),
+    );
+    const user = userEvent.setup();
+    const { rerenderWithDisabled } = renderTimeline();
+    await screen.findByText(/No timeline events yet/);
+    await user.click(screen.getByRole("button", { name: "Record activity" }));
+    await user.type(screen.getByLabelText("New stage"), "technical_interview");
+
+    rerenderWithDisabled(true);
+    fireEvent.submit(screen.getByRole("button", { name: "Record event" }).closest("form")!);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(fetchMock.mock.calls.filter(([, init]) => (init as RequestInit | undefined)?.method === "POST")).toHaveLength(0);
   });
 });

--- a/components/__tests__/dashboard-selection-scope.test.tsx
+++ b/components/__tests__/dashboard-selection-scope.test.tsx
@@ -228,9 +228,18 @@ function renderDashboard(initialApplications: Application[]) {
           headers: { "Content-Type": "application/json" },
         });
       }
-      const id = String(input).split("/").pop() ?? "";
+      const parts = String(input).split("/");
+      const isEventCommand = init.method === "POST" && parts.at(-1) === "events";
+      const id = (isEventCommand ? parts.at(-2) : parts.at(-1)) ?? "";
       const body = init.body ? JSON.parse(String(init.body)) : {};
       const current = initialApplications.find((item) => item.id === id);
+      if (isEventCommand) {
+        const status = body.type === "offer_received" ? "offer" : body.metadata?.toStatus ?? current?.status;
+        return new Response(JSON.stringify({ application: { ...current, status } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
       return new Response(JSON.stringify({ ...current, ...body }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
@@ -334,9 +343,9 @@ describe("Dashboard dataset-scoped selection", () => {
     {
       action: "bulk-status",
       isTargetCall: (init?: RequestInit) =>
-        init?.method === "PATCH" &&
+        init?.method === "POST" &&
         Boolean(init.body) &&
-        JSON.parse(String(init.body)).status === "offer",
+        JSON.parse(String(init.body)).type === "offer_received",
     },
     {
       action: "bulk-archive",
@@ -375,7 +384,10 @@ describe("Dashboard dataset-scoped selection", () => {
       await waitFor(() => {
         const targetIds = fetchMock.mock.calls
           .filter(([, init]) => isTargetCall(init))
-          .map(([input]) => String(input).split("/").pop())
+          .map(([input]) => {
+            const parts = String(input).split("/");
+            return parts.at(-1) === "events" ? parts.at(-2) : parts.at(-1);
+          })
           .sort();
         expect(targetIds).toEqual(["active-applied", "active-interview"]);
       });

--- a/components/__tests__/dashboard-selection-scope.test.tsx
+++ b/components/__tests__/dashboard-selection-scope.test.tsx
@@ -234,7 +234,11 @@ function renderDashboard(initialApplications: Application[]) {
       const body = init.body ? JSON.parse(String(init.body)) : {};
       const current = initialApplications.find((item) => item.id === id);
       if (isEventCommand) {
-        const status = body.type === "offer_received" ? "offer" : body.metadata?.toStatus ?? current?.status;
+        const status = body.type === "offer_received"
+          ? "offer"
+          : body.type === "application_rejected"
+            ? "rejected"
+            : body.metadata?.toStatus ?? current?.status;
         return new Response(JSON.stringify({ application: { ...current, status } }), {
           status: 200,
           headers: { "Content-Type": "application/json" },

--- a/components/__tests__/dashboard-status-mutation.test.tsx
+++ b/components/__tests__/dashboard-status-mutation.test.tsx
@@ -146,12 +146,12 @@ describe("Dashboard status mutation coordinator", () => {
   it("serializes a newer bulk same-record intent behind an older per-record write and rolls back to the last confirmation", async () => {
     const firstResponse = deferred<Response>();
     const secondResponse = deferred<Response>();
-    const patchBodies: Array<{ status: ApplicationStatus }> = [];
+    const eventBodies: Array<{ type: string; metadata: { toStatus: ApplicationStatus } }> = [];
     let serverStatus: ApplicationStatus = "inbound";
 
     const fetchMock = vi.fn(
       async (_input: RequestInfo | URL, init?: RequestInit) => {
-        if (init?.method !== "PATCH") {
+        if (init?.method !== "POST") {
           return new Response(JSON.stringify([application(serverStatus)]), {
             status: 200,
             headers: { "Content-Type": "application/json" },
@@ -159,13 +159,14 @@ describe("Dashboard status mutation coordinator", () => {
         }
 
         const body = JSON.parse(init.body as string) as {
-          status: ApplicationStatus;
+          type: string;
+          metadata: { toStatus: ApplicationStatus };
         };
-        patchBodies.push(body);
-        const response = await (patchBodies.length === 1
+        eventBodies.push(body);
+        const response = await (eventBodies.length === 1
           ? firstResponse.promise
           : secondResponse.promise);
-        if (response.ok) serverStatus = body.status;
+        if (response.ok) serverStatus = body.metadata.toStatus;
         return response;
       },
     );
@@ -193,27 +194,27 @@ describe("Dashboard status mutation coordinator", () => {
 
     await screen.findByText("cache-status-inbound");
     await user.click(screen.getByRole("button", { name: "per-record status" }));
-    await waitFor(() => expect(patchBodies).toEqual([{ status: "applied" }]));
+    await waitFor(() => expect(eventBodies.map((body) => body.metadata.toStatus)).toEqual(["applied"]));
 
     await user.click(screen.getByRole("button", { name: "select record" }));
     await user.click(screen.getByRole("button", { name: "bulk status" }));
 
     await screen.findByText("cache-status-interview");
-    expect(patchBodies).toEqual([{ status: "applied" }]);
+    expect(eventBodies.map((body) => body.metadata.toStatus)).toEqual(["applied"]);
     expect(screen.getByText("selected-1")).toBeTruthy();
 
     await act(async () => {
       firstResponse.resolve(
-        new Response(JSON.stringify(application("applied")), {
+        new Response(JSON.stringify({ application: application("applied") }), {
           status: 200,
           headers: { "Content-Type": "application/json" },
         }),
       );
     });
     await waitFor(() =>
-      expect(patchBodies).toEqual([
-        { status: "applied" },
-        { status: "interview" },
+      expect(eventBodies.map((body) => body.metadata.toStatus)).toEqual([
+        "applied",
+        "interview",
       ]),
     );
 
@@ -233,7 +234,7 @@ describe("Dashboard status mutation coordinator", () => {
         ?.find((item) => item.id === "application-1")?.status,
     ).toBe("applied");
     expect(
-      fetchMock.mock.calls.filter(([, init]) => init?.method === "PATCH"),
+      fetchMock.mock.calls.filter(([, init]) => init?.method === "POST"),
     ).toHaveLength(2);
   });
 });

--- a/components/__tests__/notes-field.test.tsx
+++ b/components/__tests__/notes-field.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { describe, expect, it, vi } from "vitest";
+import messages from "../../messages/en.json";
+import { NotesField } from "../application-form/notes-field";
+
+function renderField(value: string) {
+  render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <NotesField value={value} onChange={vi.fn()} size="large" />
+    </NextIntlClientProvider>,
+  );
+}
+
+describe("NotesField", () => {
+  it("labels notes as a bounded current summary", () => {
+    renderField("current context");
+    expect(screen.getByText("Summary")).toBeTruthy();
+    const textarea = screen.getByRole("textbox");
+    expect(textarea.getAttribute("maxlength")).toBe("10000");
+    expect(screen.getByText("15/10,000")).toBeTruthy();
+  });
+
+  it("warns visibly when the summary approaches its limit", () => {
+    renderField("x".repeat(9_000));
+    expect(screen.getByRole("alert").textContent).toContain("approaching");
+  });
+});

--- a/components/activity-feed.tsx
+++ b/components/activity-feed.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useInfiniteQuery } from "@tanstack/react-query";
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { AppHeader } from "./app-header";
+import { APPLICATION_EVENT_TYPES, type ApplicationEventType } from "@/lib/applications/events";
+
+interface ActivityEvent {
+  id: string;
+  applicationId: string;
+  type: string;
+  occurredAt: string;
+  createdAt: string;
+  source: string | null;
+  actor: string | null;
+  contactId: string | null;
+  outcome: string | null;
+  metadata: Record<string, unknown> | null;
+  application?: { id: string; company: string; role: string };
+}
+
+interface ActivityPage {
+  items: ActivityEvent[];
+  nextCursor: string | null;
+}
+
+interface ActivityFeedProps {
+  user: { name?: string | null; email: string; image?: string | null; isAdmin?: boolean };
+}
+
+const EMPTY_FILTERS = {
+  company: "",
+  applicationId: "",
+  type: "",
+  order: "newest",
+  occurredAfter: "",
+  occurredBefore: "",
+  source: "",
+  actor: "",
+  contactId: "",
+  outcome: "",
+};
+
+type Filters = typeof EMPTY_FILTERS;
+
+async function fetchActivity(filters: Filters, cursor: string): Promise<ActivityPage> {
+  const params = new URLSearchParams({ limit: "50" });
+  for (const [key, value] of Object.entries(filters)) {
+    if (!value) continue;
+    const normalized = key === "occurredAfter" || key === "occurredBefore"
+      ? new Date(value).toISOString()
+      : value;
+    params.set(key, normalized);
+  }
+  if (cursor) params.set("cursor", cursor);
+  const response = await fetch(`/api/events?${params.toString()}`);
+  const body = await response.json();
+  if (!response.ok) throw new Error(body.error ?? "activity_load_failed");
+  return body as ActivityPage;
+}
+
+function EventDetails({ event }: { event: ActivityEvent }) {
+  const tm = useTranslations("events.metadata");
+  const metadata = event.metadata ?? {};
+  const details = [
+    typeof metadata.fromStage === "string" && typeof metadata.toStage === "string"
+      ? `${tm("fromStage")}: ${metadata.fromStage || "—"} → ${tm("toStage")}: ${metadata.toStage}`
+      : null,
+    typeof metadata.scheduledAt === "string"
+      ? `${tm("scheduledAt")}: ${new Date(metadata.scheduledAt).toLocaleString()}`
+      : null,
+    typeof metadata.nextAction === "string" ? `${tm("nextAction")}: ${metadata.nextAction}` : null,
+    typeof metadata.reason === "string" ? `${tm("reason")}: ${metadata.reason}` : null,
+    event.outcome ? `${tm("outcome")}: ${event.outcome}` : null,
+  ].filter(Boolean) as string[];
+  if (!details.length) return null;
+  return <ul className="mt-2 space-y-1 text-xs text-slate-600 dark:text-slate-300">{details.map((detail) => <li key={detail}>{detail}</li>)}</ul>;
+}
+
+export function ActivityFeed({ user }: ActivityFeedProps) {
+  const t = useTranslations("activityFeed");
+  const te = useTranslations("events.eventTypes");
+  const [draft, setDraft] = useState<Filters>(EMPTY_FILTERS);
+  const [filters, setFilters] = useState<Filters>(EMPTY_FILTERS);
+  const activity = useInfiniteQuery({
+    queryKey: ["application-activity", filters],
+    initialPageParam: "",
+    queryFn: ({ pageParam }) => fetchActivity(filters, pageParam),
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+  });
+  const events = activity.data?.pages.flatMap((page) => page.items) ?? [];
+  const update = (name: keyof Filters, value: string) => setDraft((current) => ({ ...current, [name]: value }));
+
+  return (
+    <div className="nexus-shell">
+      <AppHeader user={user} />
+      <main className="nexus-page-bottom-space mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+        <div className="mb-6">
+          <h1 className="text-2xl font-semibold tracking-tight text-slate-950 dark:text-white">{t("title")}</h1>
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">{t("description")}</p>
+        </div>
+
+        <section className="mb-6 rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-white/8 dark:bg-[#111214]">
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <input aria-label={t("company")} className="nexus-input" placeholder={t("company")} value={draft.company} onChange={(event) => update("company", event.target.value)} />
+            <input aria-label={t("application_id")} className="nexus-input" placeholder={t("application_id")} value={draft.applicationId} onChange={(event) => update("applicationId", event.target.value)} />
+            <select aria-label={t("event_type")} className="nexus-input" value={draft.type} onChange={(event) => update("type", event.target.value)}>
+              <option value="">{t("all_types")}</option>
+              {APPLICATION_EVENT_TYPES.map((type) => <option key={type} value={type}>{te(type)}</option>)}
+            </select>
+            <select aria-label={t("order")} className="nexus-input" value={draft.order} onChange={(event) => update("order", event.target.value)}>
+              <option value="newest">{t("newest")}</option>
+              <option value="oldest">{t("oldest")}</option>
+            </select>
+            <input aria-label={t("source")} className="nexus-input" placeholder={t("source")} value={draft.source} onChange={(event) => update("source", event.target.value)} />
+            <input aria-label={t("actor")} className="nexus-input" placeholder={t("actor")} value={draft.actor} onChange={(event) => update("actor", event.target.value)} />
+            <input aria-label={t("contact_id")} className="nexus-input" placeholder={t("contact_id")} value={draft.contactId} onChange={(event) => update("contactId", event.target.value)} />
+            <input aria-label={t("outcome")} className="nexus-input" placeholder={t("outcome")} value={draft.outcome} onChange={(event) => update("outcome", event.target.value)} />
+            <div className="grid grid-cols-2 gap-2">
+              <label className="text-[11px] font-medium text-slate-500">{t("from")}<input aria-label={t("from")} type="datetime-local" className="nexus-input mt-1 w-full" value={draft.occurredAfter} onChange={(event) => update("occurredAfter", event.target.value)} /></label>
+              <label className="text-[11px] font-medium text-slate-500">{t("to")}<input aria-label={t("to")} type="datetime-local" className="nexus-input mt-1 w-full" value={draft.occurredBefore} onChange={(event) => update("occurredBefore", event.target.value)} /></label>
+            </div>
+          </div>
+          <div className="mt-4 flex justify-end gap-2">
+            <button type="button" className="nexus-button-ghost" onClick={() => { setDraft(EMPTY_FILTERS); setFilters(EMPTY_FILTERS); }}>{t("clear")}</button>
+            <button type="button" className="nexus-button-primary" onClick={() => setFilters({ ...draft })}>{t("apply")}</button>
+          </div>
+        </section>
+
+        <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-white/8 dark:bg-[#111214]">
+          {activity.isLoading && <p role="status" aria-live="polite" className="text-sm text-slate-500">{t("loading")}</p>}
+          {activity.isError && <p role="alert" className="text-sm text-red-600">{t("load_error")}</p>}
+          {!activity.isLoading && !activity.isError && events.length === 0 && <p className="text-sm text-slate-500">{t("empty")}</p>}
+          <ol>
+            {events.map((event, index) => (
+              <li key={event.id} className="relative border-b border-slate-100 py-4 pl-6 last:border-0 dark:border-white/6">
+                <span className="absolute left-0 top-6 h-2.5 w-2.5 rounded-full bg-[#5e6ad2]" />
+                <div className="flex flex-wrap items-start justify-between gap-2">
+                  <div>
+                    <h2 className="text-sm font-semibold text-slate-900 dark:text-slate-100">{APPLICATION_EVENT_TYPES.includes(event.type as ApplicationEventType) ? te(event.type as ApplicationEventType) : event.type}</h2>
+                    <p className="mt-0.5 text-xs text-slate-500">
+                      {event.application ? <Link className="font-medium text-[#5e6ad2] hover:underline" href={`/applications/${event.application.id}`}>{event.application.company} — {event.application.role}</Link> : t("application_link", { id: event.applicationId })}
+                      {(event.source || event.actor) && <> · {[event.source, event.actor].filter(Boolean).join(" · ")}</>}
+                    </p>
+                  </div>
+                  <time dateTime={event.occurredAt} className="text-xs text-slate-500">{new Date(event.occurredAt).toLocaleString()}</time>
+                </div>
+                <EventDetails event={event} />
+                {index === events.length - 1 && activity.hasNextPage && <span className="sr-only">{t("more_available")}</span>}
+              </li>
+            ))}
+          </ol>
+          {activity.hasNextPage && (
+            <div className="mt-4 flex justify-center">
+              <button type="button" className="nexus-button-ghost" disabled={activity.isFetchingNextPage} onClick={() => activity.fetchNextPage()}>
+                {activity.isFetchingNextPage ? t("loading_more") : t("load_more")}
+              </button>
+            </div>
+          )}
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/components/activity-feed.tsx
+++ b/components/activity-feed.tsx
@@ -2,10 +2,11 @@
 
 import { useInfiniteQuery } from "@tanstack/react-query";
 import Link from "next/link";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { useState } from "react";
 import { AppHeader } from "./app-header";
 import { APPLICATION_EVENT_TYPES, type ApplicationEventType } from "@/lib/applications/events";
+import { formatEventDateTime } from "@/lib/applications/event-format";
 
 interface ActivityEvent {
   id: string;
@@ -63,13 +64,14 @@ async function fetchActivity(filters: Filters, cursor: string): Promise<Activity
 
 function EventDetails({ event }: { event: ActivityEvent }) {
   const tm = useTranslations("events.metadata");
+  const locale = useLocale();
   const metadata = event.metadata ?? {};
   const details = [
     typeof metadata.fromStage === "string" && typeof metadata.toStage === "string"
       ? `${tm("fromStage")}: ${metadata.fromStage || "—"} → ${tm("toStage")}: ${metadata.toStage}`
       : null,
     typeof metadata.scheduledAt === "string"
-      ? `${tm("scheduledAt")}: ${new Date(metadata.scheduledAt).toLocaleString()}`
+      ? `${tm("scheduledAt")}: ${formatEventDateTime(metadata.scheduledAt, locale)}`
       : null,
     typeof metadata.nextAction === "string" ? `${tm("nextAction")}: ${metadata.nextAction}` : null,
     typeof metadata.reason === "string" ? `${tm("reason")}: ${metadata.reason}` : null,
@@ -82,6 +84,7 @@ function EventDetails({ event }: { event: ActivityEvent }) {
 export function ActivityFeed({ user }: ActivityFeedProps) {
   const t = useTranslations("activityFeed");
   const te = useTranslations("events.eventTypes");
+  const locale = useLocale();
   const [draft, setDraft] = useState<Filters>(EMPTY_FILTERS);
   const [filters, setFilters] = useState<Filters>(EMPTY_FILTERS);
   const activity = useInfiniteQuery({
@@ -145,7 +148,7 @@ export function ActivityFeed({ user }: ActivityFeedProps) {
                       {(event.source || event.actor) && <> · {[event.source, event.actor].filter(Boolean).join(" · ")}</>}
                     </p>
                   </div>
-                  <time dateTime={event.occurredAt} className="text-xs text-slate-500">{new Date(event.occurredAt).toLocaleString()}</time>
+                  <time dateTime={event.occurredAt} className="text-xs text-slate-500">{formatEventDateTime(event.occurredAt, locale)}</time>
                 </div>
                 <EventDetails event={event} />
                 {index === events.length - 1 && activity.hasNextPage && <span className="sr-only">{t("more_available")}</span>}

--- a/components/app-header.tsx
+++ b/components/app-header.tsx
@@ -6,6 +6,7 @@ import { useRouter, usePathname } from "next/navigation";
 import Link from "next/link";
 import {
   BarChart3,
+  Activity,
   FolderOpen,
   Bot,
   Settings,
@@ -77,6 +78,12 @@ export function AppHeader({ user, shareUrl, title, onBeforeLogout }: AppHeaderPr
       href: "/",
       label: tn("opportunities"),
       icon: BriefcaseBusiness,
+      show: true,
+    },
+    {
+      href: "/activity",
+      label: tn("activity"),
+      icon: Activity,
       show: true,
     },
     {

--- a/components/application-detail.tsx
+++ b/components/application-detail.tsx
@@ -22,6 +22,7 @@ import { TriageSection } from "./application-form/triage-section";
 import { ContactsSection } from "./application-form/contacts-section";
 import { DocumentsSection } from "./application-form/documents-section";
 import { ResumeSection } from "./application-form/resume-section";
+import { ApplicationTimeline } from "./application-timeline";
 
 interface ApplicationDetailProps {
   user: {
@@ -226,16 +227,17 @@ export function ApplicationDetail({ user, application }: ApplicationDetailProps)
           <div className="grid grid-cols-1 gap-5 lg:grid-cols-2 lg:items-start">
             <SectionCard title={td("section_details")}>
               <div className="space-y-5">
-                <CoreFieldsSection form={form} onChange={handleChange} />
+                <CoreFieldsSection form={form} onChange={handleChange} lifecycleDisabled />
                 <DetailFieldsSection
                   form={form}
                   onChange={handleChange}
                   patch={patch}
+                  lifecycleDisabled
                 />
               </div>
             </SectionCard>
             <div className="space-y-5">
-              <SectionCard title={tm("notes")}>
+              <SectionCard title={tm("summary")}>
                 <NotesField
                   value={form.notes}
                   onChange={handleChange}
@@ -254,7 +256,9 @@ export function ApplicationDetail({ user, application }: ApplicationDetailProps)
 
           <div className="mt-5 space-y-5">
             <TriageSection form={form} patch={patch} variant="open" />
-            <ContactsSection state={contactRows} variant="open" />
+            <div id="contacts">
+              <ContactsSection state={contactRows} variant="open" />
+            </div>
             <DocumentsSection
               applicationId={application.id}
               resumeId={application.resumeId}
@@ -284,6 +288,14 @@ export function ApplicationDetail({ user, application }: ApplicationDetailProps)
             </div>
           </div>
         </form>
+        <div className="mt-5">
+          <ApplicationTimeline
+            applicationId={application.id}
+            expectedUpdatedAt={baselineUpdatedAt}
+            disabled={hasUnsavedChanges}
+            onProjectionUpdated={() => window.location.reload()}
+          />
+        </div>
       </main>
     </div>
   );

--- a/components/application-form/__tests__/form-data.test.ts
+++ b/components/application-form/__tests__/form-data.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { updateApplication, type ApplicationFormData } from "../form-data";
+
+describe("updateApplication", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("omits lifecycle fields that the edit form cannot mutate", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ application: { id: "app-1" } }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const data = {
+      company: "Acme",
+      role: "Engineer",
+      status: "interview",
+      appliedAt: "2026-07-01",
+      lastContact: "2026-07-10",
+      followUpAt: "2026-07-30",
+      notes: "summary",
+    } as ApplicationFormData;
+
+    await updateApplication("app-1", data, "2026-07-24T08:00:00.000Z");
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body).toMatchObject({
+      company: "Acme",
+      role: "Engineer",
+      notes: "summary",
+      expectedUpdatedAt: "2026-07-24T08:00:00.000Z",
+    });
+    expect(body).not.toHaveProperty("status");
+    expect(body).not.toHaveProperty("appliedAt");
+    expect(body).not.toHaveProperty("lastContact");
+    expect(body).not.toHaveProperty("followUpAt");
+  });
+});

--- a/components/application-form/contacts-section.tsx
+++ b/components/application-form/contacts-section.tsx
@@ -35,7 +35,8 @@ export function ContactsSection({
       {contacts.map((c, idx) => (
         <div
           key={c.clientId}
-          className="space-y-2 rounded-xl border border-slate-200/80 bg-slate-50/80 p-3 dark:border-white/8 dark:bg-white/4"
+          id={c.id ? `contact-${encodeURIComponent(c.id)}` : undefined}
+          className="scroll-mt-6 space-y-2 rounded-xl border border-slate-200/80 bg-slate-50/80 p-3 dark:border-white/8 dark:bg-white/4"
         >
           <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
             <div>

--- a/components/application-form/core-fields-section.tsx
+++ b/components/application-form/core-fields-section.tsx
@@ -11,9 +11,10 @@ interface CoreFieldsSectionProps {
       HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
     >,
   ) => void;
+  lifecycleDisabled?: boolean;
 }
 
-export function CoreFieldsSection({ form, onChange }: CoreFieldsSectionProps) {
+export function CoreFieldsSection({ form, onChange, lifecycleDisabled = false }: CoreFieldsSectionProps) {
   const t = useTranslations("modal");
   const ts = useTranslations("status");
   const locale = useLocale();
@@ -60,7 +61,8 @@ export function CoreFieldsSection({ form, onChange }: CoreFieldsSectionProps) {
           name="status"
           value={form.status}
           onChange={onChange}
-          className="nexus-input"
+          disabled={lifecycleDisabled}
+          className="nexus-input disabled:cursor-not-allowed disabled:opacity-60"
         >
           {STATUS_ORDER.map((value) => (
             <option key={value} value={value}>
@@ -79,10 +81,12 @@ export function CoreFieldsSection({ form, onChange }: CoreFieldsSectionProps) {
           name="followUpAt"
           value={form.followUpAt}
           onChange={onChange}
+          disabled={lifecycleDisabled}
           lang={locale}
-          className="nexus-input"
+          className="nexus-input disabled:cursor-not-allowed disabled:opacity-60"
         />
       </div>
+      {lifecycleDisabled && <p className="text-xs text-slate-500 dark:text-slate-400">{t("lifecycle_timeline_help")}</p>}
     </>
   );
 }

--- a/components/application-form/detail-fields-section.tsx
+++ b/components/application-form/detail-fields-section.tsx
@@ -13,12 +13,14 @@ interface DetailFieldsSectionProps {
     >,
   ) => void;
   patch: (partial: Partial<ApplicationFormData>) => void;
+  lifecycleDisabled?: boolean;
 }
 
 export function DetailFieldsSection({
   form,
   onChange,
   patch,
+  lifecycleDisabled = false,
 }: DetailFieldsSectionProps) {
   const t = useTranslations("modal");
   const ta = useTranslations("actions");
@@ -144,8 +146,9 @@ export function DetailFieldsSection({
             name="appliedAt"
             value={form.appliedAt}
             onChange={onChange}
+            disabled={lifecycleDisabled}
             lang={locale}
-            className="nexus-input"
+            className="nexus-input disabled:cursor-not-allowed disabled:opacity-60"
           />
         </div>
 
@@ -158,8 +161,9 @@ export function DetailFieldsSection({
             name="lastContact"
             value={form.lastContact}
             onChange={onChange}
+            disabled={lifecycleDisabled}
             lang={locale}
-            className="nexus-input"
+            className="nexus-input disabled:cursor-not-allowed disabled:opacity-60"
           />
         </div>
       </div>

--- a/components/application-form/form-data.ts
+++ b/components/application-form/form-data.ts
@@ -127,11 +127,16 @@ export async function updateApplication(
   data: ApplicationFormData,
   expectedUpdatedAt?: string | null,
 ): Promise<Application> {
+  const mutableFields: Record<string, unknown> = { ...serializeForm(data) };
+  delete mutableFields.status;
+  delete mutableFields.appliedAt;
+  delete mutableFields.lastContact;
+  delete mutableFields.followUpAt;
   const res = await fetch(`/api/applications/${id}`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
-      ...serializeForm(data),
+      ...mutableFields,
       ...(expectedUpdatedAt ? { expectedUpdatedAt } : {}),
     }),
   });

--- a/components/application-form/notes-field.tsx
+++ b/components/application-form/notes-field.tsx
@@ -50,7 +50,7 @@ export function NotesField({
       />
       <div id={helpId} className="mt-1 flex justify-between gap-3 text-xs text-slate-500 dark:text-slate-400">
         <span>{t("notes_summary_help")}</span>
-        <span>{value.length.toLocaleString()}/10,000</span>
+        <span>{String(value.length)}/10,000</span>
       </div>
       {nearLimit && <p id={warningId} role="alert" className="mt-1 text-xs font-medium text-amber-600 dark:text-amber-400">{t("notes_limit_warning")}</p>}
     </div>

--- a/components/application-form/notes-field.tsx
+++ b/components/application-form/notes-field.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
+import { useId } from "react";
 
 interface NotesFieldProps {
   value: string;
@@ -21,18 +22,25 @@ export function NotesField({
   showLabel = true,
 }: NotesFieldProps) {
   const t = useTranslations("modal");
+  const inputId = useId();
+  const helpId = `${inputId}-help`;
+  const warningId = `${inputId}-warning`;
+  const nearLimit = value.length >= 9_000;
 
   return (
     <div>
       {showLabel && (
-        <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300">
-          {t("notes")}
+        <label htmlFor={inputId} className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300">
+          {t("summary")}
         </label>
       )}
       <textarea
+        id={inputId}
         name="notes"
         value={value}
         onChange={onChange}
+        maxLength={10_000}
+        aria-describedby={nearLimit ? `${helpId} ${warningId}` : helpId}
         className={
           size === "large"
             ? "nexus-input nexus-scroll min-h-64 resize-y field-sizing-content"
@@ -40,6 +48,11 @@ export function NotesField({
         }
         placeholder={t("notes_placeholder")}
       />
+      <div id={helpId} className="mt-1 flex justify-between gap-3 text-xs text-slate-500 dark:text-slate-400">
+        <span>{t("notes_summary_help")}</span>
+        <span>{value.length.toLocaleString()}/10,000</span>
+      </div>
+      {nearLimit && <p id={warningId} role="alert" className="mt-1 text-xs font-medium text-amber-600 dark:text-amber-400">{t("notes_limit_warning")}</p>}
     </div>
   );
 }

--- a/components/application-timeline.tsx
+++ b/components/application-timeline.tsx
@@ -2,12 +2,13 @@
 
 import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { useMemo, useState } from "react";
 import {
   APPLICATION_EVENT_TYPES,
   type ApplicationEventType,
 } from "@/lib/applications/events";
+import { formatEventDateTime } from "@/lib/applications/event-format";
 
 interface TimelineEvent {
   id: string;
@@ -46,6 +47,9 @@ function localDateTimeValue(date = new Date()): string {
 const VISIBLE_METADATA_KEYS = [
   "fromStage",
   "toStage",
+  "fromStatus",
+  "toStatus",
+  "channel",
   "interviewType",
   "scheduledAt",
   "followUpAt",
@@ -54,19 +58,14 @@ const VISIBLE_METADATA_KEYS = [
   "reason",
   "note",
   "durationMinutes",
-  "location",
-  "meetingUrl",
-  "offerType",
-  "compensationSummary",
-  "atsName",
-  "requisitionId",
-  "filename",
-  "documentCount",
+  "answerCount",
+  "documentType",
 ] as const;
 
 function metadataSummary(
   metadata: Record<string, unknown> | null,
   labelFor: (key: string) => string,
+  locale: string,
 ): string[] {
   if (!metadata) return [];
   return VISIBLE_METADATA_KEYS.flatMap((key) => {
@@ -74,7 +73,7 @@ function metadataSummary(
     if (value === undefined || value === null || value === "" || typeof value === "object") return [];
     const label = labelFor(key);
     if (typeof value === "string" && /^\d{4}-\d{2}-\d{2}T/.test(value)) {
-      return [`${label}: ${new Date(value).toLocaleString()}`];
+      return [`${label}: ${formatEventDateTime(value, locale)}`];
     }
     return [`${label}: ${String(value)}`];
   });
@@ -97,6 +96,7 @@ export function ApplicationTimeline({
   const t = useTranslations("timeline");
   const te = useTranslations("events.eventTypes");
   const tm = useTranslations("events.metadata");
+  const locale = useLocale();
   const queryClient = useQueryClient();
   const [open, setOpen] = useState(false);
   const [type, setType] = useState<ApplicationEventType>("stage_changed");
@@ -263,7 +263,11 @@ export function ApplicationTimeline({
       {open && (
         <form
           className="mt-4 rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-white/10 dark:bg-white/[0.03]"
-          onSubmit={(event) => { event.preventDefault(); mutation.mutate(); }}
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (disabled) return;
+            mutation.mutate();
+          }}
         >
           <div className="grid gap-3 sm:grid-cols-2">
             <label className="block space-y-1">
@@ -286,7 +290,7 @@ export function ApplicationTimeline({
           <div className="mt-4 flex justify-end">
             <button
               type="submit"
-              disabled={mutation.isPending || !occurredAt}
+              disabled={disabled || mutation.isPending || !occurredAt}
               className="nexus-button-primary disabled:cursor-not-allowed disabled:opacity-50"
             >
               {mutation.isPending ? t("recording") : t("record_event")}
@@ -301,7 +305,7 @@ export function ApplicationTimeline({
         {!timeline.isLoading && !timeline.isError && events.length === 0 && <p className="text-sm text-slate-500">{t("empty")}</p>}
         <ol className="space-y-0">
           {events.map((event, index) => {
-            const details = metadataSummary(event.metadata, (key) => tm(key));
+            const details = metadataSummary(event.metadata, (key) => tm(key), locale);
             const title = APPLICATION_EVENT_TYPES.includes(event.type as ApplicationEventType)
               ? te(event.type as ApplicationEventType)
               : t("unknown_event", { type: event.type });
@@ -314,8 +318,8 @@ export function ApplicationTimeline({
                 <div className="flex flex-wrap items-baseline justify-between gap-2">
                   <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">{title}</h3>
                   <div className="text-right text-xs text-slate-500">
-                    <time className="block" dateTime={event.occurredAt}>{new Date(event.occurredAt).toLocaleString()}</time>
-                    {event.createdAt && <time className="block text-[10px]" dateTime={event.createdAt}>{t("recorded_at", { date: new Date(event.createdAt).toLocaleString() })}</time>}
+                    <time className="block" dateTime={event.occurredAt}>{formatEventDateTime(event.occurredAt, locale)}</time>
+                    {event.createdAt && <time className="block text-[10px]" dateTime={event.createdAt}>{t("recorded_at", { date: formatEventDateTime(event.createdAt, locale) })}</time>}
                   </div>
                 </div>
                 {(event.source || event.actor) && <p className="mt-0.5 text-xs text-slate-500">{[event.source, event.actor].filter(Boolean).join(" · ")}</p>}

--- a/components/application-timeline.tsx
+++ b/components/application-timeline.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { useMemo, useState } from "react";
+import {
+  APPLICATION_EVENT_TYPES,
+  type ApplicationEventType,
+} from "@/lib/applications/events";
+
+interface TimelineEvent {
+  id: string;
+  applicationId: string;
+  type: string;
+  occurredAt: string;
+  createdAt: string;
+  source: string | null;
+  actor: string | null;
+  contactId: string | null;
+  outcome: string | null;
+  metadata: Record<string, unknown> | null;
+}
+
+interface TimelinePage {
+  items: TimelineEvent[];
+  nextCursor: string | null;
+}
+
+interface ApplicationTimelineProps {
+  applicationId: string;
+  expectedUpdatedAt: string | null;
+  disabled?: boolean;
+  onProjectionUpdated?: (updatedAt: string) => void;
+}
+
+const RECORDABLE_TYPES = APPLICATION_EVENT_TYPES.filter((type) =>
+  !["application_submitted", "opportunity_discovered", "document_attached"].includes(type),
+);
+
+function localDateTimeValue(date = new Date()): string {
+  const offset = date.getTimezoneOffset() * 60_000;
+  return new Date(date.getTime() - offset).toISOString().slice(0, 16);
+}
+
+function metadataSummary(
+  metadata: Record<string, unknown> | null,
+  labelFor: (key: string) => string,
+): string[] {
+  if (!metadata) return [];
+  const hidden = new Set(["requestHash", "fromStatus", "toStatus", "contactId", "documentId", "submissionId"]);
+  return Object.entries(metadata)
+    .filter(([key, value]) => !hidden.has(key) && value !== null && value !== "")
+    .slice(0, 6)
+    .map(([key, value]) => {
+      const label = labelFor(key);
+      if (typeof value === "string" && /^\d{4}-\d{2}-\d{2}T/.test(value)) {
+        return `${label}: ${new Date(value).toLocaleString()}`;
+      }
+      if (Array.isArray(value)) return `${label}: ${value.join(", ")}`;
+      if (typeof value === "object") return `${label}: recorded`;
+      return `${label}: ${String(value)}`;
+    });
+}
+
+async function loadTimeline(applicationId: string, order: "newest" | "oldest", cursor: string): Promise<TimelinePage> {
+  const params = new URLSearchParams({ applicationId, limit: "50", order });
+  if (cursor) params.set("cursor", cursor);
+  const response = await fetch(`/api/events?${params.toString()}`);
+  if (!response.ok) throw new Error("timeline_load_failed");
+  return response.json() as Promise<TimelinePage>;
+}
+
+export function ApplicationTimeline({
+  applicationId,
+  expectedUpdatedAt,
+  disabled = false,
+  onProjectionUpdated,
+}: ApplicationTimelineProps) {
+  const t = useTranslations("timeline");
+  const te = useTranslations("events.eventTypes");
+  const tm = useTranslations("events.metadata");
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState(false);
+  const [type, setType] = useState<ApplicationEventType>("stage_changed");
+  const [order, setOrder] = useState<"newest" | "oldest">("newest");
+  const [occurredAt, setOccurredAt] = useState(localDateTimeValue());
+  const [fields, setFields] = useState<Record<string, string>>({});
+  const [error, setError] = useState<string | null>(null);
+  const queryKey = useMemo(() => ["application-events", applicationId, order], [applicationId, order]);
+  const timeline = useInfiniteQuery({
+    queryKey,
+    initialPageParam: "",
+    queryFn: ({ pageParam }) => loadTimeline(applicationId, order, pageParam),
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+  });
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const metadata: Record<string, unknown> = {};
+      const add = (key: string) => {
+        const value = fields[key]?.trim();
+        if (value) metadata[key] = key.endsWith("At") ? new Date(value).toISOString() : value;
+      };
+      switch (type) {
+        case "stage_changed":
+          add("toStage");
+          add("toStatus");
+          break;
+        case "interview_invited":
+        case "interview_scheduled":
+          add("interviewType");
+          add("scheduledAt");
+          add("followUpAt");
+          add("nextAction");
+          break;
+        case "interview_completed":
+        case "feedback_received":
+          add("interviewType");
+          add("outcome");
+          add("nextAction");
+          add("followUpAt");
+          break;
+        case "follow_up_scheduled":
+          add("followUpAt");
+          add("nextAction");
+          break;
+        case "application_rejected":
+          add("outcome");
+          add("reason");
+          break;
+        case "offer_received":
+        case "recruiter_contacted":
+          add("outcome");
+          add("nextAction");
+          add("followUpAt");
+          break;
+        case "note_added":
+          add("note");
+          break;
+        default:
+          break;
+      }
+      const response = await fetch(`/api/applications/${applicationId}/events`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          type,
+          occurredAt: new Date(occurredAt).toISOString(),
+          expectedUpdatedAt,
+          idempotencyKey: `ui-${crypto.randomUUID()}`,
+          metadata,
+        }),
+      });
+      const result = await response.json();
+      if (!response.ok) throw new Error(result.error ?? "event_failed");
+      return result as { application: { updatedAt: string } };
+    },
+    onSuccess: async (result) => {
+      setError(null);
+      setOpen(false);
+      setFields({});
+      setOccurredAt(localDateTimeValue());
+      await queryClient.invalidateQueries({ queryKey });
+      await queryClient.invalidateQueries({ queryKey: ["applications"] });
+      onProjectionUpdated?.(result.application.updatedAt);
+    },
+    onError: (failure) => setError(failure instanceof Error ? failure.message : "event_failed"),
+  });
+
+  const field = (
+    name: string,
+    label: string,
+    options?: { type?: string; required?: boolean; placeholder?: string },
+  ) => (
+    <label className="block space-y-1" key={name}>
+      <span className="text-xs font-semibold text-slate-600 dark:text-slate-300">{label}</span>
+      <input
+        name={name}
+        type={options?.type ?? "text"}
+        required={options?.required}
+        placeholder={options?.placeholder}
+        value={fields[name] ?? ""}
+        onChange={(event) => setFields((current) => ({ ...current, [name]: event.target.value }))}
+        className="nexus-input w-full"
+      />
+    </label>
+  );
+
+  const eventFields = () => {
+    switch (type) {
+      case "stage_changed":
+        return <>{field("toStage", t("new_stage"), { required: true, placeholder: "technical_interview" })}{field("toStatus", t("status_optional"), { placeholder: "interview" })}</>;
+      case "interview_invited":
+        return <>{field("interviewType", t("interview_type"))}{field("scheduledAt", t("scheduled_for"), { type: "datetime-local" })}{field("followUpAt", t("follow_up"), { type: "datetime-local" })}{field("nextAction", t("next_action"))}</>;
+      case "interview_scheduled":
+        return <>{field("interviewType", t("interview_type"), { required: true })}{field("scheduledAt", t("scheduled_for"), { type: "datetime-local", required: true })}{field("nextAction", t("preparation"))}</>;
+      case "interview_completed":
+      case "feedback_received":
+        return <>{type === "interview_completed" && field("interviewType", t("interview_type"))}{field("outcome", t("outcome"))}{field("nextAction", t("next_action"))}{field("followUpAt", t("follow_up"), { type: "datetime-local" })}</>;
+      case "follow_up_scheduled":
+        return <>{field("followUpAt", t("follow_up"), { type: "datetime-local", required: true })}{field("nextAction", t("next_action"))}</>;
+      case "application_rejected":
+        return <>{field("outcome", t("outcome"), { placeholder: "declined" })}{field("reason", t("reason"))}</>;
+      case "offer_received":
+      case "recruiter_contacted":
+        return <>{field("outcome", t("outcome"))}{field("nextAction", t("next_action"))}{field("followUpAt", t("follow_up"), { type: "datetime-local" })}</>;
+      case "note_added":
+        return field("note", t("timeline_note"), { required: true });
+      default:
+        return null;
+    }
+  };
+
+  const events = timeline.data?.pages.flatMap((page) => Array.isArray(page.items) ? page.items : []) ?? [];
+
+  return (
+    <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-white/8 dark:bg-[#111214]">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-base font-semibold text-slate-950 dark:text-white">{t("title")}</h2>
+          <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{t("description")}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <select
+            aria-label={t("order")}
+            value={order}
+            onChange={(event) => setOrder(event.target.value as "newest" | "oldest")}
+            className="nexus-input"
+          >
+            <option value="newest">{t("newest")}</option>
+            <option value="oldest">{t("oldest")}</option>
+          </select>
+          <button
+            type="button"
+            disabled={disabled}
+            title={disabled ? t("save_first") : undefined}
+            onClick={() => setOpen((value) => !value)}
+            className="nexus-button-primary disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {open ? t("cancel") : t("record_activity")}
+          </button>
+        </div>
+      </div>
+
+      {open && (
+        <form
+          className="mt-4 rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-white/10 dark:bg-white/[0.03]"
+          onSubmit={(event) => { event.preventDefault(); mutation.mutate(); }}
+        >
+          <div className="grid gap-3 sm:grid-cols-2">
+            <label className="block space-y-1">
+              <span className="text-xs font-semibold text-slate-600 dark:text-slate-300">{t("activity")}</span>
+              <select
+                value={type}
+                onChange={(event) => { setType(event.target.value as ApplicationEventType); setFields({}); }}
+                className="nexus-input w-full"
+              >
+                {RECORDABLE_TYPES.map((eventType) => <option key={eventType} value={eventType}>{te(eventType)}</option>)}
+              </select>
+            </label>
+            <label className="block space-y-1">
+              <span className="text-xs font-semibold text-slate-600 dark:text-slate-300">{t("occurred_at")}</span>
+              <input type="datetime-local" required value={occurredAt} onChange={(event) => setOccurredAt(event.target.value)} className="nexus-input w-full" />
+            </label>
+            {eventFields()}
+          </div>
+          {error && <p role="alert" className="mt-3 text-sm text-red-600 dark:text-red-400">{error}</p>}
+          <div className="mt-4 flex justify-end">
+            <button
+              type="submit"
+              disabled={mutation.isPending || !occurredAt}
+              className="nexus-button-primary disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {mutation.isPending ? t("recording") : t("record_event")}
+            </button>
+          </div>
+        </form>
+      )}
+
+      <div className="mt-5">
+        {timeline.isLoading && <p role="status" aria-live="polite" className="text-sm text-slate-500">{t("loading")}</p>}
+        {timeline.isError && <p role="alert" className="text-sm text-red-600">{t("load_error")}</p>}
+        {!timeline.isLoading && !timeline.isError && events.length === 0 && <p className="text-sm text-slate-500">{t("empty")}</p>}
+        <ol className="space-y-0">
+          {events.map((event, index) => {
+            const details = metadataSummary(event.metadata, (key) => tm(key));
+            const title = APPLICATION_EVENT_TYPES.includes(event.type as ApplicationEventType)
+              ? te(event.type as ApplicationEventType)
+              : event.type;
+            const documentId = typeof event.metadata?.documentId === "string" ? event.metadata.documentId : null;
+            const submissionId = typeof event.metadata?.submissionId === "string" ? event.metadata.submissionId : null;
+            return (
+              <li key={event.id} className="relative pl-7 pb-5 last:pb-0">
+                {index < events.length - 1 && <span className="absolute left-[5px] top-3 h-full w-px bg-slate-200 dark:bg-white/10" />}
+                <span className="absolute left-0 top-2 h-2.5 w-2.5 rounded-full bg-cyan-500 ring-4 ring-cyan-50 dark:ring-cyan-950" />
+                <div className="flex flex-wrap items-baseline justify-between gap-2">
+                  <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">{title}</h3>
+                  <div className="text-right text-xs text-slate-500">
+                    <time className="block" dateTime={event.occurredAt}>{new Date(event.occurredAt).toLocaleString()}</time>
+                    {event.createdAt && <time className="block text-[10px]" dateTime={event.createdAt}>{t("recorded_at", { date: new Date(event.createdAt).toLocaleString() })}</time>}
+                  </div>
+                </div>
+                {(event.source || event.actor) && <p className="mt-0.5 text-xs text-slate-500">{[event.source, event.actor].filter(Boolean).join(" · ")}</p>}
+                {details.length > 0 && <ul className="mt-2 space-y-1 text-xs text-slate-600 dark:text-slate-300">{details.map((detail) => <li key={detail}>{detail}</li>)}</ul>}
+                {(event.contactId || documentId || submissionId) && (
+                  <div className="mt-2 flex flex-wrap gap-3 text-xs">
+                    {event.contactId && <Link className="text-[#5e6ad2] hover:underline" href="#contacts">{t("contact_link", { id: event.contactId })}</Link>}
+                    {documentId && <Link className="text-[#5e6ad2] hover:underline" href="/documents">{t("document_link", { id: documentId })}</Link>}
+                    {submissionId && <Link className="text-[#5e6ad2] hover:underline" href={`/api/applications/${encodeURIComponent(applicationId)}/submissions`}>{t("submission_link", { id: submissionId })}</Link>}
+                  </div>
+                )}
+              </li>
+            );
+          })}
+        </ol>
+        {timeline.hasNextPage && (
+          <div className="mt-3 flex justify-center">
+            <button type="button" className="nexus-button-ghost" disabled={timeline.isFetchingNextPage} onClick={() => timeline.fetchNextPage()}>
+              {timeline.isFetchingNextPage ? t("loading_more") : t("load_more")}
+            </button>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/components/application-timeline.tsx
+++ b/components/application-timeline.tsx
@@ -43,24 +43,41 @@ function localDateTimeValue(date = new Date()): string {
   return new Date(date.getTime() - offset).toISOString().slice(0, 16);
 }
 
+const VISIBLE_METADATA_KEYS = [
+  "fromStage",
+  "toStage",
+  "interviewType",
+  "scheduledAt",
+  "followUpAt",
+  "nextAction",
+  "outcome",
+  "reason",
+  "note",
+  "durationMinutes",
+  "location",
+  "meetingUrl",
+  "offerType",
+  "compensationSummary",
+  "atsName",
+  "requisitionId",
+  "filename",
+  "documentCount",
+] as const;
+
 function metadataSummary(
   metadata: Record<string, unknown> | null,
   labelFor: (key: string) => string,
 ): string[] {
   if (!metadata) return [];
-  const hidden = new Set(["requestHash", "fromStatus", "toStatus", "contactId", "documentId", "submissionId"]);
-  return Object.entries(metadata)
-    .filter(([key, value]) => !hidden.has(key) && value !== null && value !== "")
-    .slice(0, 6)
-    .map(([key, value]) => {
-      const label = labelFor(key);
-      if (typeof value === "string" && /^\d{4}-\d{2}-\d{2}T/.test(value)) {
-        return `${label}: ${new Date(value).toLocaleString()}`;
-      }
-      if (Array.isArray(value)) return `${label}: ${value.join(", ")}`;
-      if (typeof value === "object") return `${label}: recorded`;
-      return `${label}: ${String(value)}`;
-    });
+  return VISIBLE_METADATA_KEYS.flatMap((key) => {
+    const value = metadata[key];
+    if (value === undefined || value === null || value === "" || typeof value === "object") return [];
+    const label = labelFor(key);
+    if (typeof value === "string" && /^\d{4}-\d{2}-\d{2}T/.test(value)) {
+      return [`${label}: ${new Date(value).toLocaleString()}`];
+    }
+    return [`${label}: ${String(value)}`];
+  });
 }
 
 async function loadTimeline(applicationId: string, order: "newest" | "oldest", cursor: string): Promise<TimelinePage> {
@@ -287,7 +304,7 @@ export function ApplicationTimeline({
             const details = metadataSummary(event.metadata, (key) => tm(key));
             const title = APPLICATION_EVENT_TYPES.includes(event.type as ApplicationEventType)
               ? te(event.type as ApplicationEventType)
-              : event.type;
+              : t("unknown_event", { type: event.type });
             const documentId = typeof event.metadata?.documentId === "string" ? event.metadata.documentId : null;
             const submissionId = typeof event.metadata?.submissionId === "string" ? event.metadata.submissionId : null;
             return (
@@ -305,9 +322,9 @@ export function ApplicationTimeline({
                 {details.length > 0 && <ul className="mt-2 space-y-1 text-xs text-slate-600 dark:text-slate-300">{details.map((detail) => <li key={detail}>{detail}</li>)}</ul>}
                 {(event.contactId || documentId || submissionId) && (
                   <div className="mt-2 flex flex-wrap gap-3 text-xs">
-                    {event.contactId && <Link className="text-[#5e6ad2] hover:underline" href="#contacts">{t("contact_link", { id: event.contactId })}</Link>}
-                    {documentId && <Link className="text-[#5e6ad2] hover:underline" href="/documents">{t("document_link", { id: documentId })}</Link>}
-                    {submissionId && <Link className="text-[#5e6ad2] hover:underline" href={`/api/applications/${encodeURIComponent(applicationId)}/submissions`}>{t("submission_link", { id: submissionId })}</Link>}
+                    {event.contactId && <Link className="text-[#5e6ad2] hover:underline" href={`#contact-${encodeURIComponent(event.contactId)}`}>{t("contact_link", { id: event.contactId })}</Link>}
+                    {documentId && <Link className="text-[#5e6ad2] hover:underline" href={`/documents#document-${encodeURIComponent(documentId)}`}>{t("document_link", { id: documentId })}</Link>}
+                    {submissionId && <span className="text-slate-500 dark:text-slate-400">{t("submission_link", { id: submissionId })}</span>}
                   </div>
                 )}
               </li>

--- a/components/documents-client.tsx
+++ b/components/documents-client.tsx
@@ -280,7 +280,8 @@ export function DocumentsClient({ user }: DocumentsClientProps) {
               {documents.map((doc) => (
                 <li
                   key={doc.id}
-                  className="flex items-center gap-4 px-6 py-4 hover:bg-gray-50/60 dark:hover:bg-gray-700/50 transition-colors"
+                  id={`document-${encodeURIComponent(doc.id)}`}
+                  className="scroll-mt-6 flex items-center gap-4 px-6 py-4 hover:bg-gray-50/60 dark:hover:bg-gray-700/50 transition-colors"
                 >
                   <span className="text-2xl shrink-0">{fileIcon(doc.mimeType)}</span>
                   <div className="flex-1 min-w-0">

--- a/components/mobile-navigation-sheet.tsx
+++ b/components/mobile-navigation-sheet.tsx
@@ -2,6 +2,7 @@
 
 import {
   BarChart3,
+  Activity,
   Bot,
   BriefcaseBusiness,
   FolderOpen,
@@ -33,6 +34,7 @@ export function MobileNavigationSheet({
   const panelRef = useRef<HTMLDivElement>(null);
   const routes = [
     { href: "/", label: tn("opportunities"), icon: BriefcaseBusiness },
+    { href: "/activity", label: tn("activity"), icon: Activity },
     { href: "/documents", label: tn("documents"), icon: FolderOpen },
     { href: "/analytics", label: tn("analytics"), icon: BarChart3 },
     { href: "/resume-review", label: tn("resume_ai"), icon: Bot },

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -35,6 +35,41 @@
       ]
     },
     {
+      "collectionGroup": "applicationEvents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "occurredAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "applicationEvents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "type", "order": "ASCENDING" },
+        { "fieldPath": "occurredAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "applicationEvents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "contactId", "order": "ASCENDING" },
+        { "fieldPath": "occurredAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "applicationEvents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "outcome", "order": "ASCENDING" },
+        { "fieldPath": "occurredAt", "order": "DESCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "documents",
       "queryScope": "COLLECTION",
       "fields": [

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -70,6 +70,86 @@
       ]
     },
     {
+      "collectionGroup": "applicationEvents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "source", "order": "ASCENDING" },
+        { "fieldPath": "occurredAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "applicationEvents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "actor", "order": "ASCENDING" },
+        { "fieldPath": "occurredAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "applicationEvents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "applicationId", "order": "ASCENDING" },
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "occurredAt", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "applicationEvents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "occurredAt", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "applicationEvents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "type", "order": "ASCENDING" },
+        { "fieldPath": "occurredAt", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "applicationEvents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "contactId", "order": "ASCENDING" },
+        { "fieldPath": "occurredAt", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "applicationEvents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "outcome", "order": "ASCENDING" },
+        { "fieldPath": "occurredAt", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "applicationEvents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "source", "order": "ASCENDING" },
+        { "fieldPath": "occurredAt", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "applicationEvents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "actor", "order": "ASCENDING" },
+        { "fieldPath": "occurredAt", "order": "ASCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "documents",
       "queryScope": "COLLECTION",
       "fields": [

--- a/hooks/__tests__/use-application-status-mutation.test.tsx
+++ b/hooks/__tests__/use-application-status-mutation.test.tsx
@@ -172,24 +172,26 @@ describe("useApplicationStatusMutation concurrency", () => {
       serverStatus = "applied";
       firstRequest.resolve({
         ok: true,
-        json: async () => application("a", serverStatus),
+        json: async () => ({ application: application("a", serverStatus) }),
       } as Response);
       await firstMutation;
     });
 
     expect(serverStatus).toBe("applied");
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(
-      fetchMock.mock.calls.map(([, init]) =>
-        JSON.parse((init as RequestInit).body as string),
-      ),
-    ).toEqual([{ status: "applied" }, { status: "interview" }]);
+    const writtenEvents = fetchMock.mock.calls.map(([, init]) =>
+      JSON.parse((init as RequestInit).body as string),
+    );
+    expect(writtenEvents.map(({ type, metadata }) => ({ type, status: metadata.toStatus }))).toEqual([
+      { type: "stage_changed", status: "applied" },
+      { type: "stage_changed", status: "interview" },
+    ]);
 
     await act(async () => {
       serverStatus = "interview";
       secondRequest.resolve({
         ok: true,
-        json: async () => application("a", serverStatus),
+        json: async () => ({ application: application("a", serverStatus) }),
       } as Response);
       await secondMutation;
     });
@@ -242,16 +244,18 @@ describe("useApplicationStatusMutation concurrency", () => {
         .getQueryData<Application[]>(["applications"])
         ?.find((item) => item.id === "a")?.status,
     ).toBe("interview");
-    expect(
-      fetchMock.mock.calls.map(([, init]) =>
-        JSON.parse((init as RequestInit).body as string),
-      ),
-    ).toEqual([{ status: "applied" }, { status: "interview" }]);
+    const writtenEvents = fetchMock.mock.calls.map(([, init]) =>
+      JSON.parse((init as RequestInit).body as string),
+    );
+    expect(writtenEvents.map(({ type, metadata }) => ({ type, status: metadata.toStatus }))).toEqual([
+      { type: "stage_changed", status: "applied" },
+      { type: "stage_changed", status: "interview" },
+    ]);
 
     await act(async () => {
       secondRequest.resolve({
         ok: true,
-        json: async () => application("a", "interview"),
+        json: async () => ({ application: application("a", "interview") }),
       } as Response);
       await secondMutation;
     });
@@ -288,7 +292,7 @@ describe("useApplicationStatusMutation concurrency", () => {
     await act(async () => {
       firstRequest.resolve({
         ok: true,
-        json: async () => application("a", "applied"),
+        json: async () => ({ application: application("a", "applied") }),
       } as Response);
       await firstMutation;
     });
@@ -343,7 +347,7 @@ describe("useApplicationStatusMutation concurrency", () => {
       .mockReturnValueOnce(firstRequest.promise)
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => successfulB,
+        json: async () => ({ application: successfulB }),
       } as Response);
     vi.stubGlobal("fetch", fetchMock);
 

--- a/hooks/use-application-status-mutation.ts
+++ b/hooks/use-application-status-mutation.ts
@@ -12,23 +12,36 @@ export interface ApplicationStatusVariables {
 interface PendingStatusState {
   latestToken: symbol;
   confirmedStatus?: ApplicationStatus;
+  confirmedApplication?: Application;
 }
 
 interface StatusMutationContext {
   token: symbol;
 }
 
-async function patchApplicationStatus({
-  id,
-  status,
-}: ApplicationStatusVariables): Promise<Application> {
-  const response = await fetch(`/api/applications/${id}`, {
-    method: "PATCH",
+async function recordApplicationStatus(
+  { id, status }: ApplicationStatusVariables,
+  current?: Application,
+): Promise<Application> {
+  const eventType = status === "rejected"
+    ? "application_rejected"
+    : status === "offer" ? "offer_received" : "stage_changed";
+  const currentStage = (current as (Application & { currentStage?: string | null }) | undefined)?.currentStage;
+  const response = await fetch(`/api/applications/${id}/events`, {
+    method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ status }),
+    body: JSON.stringify({
+      type: eventType,
+      occurredAt: new Date().toISOString(),
+      expectedUpdatedAt: current?.updatedAt,
+      metadata: eventType === "stage_changed"
+        ? { toStage: currentStage || status, toStatus: status }
+        : {},
+    }),
   });
   if (!response.ok) throw new Error("Failed to update status");
-  return response.json();
+  const result = await response.json() as { application: Application };
+  return result.application;
 }
 
 export function useApplicationStatusMutation(options?: {
@@ -44,9 +57,12 @@ export function useApplicationStatusMutation(options?: {
     const previousWrite =
       writeTailByApplication.current.get(variables.id) ?? Promise.resolve();
     const request = previousWrite.catch(() => undefined).then(async () => {
-      const updated = await patchApplicationStatus(variables);
       const pending = pendingByApplication.current.get(variables.id);
-      if (pending) pending.confirmedStatus = updated.status;
+      const updated = await recordApplicationStatus(variables, pending?.confirmedApplication);
+      if (pending) {
+        pending.confirmedStatus = updated.status;
+        pending.confirmedApplication = updated;
+      }
       return updated;
     });
     const tail = request.then(
@@ -81,11 +97,13 @@ export function useApplicationStatusMutation(options?: {
       if (currentPending) {
         currentPending.latestToken = token;
       } else {
+        const confirmedApplication = currentApplications?.find(
+          (application: Application) => application.id === id,
+        );
         pendingByApplication.current.set(id, {
           latestToken: token,
-          confirmedStatus: currentApplications?.find(
-            (application: Application) => application.id === id,
-          )?.status,
+          confirmedStatus: confirmedApplication?.status,
+          confirmedApplication,
         });
       }
       queryClient.setQueryData<Application[]>(

--- a/lib/applications/__tests__/events.test.ts
+++ b/lib/applications/__tests__/events.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import {
+  APPLICATION_EVENT_TYPES,
+  decodeEventCursor,
+  deriveEventProjection,
+  encodeEventCursor,
+  parseApplicationEventCommand,
+  parseEventQuery,
+  validateApplicationSummary,
+} from "../events";
+
+describe("application event taxonomy", () => {
+  it("publishes the canonical lifecycle event types", () => {
+    expect(APPLICATION_EVENT_TYPES).toEqual([
+      "opportunity_discovered",
+      "application_submitted",
+      "recruiter_contacted",
+      "stage_changed",
+      "interview_invited",
+      "interview_scheduled",
+      "interview_completed",
+      "feedback_received",
+      "follow_up_scheduled",
+      "offer_received",
+      "application_rejected",
+      "document_attached",
+      "note_added",
+    ]);
+  });
+
+  it("rejects unknown event types without accepting arbitrary metadata", () => {
+    expect(() => parseApplicationEventCommand({
+      type: "whatever",
+      occurredAt: "2026-07-24T09:00:00Z",
+      metadata: {},
+    })).toThrow("event_type_invalid");
+    expect(() => parseApplicationEventCommand({
+      type: "stage_changed",
+      occurredAt: "2026-07-24T09:00:00Z",
+      metadata: { toStage: "technical", injected: true },
+    })).toThrow("event_metadata_invalid");
+  });
+});
+
+describe("parseApplicationEventCommand", () => {
+  it("normalizes an interview schedule and its indexed dimensions", () => {
+    const command = parseApplicationEventCommand({
+      type: "interview_scheduled",
+      occurredAt: "2026-07-24T09:00:00+02:00",
+      idempotencyKey: "schedule-123",
+      expectedUpdatedAt: "2026-07-23T10:00:00Z",
+      source: " mcp ",
+      actor: " christian@example.com ",
+      metadata: {
+        interviewType: " practical_coding ",
+        scheduledAt: "2026-07-28T12:30:00+02:00",
+        durationMinutes: 60,
+        contactId: " 42 ",
+        nextAction: " Prepare repository ",
+      },
+    });
+
+    expect(command).toMatchObject({
+      type: "interview_scheduled",
+      idempotencyKey: "schedule-123",
+      source: "mcp",
+      actor: "christian@example.com",
+      contactId: "42",
+      outcome: null,
+    });
+    expect(command.occurredAt.toISOString()).toBe("2026-07-24T07:00:00.000Z");
+    expect(command.expectedUpdatedAt?.toISOString()).toBe("2026-07-23T10:00:00.000Z");
+    expect(command.metadata).toEqual({
+      interviewType: "practical_coding",
+      scheduledAt: "2026-07-28T10:30:00.000Z",
+      durationMinutes: 60,
+      contactId: "42",
+      nextAction: "Prepare repository",
+    });
+  });
+
+  it.each([
+    ["follow_up_scheduled", {}, "event_metadata_invalid"],
+    ["interview_scheduled", { interviewType: "technical" }, "event_metadata_invalid"],
+    ["stage_changed", { toStage: "" }, "event_metadata_invalid"],
+    ["document_attached", {}, "event_metadata_invalid"],
+  ])("rejects missing required metadata for %s", (type, metadata, code) => {
+    expect(() => parseApplicationEventCommand({
+      type,
+      occurredAt: "2026-07-24T09:00:00Z",
+      metadata,
+    })).toThrow(code);
+  });
+
+  it("requires stable occurrence time for idempotent commands", () => {
+    expect(() => parseApplicationEventCommand({
+      type: "note_added",
+      idempotencyKey: "note-key-1",
+      metadata: { note: "hello" },
+    })).toThrow("occurred_at_required_for_idempotency");
+  });
+
+  it("enforces aggregate metadata limits", () => {
+    expect(() => parseApplicationEventCommand({
+      type: "note_added",
+      occurredAt: "2026-07-24T09:00:00Z",
+      metadata: { note: "x".repeat(32_001) },
+    })).toThrow(/event_metadata_(invalid|too_large)/);
+  });
+});
+
+describe("deriveEventProjection", () => {
+  const application = {
+    status: "applied",
+    currentStage: "recruiter_screen" as string | null,
+    followUpAt: new Date("2026-07-25T10:00:00Z") as Date | null,
+  };
+
+  it("derives interview projection state and trustworthy before values", () => {
+    const command = parseApplicationEventCommand({
+      type: "interview_scheduled",
+      occurredAt: "2026-07-24T09:00:00Z",
+      metadata: {
+        interviewType: "technical",
+        scheduledAt: "2026-07-28T12:30:00Z",
+      },
+    });
+    const result = deriveEventProjection(command, application);
+    expect(result.patch).toEqual({
+      status: "interview",
+      currentStage: "interview_scheduled",
+      lastContact: new Date("2026-07-24T09:00:00Z"),
+      followUpAt: new Date("2026-07-28T12:30:00Z"),
+    });
+    expect(result.metadata).toMatchObject({
+      fromStage: "recruiter_screen",
+      toStage: "interview_scheduled",
+      fromStatus: "applied",
+      toStatus: "interview",
+    });
+  });
+
+  it("rejects an application atomically and clears stale follow-up", () => {
+    const command = parseApplicationEventCommand({
+      type: "application_rejected",
+      occurredAt: "2026-07-24T09:00:00Z",
+      metadata: { outcome: "role_closed" },
+    });
+    const result = deriveEventProjection(command, application);
+    expect(result.patch).toEqual({
+      status: "rejected",
+      currentStage: "rejected",
+      lastContact: new Date("2026-07-24T09:00:00Z"),
+      followUpAt: null,
+    });
+    expect(result.metadata).toMatchObject({ fromStage: "recruiter_screen", outcome: "role_closed" });
+  });
+});
+
+describe("event query cursors", () => {
+  it("round-trips the deterministic occurrence/id cursor", () => {
+    const value = { version: 1 as const, occurredAt: "2026-07-24T09:00:00.000Z", id: "42" };
+    expect(decodeEventCursor(encodeEventCursor(value))).toEqual(value);
+  });
+
+  it("normalizes bounded filters and rejects invalid cursors/types", () => {
+    expect(parseEventQuery({
+      limit: 999,
+      order: "oldest",
+      types: ["stage_changed", "interview_completed"],
+      occurredAfter: "2026-07-01T00:00:00Z",
+      applicationId: " 12 ",
+    })).toMatchObject({
+      limit: 100,
+      order: "oldest",
+      types: ["stage_changed", "interview_completed"],
+      applicationId: "12",
+    });
+    expect(() => parseEventQuery({ types: ["unknown"] })).toThrow("event_query_invalid");
+    expect(() => parseEventQuery({ cursor: "not-a-cursor" })).toThrow("event_query_invalid");
+  });
+});
+
+describe("validateApplicationSummary", () => {
+  it("preserves valid text and rejects rather than truncating oversized summaries", () => {
+    expect(validateApplicationSummary(" summary ")).toBe(" summary ");
+    expect(validateApplicationSummary("")).toBeNull();
+    expect(() => validateApplicationSummary("x".repeat(10_001))).toThrow("notes_too_long");
+  });
+});

--- a/lib/applications/__tests__/events.test.ts
+++ b/lib/applications/__tests__/events.test.ts
@@ -43,6 +43,22 @@ describe("application event taxonomy", () => {
 });
 
 describe("parseApplicationEventCommand", () => {
+  it("rejects workflow-reserved submission events semantically", () => {
+    expect(() => parseApplicationEventCommand({
+      type: "application_submitted",
+      occurredAt: "2026-07-24T09:00:00Z",
+      metadata: {},
+    })).toThrow("submission_event_requires_submission_workflow");
+  });
+
+  it("does not accept client-supplied previous status metadata", () => {
+    expect(() => parseApplicationEventCommand({
+      type: "stage_changed",
+      occurredAt: "2026-07-24T09:00:00Z",
+      metadata: { toStage: "technical", fromStatus: "offer" },
+    })).toThrow("event_metadata_invalid");
+  });
+
   it("normalizes an interview schedule and its indexed dimensions", () => {
     const command = parseApplicationEventCommand({
       type: "interview_scheduled",
@@ -140,6 +156,19 @@ describe("deriveEventProjection", () => {
     });
   });
 
+  it("derives the previous status for stage-only changes", () => {
+    const command = parseApplicationEventCommand({
+      type: "stage_changed",
+      occurredAt: "2026-07-24T09:00:00Z",
+      metadata: { toStage: "technical" },
+    });
+    expect(deriveEventProjection(command, application).metadata).toMatchObject({
+      fromStage: "recruiter_screen",
+      fromStatus: "applied",
+      toStage: "technical",
+    });
+  });
+
   it("rejects an application atomically and clears stale follow-up", () => {
     const command = parseApplicationEventCommand({
       type: "application_rejected",
@@ -178,6 +207,7 @@ describe("event query cursors", () => {
     });
     expect(() => parseEventQuery({ types: ["unknown"] })).toThrow("event_query_invalid");
     expect(() => parseEventQuery({ cursor: "not-a-cursor" })).toThrow("event_query_invalid");
+    expect(() => parseEventQuery({ limit: 0.5 })).toThrow("event_query_invalid");
   });
 });
 

--- a/lib/applications/event-format.ts
+++ b/lib/applications/event-format.ts
@@ -1,0 +1,13 @@
+export function formatEventDateTime(value: string, locale: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat(locale, {
+    year: "numeric",
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: "UTC",
+    timeZoneName: "short",
+  }).format(date);
+}

--- a/lib/applications/events.ts
+++ b/lib/applications/events.ts
@@ -59,7 +59,7 @@ const EVENT_KEYS: Record<ApplicationEventType, readonly string[]> = {
     "followUpAt",
     "toStage",
   ],
-  stage_changed: ["fromStage", "toStage", "fromStatus", "toStatus"],
+  stage_changed: ["fromStage", "toStage", "toStatus"],
   interview_invited: [
     ...COMMON_KEYS,
     "interviewType",
@@ -250,6 +250,9 @@ export function parseApplicationEventCommand(
   const rawType = typeof input.type === "string" ? input.type.trim() : "";
   if (!EVENT_TYPE_SET.has(rawType)) throw new Error("event_type_invalid");
   const type = rawType as ApplicationEventType;
+  if (type === "application_submitted") {
+    throw new Error("submission_event_requires_submission_workflow");
+  }
 
   const idempotencyKey = input.idempotencyKey == null
     ? undefined
@@ -317,10 +320,10 @@ export function deriveEventProjection(
       const toStage = metadataString(metadata, "toStage")!;
       patch.currentStage = toStage;
       metadata.fromStage = application.currentStage;
+      if (currentStatus) metadata.fromStatus = currentStatus;
       const toStatus = metadataString(metadata, "toStatus") as ApplicationStatus | undefined;
       if (toStatus) {
         patch.status = toStatus;
-        if (currentStatus) metadata.fromStatus = currentStatus;
       }
       break;
     }
@@ -427,7 +430,7 @@ export function parseEventQuery(input: Record<string, unknown>): ParsedEventQuer
     types = [...new Set(normalized)] as ApplicationEventType[];
   }
   const rawLimit = input.limit == null ? 50 : Number(input.limit);
-  if (!Number.isFinite(rawLimit) || rawLimit <= 0) throw new Error("event_query_invalid");
+  if (!Number.isInteger(rawLimit) || rawLimit <= 0) throw new Error("event_query_invalid");
   const order = input.order == null ? "newest" : input.order;
   if (order !== "newest" && order !== "oldest") throw new Error("event_query_invalid");
   const occurredAfter = input.occurredAfter == null

--- a/lib/applications/events.ts
+++ b/lib/applications/events.ts
@@ -1,0 +1,463 @@
+import type { ApplicationStatus } from "@/types";
+
+export const APPLICATION_EVENT_TYPES = [
+  "opportunity_discovered",
+  "application_submitted",
+  "recruiter_contacted",
+  "stage_changed",
+  "interview_invited",
+  "interview_scheduled",
+  "interview_completed",
+  "feedback_received",
+  "follow_up_scheduled",
+  "offer_received",
+  "application_rejected",
+  "document_attached",
+  "note_added",
+] as const;
+
+export const RECORDABLE_APPLICATION_EVENT_TYPES = [
+  "opportunity_discovered",
+  "recruiter_contacted",
+  "stage_changed",
+  "interview_invited",
+  "interview_scheduled",
+  "interview_completed",
+  "feedback_received",
+  "follow_up_scheduled",
+  "offer_received",
+  "application_rejected",
+  "document_attached",
+  "note_added",
+] as const;
+
+export type ApplicationEventType = (typeof APPLICATION_EVENT_TYPES)[number];
+export type EventOrder = "newest" | "oldest";
+
+const EVENT_TYPE_SET = new Set<string>(APPLICATION_EVENT_TYPES);
+const STATUS_SET = new Set<ApplicationStatus>([
+  "inbound",
+  "applied",
+  "interview",
+  "offer",
+  "rejected",
+]);
+
+const COMMON_KEYS = ["contactId", "outcome", "nextAction"] as const;
+const EVENT_KEYS: Record<ApplicationEventType, readonly string[]> = {
+  opportunity_discovered: ["channel", "nextAction"],
+  application_submitted: [
+    "submissionId",
+    "documentIds",
+    "answerCount",
+    "policy",
+    "followUpAt",
+  ],
+  recruiter_contacted: [
+    ...COMMON_KEYS,
+    "channel",
+    "followUpAt",
+    "toStage",
+  ],
+  stage_changed: ["fromStage", "toStage", "fromStatus", "toStatus"],
+  interview_invited: [
+    ...COMMON_KEYS,
+    "interviewType",
+    "scheduledAt",
+    "durationMinutes",
+    "followUpAt",
+    "toStage",
+  ],
+  interview_scheduled: [
+    ...COMMON_KEYS,
+    "interviewType",
+    "scheduledAt",
+    "durationMinutes",
+    "toStage",
+  ],
+  interview_completed: [
+    ...COMMON_KEYS,
+    "interviewType",
+    "followUpAt",
+    "toStage",
+  ],
+  feedback_received: [...COMMON_KEYS, "followUpAt", "toStage"],
+  follow_up_scheduled: ["contactId", "followUpAt", "nextAction"],
+  offer_received: [...COMMON_KEYS, "followUpAt"],
+  application_rejected: ["contactId", "outcome", "reason", "fromStage"],
+  document_attached: ["documentId", "documentType"],
+  note_added: ["note"],
+};
+
+const ISO_KEYS = new Set(["scheduledAt", "followUpAt"]);
+const ARRAY_KEYS = new Set(["documentIds"]);
+const INTEGER_KEYS = new Set(["durationMinutes", "answerCount"]);
+const OBJECT_KEYS = new Set(["policy"]);
+
+export interface ApplicationEventCommandInput {
+  type: unknown;
+  occurredAt?: unknown;
+  idempotencyKey?: unknown;
+  expectedUpdatedAt?: unknown;
+  source?: unknown;
+  actor?: unknown;
+  metadata?: unknown;
+}
+
+export interface ParsedApplicationEventCommand {
+  type: ApplicationEventType;
+  occurredAt: Date;
+  idempotencyKey?: string;
+  expectedUpdatedAt?: Date;
+  source: string | null;
+  actor: string | null;
+  metadata: Record<string, unknown>;
+  contactId: string | null;
+  outcome: string | null;
+}
+
+export interface EventProjectionApplication {
+  status: string;
+  currentStage: string | null;
+  followUpAt: Date | null;
+}
+
+export interface EventProjectionPatch {
+  status?: ApplicationStatus;
+  currentStage?: string | null;
+  appliedAt?: Date | null;
+  lastContact?: Date | null;
+  followUpAt?: Date | null;
+}
+
+export interface EventCursor {
+  version: 1;
+  occurredAt: string;
+  id: string;
+}
+
+export interface ParsedEventQuery {
+  applicationId?: string;
+  company?: string;
+  types?: ApplicationEventType[];
+  occurredAfter?: Date;
+  occurredBefore?: Date;
+  source?: string;
+  actor?: string;
+  contactId?: string;
+  outcome?: string;
+  cursor?: EventCursor;
+  order: EventOrder;
+  limit: number;
+}
+
+function invalidMetadata(): never {
+  throw new Error("event_metadata_invalid");
+}
+
+function parseDate(value: unknown, errorCode: string): Date {
+  if (typeof value !== "string" && !(value instanceof Date)) {
+    throw new Error(errorCode);
+  }
+  const date = value instanceof Date ? new Date(value) : new Date(value);
+  if (Number.isNaN(date.getTime())) throw new Error(errorCode);
+  return date;
+}
+
+function optionalString(
+  value: unknown,
+  maxLength = 255,
+): string | null {
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string") invalidMetadata();
+  const normalized = value.trim();
+  if (!normalized || normalized.length > maxLength) invalidMetadata();
+  return normalized;
+}
+
+function parseMetadata(
+  type: ApplicationEventType,
+  value: unknown,
+): Record<string, unknown> {
+  if (value === undefined || value === null) value = {};
+  if (typeof value !== "object" || Array.isArray(value)) invalidMetadata();
+  const raw = value as Record<string, unknown>;
+  const entries = Object.entries(raw);
+  if (entries.length > 100 || entries.some(([key]) => !key || key.length > 100)) {
+    invalidMetadata();
+  }
+  const allowed = new Set(EVENT_KEYS[type]);
+  if (entries.some(([key]) => !allowed.has(key))) invalidMetadata();
+
+  const metadata: Record<string, unknown> = {};
+  for (const [key, item] of entries) {
+    if (item === undefined || item === null || item === "") continue;
+    if (ISO_KEYS.has(key)) {
+      metadata[key] = parseDate(item, "event_metadata_invalid").toISOString();
+      continue;
+    }
+    if (ARRAY_KEYS.has(key)) {
+      if (!Array.isArray(item) || item.length > 20) invalidMetadata();
+      const values = item.map((entry) => optionalString(entry));
+      if (values.some((entry) => entry === null)) invalidMetadata();
+      metadata[key] = values;
+      continue;
+    }
+    if (INTEGER_KEYS.has(key)) {
+      if (!Number.isInteger(item)) invalidMetadata();
+      const number = item as number;
+      const max = key === "durationMinutes" ? 1_440 : 50;
+      const min = key === "durationMinutes" ? 1 : 0;
+      if (number < min || number > max) invalidMetadata();
+      metadata[key] = number;
+      continue;
+    }
+    if (OBJECT_KEYS.has(key)) {
+      if (typeof item !== "object" || Array.isArray(item)) invalidMetadata();
+      metadata[key] = item;
+      continue;
+    }
+    if (key === "toStatus" || key === "fromStatus") {
+      const status = optionalString(item) as ApplicationStatus | null;
+      if (!status || !STATUS_SET.has(status)) invalidMetadata();
+      metadata[key] = status;
+      continue;
+    }
+    const maxLength = key === "note" ? 5_000 : key === "reason" || key === "nextAction" ? 2_000 : 255;
+    const normalized = optionalString(item, maxLength);
+    if (normalized !== null) metadata[key] = normalized;
+  }
+
+  const required: Partial<Record<ApplicationEventType, readonly string[]>> = {
+    stage_changed: ["toStage"],
+    interview_scheduled: ["interviewType", "scheduledAt"],
+    follow_up_scheduled: ["followUpAt"],
+    document_attached: ["documentId"],
+    note_added: ["note"],
+  };
+  if (required[type]?.some((key) => metadata[key] === undefined)) {
+    invalidMetadata();
+  }
+  if (Buffer.byteLength(JSON.stringify(metadata), "utf8") > 32_000) {
+    throw new Error("event_metadata_too_large");
+  }
+  return metadata;
+}
+
+export function parseApplicationEventCommand(
+  input: ApplicationEventCommandInput,
+): ParsedApplicationEventCommand {
+  const rawType = typeof input.type === "string" ? input.type.trim() : "";
+  if (!EVENT_TYPE_SET.has(rawType)) throw new Error("event_type_invalid");
+  const type = rawType as ApplicationEventType;
+
+  const idempotencyKey = input.idempotencyKey == null
+    ? undefined
+    : typeof input.idempotencyKey === "string"
+      ? input.idempotencyKey.trim()
+      : "";
+  if (idempotencyKey !== undefined && (idempotencyKey.length < 8 || idempotencyKey.length > 128)) {
+    throw new Error("idempotency_key_invalid");
+  }
+  if (idempotencyKey && input.occurredAt == null) {
+    throw new Error("occurred_at_required_for_idempotency");
+  }
+
+  const occurredAt = input.occurredAt == null
+    ? new Date()
+    : parseDate(input.occurredAt, "event_occurred_at_invalid");
+  const expectedUpdatedAt = input.expectedUpdatedAt == null
+    ? undefined
+    : parseDate(input.expectedUpdatedAt, "invalid_expected_updated_at");
+  const source = optionalString(input.source);
+  const actor = optionalString(input.actor);
+  const metadata = parseMetadata(type, input.metadata);
+
+  return {
+    type,
+    occurredAt,
+    ...(idempotencyKey ? { idempotencyKey } : {}),
+    ...(expectedUpdatedAt ? { expectedUpdatedAt } : {}),
+    source,
+    actor,
+    metadata,
+    contactId: typeof metadata.contactId === "string" ? metadata.contactId : null,
+    outcome: typeof metadata.outcome === "string" ? metadata.outcome : null,
+  };
+}
+
+function metadataString(
+  metadata: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  return typeof metadata[key] === "string" ? metadata[key] as string : undefined;
+}
+
+export function deriveEventProjection(
+  command: Pick<ParsedApplicationEventCommand, "type" | "occurredAt" | "metadata">,
+  application: EventProjectionApplication,
+): { patch: EventProjectionPatch; metadata: Record<string, unknown> } {
+  const patch: EventProjectionPatch = {};
+  const metadata = { ...command.metadata };
+  const currentStatus = STATUS_SET.has(application.status as ApplicationStatus)
+    ? application.status as ApplicationStatus
+    : undefined;
+  const setTransition = (status: ApplicationStatus, stage: string) => {
+    patch.status = status;
+    patch.currentStage = stage;
+    patch.lastContact = command.occurredAt;
+    metadata.fromStage = application.currentStage;
+    metadata.toStage = stage;
+    if (currentStatus) metadata.fromStatus = currentStatus;
+    metadata.toStatus = status;
+  };
+
+  switch (command.type) {
+    case "stage_changed": {
+      const toStage = metadataString(metadata, "toStage")!;
+      patch.currentStage = toStage;
+      metadata.fromStage = application.currentStage;
+      const toStatus = metadataString(metadata, "toStatus") as ApplicationStatus | undefined;
+      if (toStatus) {
+        patch.status = toStatus;
+        if (currentStatus) metadata.fromStatus = currentStatus;
+      }
+      break;
+    }
+    case "interview_invited": {
+      const stage = metadataString(metadata, "toStage") ?? "interview_invited";
+      setTransition("interview", stage);
+      const followUpAt = metadataString(metadata, "followUpAt");
+      if (followUpAt) patch.followUpAt = new Date(followUpAt);
+      break;
+    }
+    case "interview_scheduled": {
+      const stage = metadataString(metadata, "toStage") ?? "interview_scheduled";
+      setTransition("interview", stage);
+      patch.followUpAt = new Date(metadataString(metadata, "scheduledAt")!);
+      break;
+    }
+    case "interview_completed": {
+      const stage = metadataString(metadata, "toStage") ?? "interview_completed";
+      setTransition("interview", stage);
+      const followUpAt = metadataString(metadata, "followUpAt");
+      if (followUpAt) patch.followUpAt = new Date(followUpAt);
+      break;
+    }
+    case "recruiter_contacted":
+    case "feedback_received": {
+      patch.lastContact = command.occurredAt;
+      const toStage = metadataString(metadata, "toStage");
+      const followUpAt = metadataString(metadata, "followUpAt");
+      if (toStage) {
+        patch.currentStage = toStage;
+        metadata.fromStage = application.currentStage;
+      }
+      if (followUpAt) patch.followUpAt = new Date(followUpAt);
+      break;
+    }
+    case "follow_up_scheduled":
+      patch.followUpAt = new Date(metadataString(metadata, "followUpAt")!);
+      break;
+    case "offer_received": {
+      setTransition("offer", "offer_received");
+      const followUpAt = metadataString(metadata, "followUpAt");
+      if (followUpAt) patch.followUpAt = new Date(followUpAt);
+      break;
+    }
+    case "application_rejected":
+      setTransition("rejected", "rejected");
+      patch.followUpAt = null;
+      break;
+    case "application_submitted": {
+      patch.status = "applied";
+      patch.appliedAt = command.occurredAt;
+      const followUpAt = metadataString(metadata, "followUpAt");
+      if (followUpAt) patch.followUpAt = new Date(followUpAt);
+      if (currentStatus) metadata.fromStatus = currentStatus;
+      metadata.toStatus = "applied";
+      break;
+    }
+    default:
+      break;
+  }
+  return { patch, metadata };
+}
+
+export function encodeEventCursor(cursor: EventCursor): string {
+  return Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url");
+}
+
+export function decodeEventCursor(value: string): EventCursor {
+  try {
+    const parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8")) as Partial<EventCursor>;
+    if (
+      parsed.version !== 1
+      || typeof parsed.id !== "string"
+      || !parsed.id
+      || typeof parsed.occurredAt !== "string"
+    ) throw new Error("invalid");
+    const occurredAt = parseDate(parsed.occurredAt, "event_query_invalid").toISOString();
+    return { version: 1, id: parsed.id, occurredAt };
+  } catch {
+    throw new Error("event_query_invalid");
+  }
+}
+
+function queryString(value: unknown): string | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+  if (typeof value !== "string") throw new Error("event_query_invalid");
+  const normalized = value.trim();
+  if (!normalized || normalized.length > 255) throw new Error("event_query_invalid");
+  return normalized;
+}
+
+export function parseEventQuery(input: Record<string, unknown>): ParsedEventQuery {
+  let types: ApplicationEventType[] | undefined;
+  if (input.types !== undefined) {
+    const raw = Array.isArray(input.types)
+      ? input.types
+      : typeof input.types === "string"
+        ? input.types.split(",")
+        : [];
+    const normalized = raw.map((type) => typeof type === "string" ? type.trim() : "");
+    if (!normalized.length || normalized.some((type) => !EVENT_TYPE_SET.has(type))) {
+      throw new Error("event_query_invalid");
+    }
+    types = [...new Set(normalized)] as ApplicationEventType[];
+  }
+  const rawLimit = input.limit == null ? 50 : Number(input.limit);
+  if (!Number.isFinite(rawLimit) || rawLimit <= 0) throw new Error("event_query_invalid");
+  const order = input.order == null ? "newest" : input.order;
+  if (order !== "newest" && order !== "oldest") throw new Error("event_query_invalid");
+  const occurredAfter = input.occurredAfter == null
+    ? undefined
+    : parseDate(input.occurredAfter, "event_query_invalid");
+  const occurredBefore = input.occurredBefore == null
+    ? undefined
+    : parseDate(input.occurredBefore, "event_query_invalid");
+  if (occurredAfter && occurredBefore && occurredAfter > occurredBefore) {
+    throw new Error("event_query_invalid");
+  }
+  return {
+    ...(queryString(input.applicationId) ? { applicationId: queryString(input.applicationId) } : {}),
+    ...(queryString(input.company) ? { company: queryString(input.company) } : {}),
+    ...(types ? { types } : {}),
+    ...(occurredAfter ? { occurredAfter } : {}),
+    ...(occurredBefore ? { occurredBefore } : {}),
+    ...(queryString(input.source) ? { source: queryString(input.source) } : {}),
+    ...(queryString(input.actor) ? { actor: queryString(input.actor) } : {}),
+    ...(queryString(input.contactId) ? { contactId: queryString(input.contactId) } : {}),
+    ...(queryString(input.outcome) ? { outcome: queryString(input.outcome) } : {}),
+    ...(input.cursor ? { cursor: decodeEventCursor(String(input.cursor)) } : {}),
+    order,
+    limit: Math.min(100, Math.floor(rawLimit)),
+  };
+}
+
+export function validateApplicationSummary(value: unknown): string | null {
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string") throw new Error("notes_invalid");
+  if (value.length > 10_000) throw new Error("notes_too_long");
+  return value;
+}

--- a/lib/db/__tests__/firestore-adapter.test.ts
+++ b/lib/db/__tests__/firestore-adapter.test.ts
@@ -76,41 +76,72 @@ function makeDocRef(store: Map<string, Record<string, unknown>>, id: string): Mo
 function makeQuery(
   store: Map<string, Record<string, unknown>>,
   filters: Array<{ field: string; operator: string; value: unknown }> = [],
-  sort?: { field: string; direction: "asc" | "desc" },
+  sorts: Array<{ field: string; direction: "asc" | "desc" }> = [],
   max?: number,
+  after?: unknown[],
 ) {
+  const normalize = (item: unknown) => {
+    if (item && typeof item === "object" && "toDate" in item) {
+      return (item as { toDate: () => Date }).toDate().getTime();
+    }
+    if (item instanceof Date) return item.getTime();
+    return item ?? "";
+  };
+  const fieldValue = (id: string, data: Record<string, unknown>, field: string) =>
+    field === "__name__" ? id : data[field];
+  const compareValues = (left: unknown, right: unknown) => {
+    const a = normalize(left);
+    const b = normalize(right);
+    return a < b ? -1 : a > b ? 1 : 0;
+  };
   return {
     where(field: string, operator: string, value: unknown) {
-      if (!["==", "array-contains", "in"].includes(operator)) {
+      if (!["==", "array-contains", "in", ">=", "<="].includes(operator)) {
         throw new Error(`Unsupported mock operator: ${operator}`);
       }
-      return makeQuery(store, [...filters, { field, operator, value }], sort, max);
+      return makeQuery(store, [...filters, { field, operator, value }], sorts, max, after);
     },
     orderBy(field: string, direction: "asc" | "desc" = "asc") {
-      return makeQuery(store, filters, { field, direction }, max);
+      return makeQuery(store, filters, [...sorts, { field, direction }], max, after);
     },
     limit(value: number) {
-      return makeQuery(store, filters, sort, value);
+      return makeQuery(store, filters, sorts, value, after);
+    },
+    startAfter(...values: unknown[]) {
+      return makeQuery(store, filters, sorts, max, values);
     },
     async get() {
-      let entries = Array.from(store.entries()).filter(([, data]) =>
+      let entries = Array.from(store.entries()).filter(([id, data]) =>
         filters.every(({ field, operator, value }) => {
-          if (operator === "==") return data[field] === value;
-          if (operator === "array-contains") return Array.isArray(data[field]) && data[field].includes(value);
-          return Array.isArray(value) && value.includes(data[field]);
+          const actual = fieldValue(id, data, field);
+          if (operator === "==") return actual === value;
+          if (operator === "array-contains") return Array.isArray(actual) && actual.includes(value);
+          if (operator === "in") return Array.isArray(value) && value.includes(actual);
+          const comparison = compareValues(actual, value);
+          return operator === ">=" ? comparison >= 0 : comparison <= 0;
         }),
       );
-      if (sort) {
-        entries.sort(([, left], [, right]) => {
-          const a = left[sort.field] as { toDate?: () => Date } | Date | number | string | undefined;
-          const b = right[sort.field] as { toDate?: () => Date } | Date | number | string | undefined;
-          const normalize = (item: typeof a) => {
-            if (item && typeof item === "object" && "toDate" in item && item.toDate) return item.toDate().getTime();
-            if (item instanceof Date) return item.getTime();
-            return item ?? "";
-          };
-          const result = normalize(a) < normalize(b) ? -1 : normalize(a) > normalize(b) ? 1 : 0;
-          return sort.direction === "desc" ? -result : result;
+      if (sorts.length) {
+        entries.sort(([leftId, left], [rightId, right]) => {
+          for (const sort of sorts) {
+            const result = compareValues(
+              fieldValue(leftId, left, sort.field),
+              fieldValue(rightId, right, sort.field),
+            );
+            if (result) return sort.direction === "desc" ? -result : result;
+          }
+          return 0;
+        });
+      }
+      if (after?.length) {
+        entries = entries.filter(([id, data]) => {
+          for (let index = 0; index < sorts.length; index += 1) {
+            const sort = sorts[index];
+            const result = compareValues(fieldValue(id, data, sort.field), after[index]);
+            if (!result) continue;
+            return sort.direction === "desc" ? result < 0 : result > 0;
+          }
+          return false;
         });
       }
       if (max !== undefined) entries = entries.slice(0, max);
@@ -205,6 +236,9 @@ vi.mock("firebase-admin/firestore", () => ({
   Timestamp: {
     now: () => mockTimestamp,
     fromDate: (d: Date) => ({ toDate: () => d }),
+  },
+  FieldPath: {
+    documentId: () => "__name__",
   },
   FieldValue: {
     serverTimestamp: () => mockTimestamp,
@@ -1231,6 +1265,54 @@ describe("FirestoreAdapter — first-class application events", () => {
     })).rejects.toThrow("conflict");
     expect(stores.applicationEvents.size).toBe(0);
     expect(stores.applications.get("app-1")!.status).toBe("applied");
+  });
+
+  it("allows unrelated updates to preserve an oversized legacy summary unchanged", async () => {
+    seedEventApplication();
+    const legacyNotes = "x".repeat(10_001);
+    stores.applications.set("app-1", { ...stores.applications.get("app-1")!, notes: legacyNotes });
+    await expect(new FirestoreAdapter().updateApplication("app-1", userId, {
+      company: "Acme 2",
+      notes: legacyNotes,
+    })).resolves.toMatchObject({ company: "Acme 2", notes: legacyNotes });
+  });
+
+  it("still rejects a newly changed oversized summary", async () => {
+    seedEventApplication();
+    stores.applications.set("app-1", { ...stores.applications.get("app-1")!, notes: "legacy" });
+    await expect(new FirestoreAdapter().updateApplication("app-1", userId, {
+      notes: "x".repeat(10_001),
+    })).rejects.toThrow("notes_too_long");
+  });
+
+  it("continues sparse in-memory filters with a bounded scan cursor", async () => {
+    seedApps([
+      { id: "app-acme", userId, company: "Acme", role: "Engineer" },
+      { id: "app-beta", userId, company: "Beta", role: "Engineer" },
+    ]);
+    const timestamp = { toDate: () => new Date("2026-07-24T09:00:00Z") };
+    for (let id = 1; id <= 7; id += 1) {
+      stores.applicationEvents.set(String(id), {
+        userId,
+        applicationId: id === 1 ? "app-beta" : "app-acme",
+        type: "stage_changed",
+        occurredAt: timestamp,
+        createdAt: timestamp,
+      });
+    }
+    const adapter = new FirestoreAdapter();
+    const first = await adapter.listApplicationEventsFiltered(userId, {
+      company: "Beta", order: "newest", limit: 1,
+    });
+    expect(first.items).toEqual([]);
+    expect(first.nextCursor).toBeTruthy();
+    const { decodeEventCursor } = await import("../../applications/events");
+    const second = await adapter.listApplicationEventsFiltered(userId, {
+      company: "Beta", order: "newest", limit: 1,
+      cursor: decodeEventCursor(first.nextCursor!),
+    });
+    expect(second.items.map((event) => event.id)).toEqual(["1"]);
+    expect(second.nextCursor).toBeNull();
   });
 
   it("uses the same lexical ID tie-breaker for sorting and cursors", async () => {

--- a/lib/db/__tests__/firestore-adapter.test.ts
+++ b/lib/db/__tests__/firestore-adapter.test.ts
@@ -1185,6 +1185,39 @@ describe("FirestoreAdapter — first-class application events", () => {
     expect(stores.applicationEvents.size).toBe(1);
   });
 
+  it.each([
+    {
+      label: "contact",
+      seed: () => stores.contacts.set("contact-1", { applicationId: "other-app", name: "Recruiter" }),
+      input: { contactId: "contact-1", metadata: { toStage: "technical" } },
+      code: "contact_not_found",
+    },
+    {
+      label: "document",
+      seed: () => stores.documents.set("document-1", { userId, applicationIds: ["other-app"] }),
+      input: { contactId: null, metadata: { toStage: "technical", documentId: "document-1" } },
+      code: "document_not_found",
+    },
+    {
+      label: "submission",
+      seed: () => stores.applicationSubmissions.set("submission-1", { userId, applicationId: "other-app" }),
+      input: { contactId: null, metadata: { toStage: "technical", submissionId: "submission-1" } },
+      code: "submission_not_found",
+    },
+  ])("rejects a linked $label outside the owner/application boundary", async ({ seed, input, code }) => {
+    seedEventApplication();
+    seed();
+    await expect(new FirestoreAdapter().recordApplicationEvent("app-1", userId, {
+      type: "stage_changed",
+      occurredAt: new Date("2026-07-24T09:00:00Z"),
+      idempotencyKey: `missing-${code}`,
+      source: "test",
+      outcome: null,
+      ...input,
+    })).rejects.toThrow(code);
+    expect(stores.applicationEvents.size).toBe(0);
+  });
+
   it("rejects stale commands without writing an event", async () => {
     seedEventApplication();
     const adapter = new FirestoreAdapter();

--- a/lib/db/__tests__/firestore-adapter.test.ts
+++ b/lib/db/__tests__/firestore-adapter.test.ts
@@ -1316,7 +1316,7 @@ describe("FirestoreAdapter — first-class application events", () => {
     })).rejects.toThrow("notes_too_long");
   });
 
-  it("continues sparse in-memory filters with a bounded scan cursor", async () => {
+  it("skips sparse scan windows before returning a filtered page", async () => {
     seedApps([
       { id: "app-acme", userId, company: "Acme", role: "Engineer" },
       { id: "app-beta", userId, company: "Beta", role: "Engineer" },
@@ -1332,18 +1332,11 @@ describe("FirestoreAdapter — first-class application events", () => {
       });
     }
     const adapter = new FirestoreAdapter();
-    const first = await adapter.listApplicationEventsFiltered(userId, {
+    const page = await adapter.listApplicationEventsFiltered(userId, {
       company: "Beta", order: "newest", limit: 1,
     });
-    expect(first.items).toEqual([]);
-    expect(first.nextCursor).toBeTruthy();
-    const { decodeEventCursor } = await import("../../applications/events");
-    const second = await adapter.listApplicationEventsFiltered(userId, {
-      company: "Beta", order: "newest", limit: 1,
-      cursor: decodeEventCursor(first.nextCursor!),
-    });
-    expect(second.items.map((event) => event.id)).toEqual(["1"]);
-    expect(second.nextCursor).toBeNull();
+    expect(page.items.map((event) => event.id)).toEqual(["1"]);
+    expect(page.nextCursor).toBeNull();
   });
 
   it("uses the same lexical ID tie-breaker for sorting and cursors", async () => {

--- a/lib/db/__tests__/firestore-adapter.test.ts
+++ b/lib/db/__tests__/firestore-adapter.test.ts
@@ -435,6 +435,20 @@ describe("FirestoreAdapter — application metadata", () => {
     expect(Array.from(stores.applicationCanonicalUrls.values())[0].canonicalJobUrl)
       .toBe("https://example.com/jobs/1");
   });
+
+  it("rejects lifecycle fields in batch updates", async () => {
+    const adapter = new FirestoreAdapter();
+    const result = await adapter.batchUpsertApplications("user-1", [{
+      id: "app-1",
+      status: "interview",
+    }]);
+
+    expect(result).toMatchObject({
+      succeeded: 0,
+      failed: 1,
+      results: [{ error: "lifecycle_event_required" }],
+    });
+  });
 });
 
 describe("FirestoreAdapter — retryable application deletion", () => {

--- a/lib/db/__tests__/firestore-adapter.test.ts
+++ b/lib/db/__tests__/firestore-adapter.test.ts
@@ -1073,3 +1073,173 @@ describe("FirestoreAdapter — document operations", () => {
     });
   });
 });
+
+describe("FirestoreAdapter — first-class application events", () => {
+  const userId = "user-1";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.values(stores).forEach((store) => store.clear());
+    mockGetAll.mockImplementation(async (...refs: MockDocRef[]) =>
+      Promise.all(refs.map((ref) => ref.get())),
+    );
+  });
+
+  function seedEventApplication() {
+    stores.applications.set("app-1", {
+      userId,
+      company: "Acme",
+      role: "Engineer",
+      status: "applied",
+      currentStage: "recruiter_screen",
+      followUpAt: { toDate: () => new Date("2026-07-25T10:00:00Z") },
+      createdAt: mockTimestamp,
+      updatedAt: mockTimestamp,
+    });
+  }
+
+  it("atomically records an interview schedule and updates the projection", async () => {
+    seedEventApplication();
+    const adapter = new FirestoreAdapter();
+    const result = await adapter.recordApplicationEvent("app-1", userId, {
+      type: "interview_scheduled",
+      occurredAt: new Date("2026-07-24T09:00:00Z"),
+      idempotencyKey: "schedule-123",
+      source: "test",
+      metadata: {
+        interviewType: "technical",
+        scheduledAt: "2026-07-28T12:30:00.000Z",
+      },
+      contactId: null,
+      outcome: null,
+    });
+
+    expect(result.replayed).toBe(false);
+    expect(result.application).toMatchObject({ status: "interview", currentStage: "interview_scheduled" });
+    expect(result.application.followUpAt?.toISOString()).toBe("2026-07-28T12:30:00.000Z");
+    expect(result.event.metadata).toMatchObject({
+      fromStage: "recruiter_screen",
+      toStage: "interview_scheduled",
+      fromStatus: "applied",
+      toStatus: "interview",
+    });
+    expect(stores.applicationEvents.size).toBe(1);
+    expect(result.event.metadata).not.toHaveProperty("requestHash");
+    expect([...stores.applicationEvents.values()][0].requestHash).toEqual(expect.any(String));
+  });
+
+  it("replays the same command once and rejects a changed payload", async () => {
+    seedEventApplication();
+    const adapter = new FirestoreAdapter();
+    const base = {
+      type: "follow_up_scheduled" as const,
+      occurredAt: new Date("2026-07-24T09:00:00Z"),
+      idempotencyKey: "follow-up-123",
+      source: "test",
+      metadata: { followUpAt: "2026-07-30T09:00:00.000Z" },
+      contactId: null,
+      outcome: null,
+    };
+    await adapter.recordApplicationEvent("app-1", userId, base);
+    const replay = await adapter.recordApplicationEvent("app-1", userId, base);
+    expect(replay.replayed).toBe(true);
+    expect(stores.applicationEvents.size).toBe(1);
+    await expect(adapter.recordApplicationEvent("app-1", userId, {
+      ...base,
+      metadata: { followUpAt: "2026-07-31T09:00:00.000Z" },
+    })).rejects.toThrow("idempotency_conflict");
+  });
+
+  it("replays a legacy idempotency hash after migration", async () => {
+    seedEventApplication();
+    const command = {
+      type: "follow_up_scheduled" as const,
+      occurredAt: new Date("2026-07-24T09:00:00Z"),
+      idempotencyKey: "legacy-follow-up",
+      source: "test",
+      metadata: { followUpAt: "2026-07-30T09:00:00.000Z" },
+      contactId: null,
+      outcome: null,
+    };
+    const legacyHash = submissionRequestHash({
+      applicationId: "app-1",
+      type: command.type,
+      occurredAt: command.occurredAt,
+      metadata: command.metadata,
+    });
+    const eventId = submissionRequestHash({ userId, key: command.idempotencyKey }).slice(0, 40);
+    stores.applicationEvents.set(eventId, {
+      userId,
+      applicationId: "app-1",
+      type: command.type,
+      idempotencyKey: command.idempotencyKey,
+      occurredAt: mockTimestamp,
+      createdAt: mockTimestamp,
+      metadata: { ...command.metadata, requestHash: legacyHash },
+    });
+
+    const replay = await new FirestoreAdapter().recordApplicationEvent("app-1", userId, command);
+    expect(replay.replayed).toBe(true);
+    expect(replay.event.metadata).not.toHaveProperty("requestHash");
+    expect(replay.event).not.toHaveProperty("requestHash");
+    expect(stores.applicationEvents.size).toBe(1);
+  });
+
+  it("rejects stale commands without writing an event", async () => {
+    seedEventApplication();
+    const adapter = new FirestoreAdapter();
+    await expect(adapter.recordApplicationEvent("app-1", userId, {
+      type: "application_rejected",
+      occurredAt: new Date("2026-07-24T09:00:00Z"),
+      expectedUpdatedAt: new Date("2026-01-01T00:00:00Z"),
+      metadata: { outcome: "declined" },
+      contactId: null,
+      outcome: "declined",
+    })).rejects.toThrow("conflict");
+    expect(stores.applicationEvents.size).toBe(0);
+    expect(stores.applications.get("app-1")!.status).toBe("applied");
+  });
+
+  it("uses the same lexical ID tie-breaker for sorting and cursors", async () => {
+    seedApps([{ id: "app-1", userId, company: "Acme", role: "Engineer" }]);
+    const timestamp = { toDate: () => new Date("2026-07-24T09:00:00Z") };
+    stores.applicationEvents.set("2", { userId, applicationId: "app-1", type: "stage_changed", occurredAt: timestamp, createdAt: timestamp });
+    stores.applicationEvents.set("10", { userId, applicationId: "app-1", type: "stage_changed", occurredAt: timestamp, createdAt: timestamp });
+    const adapter = new FirestoreAdapter();
+    const first = await adapter.listApplicationEventsFiltered(userId, { order: "newest", limit: 1 });
+    expect(first.items.map((event) => event.id)).toEqual(["2"]);
+    const { decodeEventCursor } = await import("../../applications/events");
+    const second = await adapter.listApplicationEventsFiltered(userId, {
+      order: "newest", limit: 1, cursor: decodeEventCursor(first.nextCursor!),
+    });
+    expect(second.items.map((event) => event.id)).toEqual(["10"]);
+    const legacyList = await adapter.listApplicationEvents("app-1", userId, 2);
+    expect(legacyList.map((event) => event.id)).toEqual(["2", "10"]);
+  });
+
+  it("paginates owner-scoped filtered activity deterministically", async () => {
+    seedApps([
+      { id: "app-1", userId, company: "Acme", role: "Engineer" },
+      { id: "app-2", userId, company: "Beta", role: "Platform Engineer" },
+    ]);
+    const timestamp = { toDate: () => new Date("2026-07-24T09:00:00Z") };
+    stores.applicationEvents.set("1", { userId, applicationId: "app-1", type: "stage_changed", occurredAt: timestamp, createdAt: timestamp });
+    stores.applicationEvents.set("2", { userId, applicationId: "app-2", type: "stage_changed", occurredAt: timestamp, createdAt: timestamp });
+    stores.applicationEvents.set("3", { userId: "other", applicationId: "app-1", type: "stage_changed", occurredAt: timestamp, createdAt: timestamp });
+    const adapter = new FirestoreAdapter();
+    const first = await adapter.listApplicationEventsFiltered(userId, {
+      types: ["stage_changed"], order: "newest", limit: 1,
+    });
+    expect(first.items).toHaveLength(1);
+    expect(first.items[0].id).toBe("2");
+    expect(first.items[0].application?.company).toBe("Beta");
+    expect(first.nextCursor).toBeTruthy();
+    const { decodeEventCursor } = await import("../../applications/events");
+    const second = await adapter.listApplicationEventsFiltered(userId, {
+      types: ["stage_changed"], order: "newest", limit: 1,
+      cursor: decodeEventCursor(first.nextCursor!),
+    });
+    expect(second.items.map((event) => event.id)).toEqual(["1"]);
+    expect(second.nextCursor).toBeNull();
+  });
+});

--- a/lib/db/__tests__/firestore-adapter.test.ts
+++ b/lib/db/__tests__/firestore-adapter.test.ts
@@ -1176,6 +1176,23 @@ describe("FirestoreAdapter — first-class application events", () => {
     expect([...stores.applicationEvents.values()][0].requestHash).toEqual(expect.any(String));
   });
 
+  it("touches the application for event-only commands", async () => {
+    seedEventApplication();
+    stores.applications.get("app-1")!.updatedAt = { toDate: () => new Date("2024-01-01") };
+
+    const result = await new FirestoreAdapter().recordApplicationEvent("app-1", userId, {
+      type: "note_added",
+      occurredAt: new Date("2026-07-24T09:00:00Z"),
+      source: "test",
+      metadata: { note: "Chronological update" },
+      contactId: null,
+      outcome: null,
+    });
+
+    expect(result.application.updatedAt.toISOString()).toBe("2025-01-01T00:00:00.000Z");
+    expect(stores.applicationEvents.size).toBe(1);
+  });
+
   it("replays the same command once and rejects a changed payload", async () => {
     seedEventApplication();
     const adapter = new FirestoreAdapter();

--- a/lib/db/__tests__/prisma-application-events.test.ts
+++ b/lib/db/__tests__/prisma-application-events.test.ts
@@ -267,6 +267,20 @@ describe("PrismaAdapter — atomic application events", () => {
     })).rejects.toThrow("notes_too_long");
   });
 
+  it("rejects lifecycle fields in batch updates", async () => {
+    const result = await new PrismaAdapter().batchUpsertApplications("owner-1", [{
+      id: "1",
+      currentStage: "technical",
+    }]);
+
+    expect(result).toMatchObject({
+      succeeded: 0,
+      failed: 1,
+      results: [{ error: "lifecycle_event_required" }],
+    });
+    expect((fake.prisma.application as { update: ReturnType<typeof vi.fn> }).update).not.toHaveBeenCalled();
+  });
+
   it("rolls back projection changes when event creation fails", async () => {
     fake.setFailCreate(true);
     await expect(new PrismaAdapter().recordApplicationEvent("1", "owner-1", command)).rejects.toThrow("event_write_failed");

--- a/lib/db/__tests__/prisma-application-events.test.ts
+++ b/lib/db/__tests__/prisma-application-events.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { submissionRequestHash } from "@/lib/applications/submission";
+
+const fake = vi.hoisted(() => {
+  type Row = Record<string, unknown>;
+  let application: Row;
+  let events: Row[];
+  let failCreate = false;
+
+  const reset = () => {
+    application = {
+      id: 1,
+      userId: "owner-1",
+      company: "Acme",
+      role: "Engineer",
+      status: "applied",
+      appliedAt: new Date("2026-07-01T00:00:00Z"),
+      lastContact: null,
+      followUpAt: null,
+      notes: null,
+      jobDescription: null,
+      source: null,
+      remote: true,
+      salaryMin: null,
+      salaryMax: null,
+      rating: null,
+      jobUrl: null,
+      canonicalJobUrl: null,
+      currentStage: "screen",
+      createdAt: new Date("2026-07-01T00:00:00Z"),
+      updatedAt: new Date("2026-07-24T08:00:00Z"),
+      contacts: [],
+    };
+    events = [];
+    failCreate = false;
+  };
+  reset();
+
+  const prisma: Record<string, unknown> = {};
+  const applicationApi = {
+    findFirst: vi.fn(async ({ where }: { where: { id?: number; userId?: string } }) => {
+      if (where.id !== undefined && where.id !== application.id) return null;
+      if (where.userId !== undefined && where.userId !== application.userId) return null;
+      return { ...application, contacts: [] };
+    }),
+    updateMany: vi.fn(async ({ where, data }: { where: { id: number; userId: string; updatedAt: Date }; data: Row }) => {
+      const matches = where.id === application.id
+        && where.userId === application.userId
+        && where.updatedAt.getTime() === (application.updatedAt as Date).getTime();
+      if (!matches) return { count: 0 };
+      const nextUpdatedAt = data.updatedAt instanceof Date
+        ? data.updatedAt
+        : new Date((application.updatedAt as Date).getTime() + 1_000);
+      application = { ...application, ...data, updatedAt: nextUpdatedAt };
+      return { count: 1 };
+    }),
+    update: vi.fn(async ({ data }: { data: Row }) => {
+      application = { ...application, ...data, updatedAt: new Date((application.updatedAt as Date).getTime() + 1_000) };
+      return { ...application, contacts: [] };
+    }),
+  };
+  const eventApi = {
+    findUnique: vi.fn(async ({ where }: { where: { userId_idempotencyKey: { userId: string; idempotencyKey: string } } }) => {
+      const key = where.userId_idempotencyKey;
+      return events.find((event) => event.userId === key.userId && event.idempotencyKey === key.idempotencyKey) ?? null;
+    }),
+    create: vi.fn(async ({ data }: { data: Row }) => {
+      if (failCreate) throw new Error("event_write_failed");
+      const row = { id: events.length + 1, createdAt: new Date("2026-07-24T09:00:01Z"), contactId: null, outcome: null, ...data };
+      events.push(row);
+      return row;
+    }),
+  };
+  Object.assign(prisma, {
+    application: applicationApi,
+    applicationEvent: eventApi,
+    $transaction: vi.fn(async (callback: (transaction: unknown) => Promise<unknown>) => {
+      const applicationBefore = structuredClone(application);
+      const eventsBefore = structuredClone(events);
+      try {
+        return await callback(prisma);
+      } catch (error) {
+        application = applicationBefore;
+        events = eventsBefore;
+        throw error;
+      }
+    }),
+  });
+
+  return {
+    prisma,
+    reset,
+    app: () => application,
+    events: () => events,
+    seedEvent: (row: Row) => events.push(row),
+    setFailCreate: (value: boolean) => { failCreate = value; },
+  };
+});
+
+vi.mock("@/lib/prisma", () => ({ prisma: fake.prisma }));
+
+import { PrismaAdapter } from "../prisma-adapter";
+
+const command = {
+  type: "stage_changed" as const,
+  occurredAt: new Date("2026-07-24T09:00:00Z"),
+  expectedUpdatedAt: new Date("2026-07-24T08:00:00Z"),
+  idempotencyKey: "stage-change-1",
+  source: "test",
+  actor: "owner@example.com",
+  metadata: { toStage: "technical", toStatus: "interview" },
+  contactId: null,
+  outcome: null,
+};
+
+describe("PrismaAdapter — atomic application events", () => {
+  beforeEach(() => {
+    fake.reset();
+    vi.clearAllMocks();
+  });
+
+  it("updates the projection and creates one immutable event", async () => {
+    const result = await new PrismaAdapter().recordApplicationEvent("1", "owner-1", command);
+    expect(result.replayed).toBe(false);
+    expect(result.application).toMatchObject({ status: "interview", currentStage: "technical" });
+    expect(result.event.metadata).toMatchObject({ fromStage: "screen", toStage: "technical" });
+    expect(result.event.metadata).not.toHaveProperty("requestHash");
+    expect(fake.events()).toHaveLength(1);
+    expect(fake.events()[0].requestHash).toEqual(expect.any(String));
+  });
+
+  it("replays a pre-migration legacy idempotency hash", async () => {
+    const legacyHash = submissionRequestHash({
+      applicationId: "1",
+      type: command.type,
+      occurredAt: command.occurredAt,
+      metadata: command.metadata,
+    });
+    fake.seedEvent({
+      id: 99,
+      userId: "owner-1",
+      applicationId: 1,
+      type: command.type,
+      idempotencyKey: command.idempotencyKey,
+      requestHash: null,
+      occurredAt: command.occurredAt,
+      createdAt: command.occurredAt,
+      source: null,
+      actor: null,
+      contactId: null,
+      outcome: null,
+      metadata: { ...command.metadata, requestHash: legacyHash },
+    });
+
+    const replay = await new PrismaAdapter().recordApplicationEvent("1", "owner-1", command);
+    expect(replay.replayed).toBe(true);
+    expect(replay.event.metadata).not.toHaveProperty("requestHash");
+    expect(replay.event).not.toHaveProperty("requestHash");
+    expect(fake.events()).toHaveLength(1);
+  });
+
+  it("replays an identical idempotent command without another write", async () => {
+    const adapter = new PrismaAdapter();
+    await adapter.recordApplicationEvent("1", "owner-1", command);
+    const replay = await adapter.recordApplicationEvent("1", "owner-1", command);
+    expect(replay.replayed).toBe(true);
+    expect(fake.events()).toHaveLength(1);
+  });
+
+  it("rejects a changed payload for the same idempotency key", async () => {
+    const adapter = new PrismaAdapter();
+    await adapter.recordApplicationEvent("1", "owner-1", command);
+    await expect(adapter.recordApplicationEvent("1", "owner-1", {
+      ...command,
+      metadata: { toStage: "onsite", toStatus: "interview" },
+    })).rejects.toThrow("idempotency_conflict");
+  });
+
+  it("rejects stale and cross-owner commands without an event", async () => {
+    const adapter = new PrismaAdapter();
+    await expect(adapter.recordApplicationEvent("1", "owner-1", {
+      ...command,
+      expectedUpdatedAt: new Date("2026-07-24T07:00:00Z"),
+    })).rejects.toThrow("conflict");
+    await expect(adapter.recordApplicationEvent("1", "other", command)).rejects.toThrow("not_found");
+    expect(fake.events()).toHaveLength(0);
+  });
+
+  it("takes an optimistic write lock for events without projection changes", async () => {
+    const before = fake.app().updatedAt;
+    const noteCommand = {
+      ...command,
+      type: "note_added" as const,
+      idempotencyKey: "note-added-1",
+      metadata: { note: "Chronological update" },
+    };
+    await new PrismaAdapter().recordApplicationEvent("1", "owner-1", noteCommand);
+    expect((fake.prisma.application as { updateMany: ReturnType<typeof vi.fn> }).updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { updatedAt: before } }),
+    );
+    expect(fake.app().updatedAt).toEqual(before);
+    expect(fake.events()).toHaveLength(1);
+  });
+
+  it("rolls back projection changes when event creation fails", async () => {
+    fake.setFailCreate(true);
+    await expect(new PrismaAdapter().recordApplicationEvent("1", "owner-1", command)).rejects.toThrow("event_write_failed");
+    expect(fake.app()).toMatchObject({ status: "applied", currentStage: "screen" });
+    expect(fake.events()).toHaveLength(0);
+  });
+});

--- a/lib/db/__tests__/prisma-application-events.test.ts
+++ b/lib/db/__tests__/prisma-application-events.test.ts
@@ -27,6 +27,7 @@ const fake = vi.hoisted(() => {
       jobUrl: null,
       canonicalJobUrl: null,
       currentStage: "screen",
+      eventVersion: 0,
       createdAt: new Date("2026-07-01T00:00:00Z"),
       updatedAt: new Date("2026-07-24T08:00:00Z"),
       contacts: [],
@@ -43,19 +44,31 @@ const fake = vi.hoisted(() => {
       if (where.userId !== undefined && where.userId !== application.userId) return null;
       return { ...application, contacts: [] };
     }),
-    updateMany: vi.fn(async ({ where, data }: { where: { id: number; userId: string; updatedAt: Date }; data: Row }) => {
+    updateMany: vi.fn(async ({ where, data }: { where: { id: number; userId: string; updatedAt?: Date; eventVersion?: number }; data: Row }) => {
       const matches = where.id === application.id
         && where.userId === application.userId
-        && where.updatedAt.getTime() === (application.updatedAt as Date).getTime();
+        && (where.updatedAt === undefined || where.updatedAt.getTime() === (application.updatedAt as Date).getTime())
+        && (where.eventVersion === undefined || where.eventVersion === application.eventVersion);
       if (!matches) return { count: 0 };
-      const nextUpdatedAt = data.updatedAt instanceof Date
-        ? data.updatedAt
-        : new Date((application.updatedAt as Date).getTime() + 1_000);
-      application = { ...application, ...data, updatedAt: nextUpdatedAt };
+      const nextData = { ...data };
+      if (typeof data.eventVersion === "object" && data.eventVersion !== null) {
+        nextData.eventVersion = Number(application.eventVersion) + Number((data.eventVersion as { increment: number }).increment);
+      }
+      application = {
+        ...application,
+        ...nextData,
+        updatedAt: new Date((application.updatedAt as Date).getTime() + 1_000),
+      };
       return { count: 1 };
     }),
     update: vi.fn(async ({ data }: { data: Row }) => {
-      application = { ...application, ...data, updatedAt: new Date((application.updatedAt as Date).getTime() + 1_000) };
+      const increment = (data.eventVersion as { increment?: number } | undefined)?.increment ?? 0;
+      application = {
+        ...application,
+        ...data,
+        eventVersion: Number(application.eventVersion) + increment,
+        updatedAt: new Date((application.updatedAt as Date).getTime() + 1_000),
+      };
       return { ...application, contacts: [] };
     }),
   };
@@ -102,6 +115,7 @@ const fake = vi.hoisted(() => {
     contactCount: contactApi.count,
     documentCount: documentApi.count,
     submissionCount: submissionApi.count,
+    setApplication: (update: Row) => { application = { ...application, ...update }; },
     setFailCreate: (value: boolean) => { failCreate = value; },
   };
 });
@@ -230,10 +244,27 @@ describe("PrismaAdapter — atomic application events", () => {
     };
     await new PrismaAdapter().recordApplicationEvent("1", "owner-1", noteCommand);
     expect((fake.prisma.application as { updateMany: ReturnType<typeof vi.fn> }).updateMany).toHaveBeenCalledWith(
-      expect.objectContaining({ data: { updatedAt: before } }),
+      expect.objectContaining({ data: { eventVersion: { increment: 1 } } }),
     );
-    expect(fake.app().updatedAt).toEqual(before);
+    expect(fake.app().eventVersion).toBe(1);
+    expect((fake.app().updatedAt as Date).getTime()).toBeGreaterThan((before as Date).getTime());
     expect(fake.events()).toHaveLength(1);
+  });
+
+  it("allows unrelated updates to preserve an oversized legacy summary unchanged", async () => {
+    const legacyNotes = "x".repeat(10_001);
+    fake.setApplication({ notes: legacyNotes });
+    await expect(new PrismaAdapter().updateApplication("1", "owner-1", {
+      company: "Acme 2",
+      notes: legacyNotes,
+    })).resolves.toMatchObject({ company: "Acme 2", notes: legacyNotes });
+  });
+
+  it("still rejects a newly changed oversized summary", async () => {
+    fake.setApplication({ notes: "legacy" });
+    await expect(new PrismaAdapter().updateApplication("1", "owner-1", {
+      notes: "x".repeat(10_001),
+    })).rejects.toThrow("notes_too_long");
   });
 
   it("rolls back projection changes when event creation fails", async () => {

--- a/lib/db/__tests__/prisma-application-events.test.ts
+++ b/lib/db/__tests__/prisma-application-events.test.ts
@@ -71,9 +71,15 @@ const fake = vi.hoisted(() => {
       return row;
     }),
   };
+  const contactApi = { count: vi.fn(async () => 1) };
+  const documentApi = { count: vi.fn(async () => 1) };
+  const submissionApi = { count: vi.fn(async () => 1) };
   Object.assign(prisma, {
     application: applicationApi,
     applicationEvent: eventApi,
+    contact: contactApi,
+    document: documentApi,
+    applicationSubmission: submissionApi,
     $transaction: vi.fn(async (callback: (transaction: unknown) => Promise<unknown>) => {
       const applicationBefore = structuredClone(application);
       const eventsBefore = structuredClone(events);
@@ -93,6 +99,9 @@ const fake = vi.hoisted(() => {
     app: () => application,
     events: () => events,
     seedEvent: (row: Row) => events.push(row),
+    contactCount: contactApi.count,
+    documentCount: documentApi.count,
+    submissionCount: submissionApi.count,
     setFailCreate: (value: boolean) => { failCreate = value; },
   };
 });
@@ -174,6 +183,31 @@ describe("PrismaAdapter — atomic application events", () => {
       ...command,
       metadata: { toStage: "onsite", toStatus: "interview" },
     })).rejects.toThrow("idempotency_conflict");
+  });
+
+  it.each([
+    {
+      label: "contact",
+      fail: () => fake.contactCount.mockResolvedValueOnce(0),
+      input: { ...command, idempotencyKey: "missing-contact", contactId: "7" },
+      code: "contact_not_found",
+    },
+    {
+      label: "document",
+      fail: () => fake.documentCount.mockResolvedValueOnce(0),
+      input: { ...command, idempotencyKey: "missing-document", metadata: { ...command.metadata, documentId: "8" } },
+      code: "document_not_found",
+    },
+    {
+      label: "submission",
+      fail: () => fake.submissionCount.mockResolvedValueOnce(0),
+      input: { ...command, idempotencyKey: "missing-submission", metadata: { ...command.metadata, submissionId: "9" } },
+      code: "submission_not_found",
+    },
+  ])("rejects a linked $label outside the owner/application boundary", async ({ fail, input, code }) => {
+    fail();
+    await expect(new PrismaAdapter().recordApplicationEvent("1", "owner-1", input)).rejects.toThrow(code);
+    expect(fake.events()).toHaveLength(0);
   });
 
   it("rejects stale and cross-owner commands without an event", async () => {

--- a/lib/db/adapter.ts
+++ b/lib/db/adapter.ts
@@ -28,6 +28,10 @@ import type {
   RecordSubmissionInput,
   RecordSubmissionResult,
   CreateApplicationEventInput,
+  RecordApplicationEventInput,
+  RecordApplicationEventResult,
+  ListApplicationEventsFilter,
+  ApplicationEventPage,
   ListDocumentsFilter,
   UpdateDocumentMetadataInput,
 } from "./types";
@@ -53,7 +57,9 @@ export interface DatabaseAdapter {
   listUserSubmissions(userId: string): Promise<ApplicationSubmissionRecord[]>;
   getApplicationSubmission(id: string, userId: string): Promise<ApplicationSubmissionRecord | null>;
   createApplicationEvent(applicationId: string, userId: string, input: CreateApplicationEventInput): Promise<ApplicationEventRecord>;
+  recordApplicationEvent(applicationId: string, userId: string, input: RecordApplicationEventInput): Promise<RecordApplicationEventResult>;
   listApplicationEvents(applicationId: string, userId: string, limit?: number): Promise<ApplicationEventRecord[]>;
+  listApplicationEventsFiltered(userId: string, filter: ListApplicationEventsFilter): Promise<ApplicationEventPage>;
 
   /** List applications with optional filters and field selection. */
   listApplicationsFiltered(userId: string | null, filter: ListApplicationsFilter): Promise<Partial<ApplicationRecord>[]>;

--- a/lib/db/firestore-adapter.ts
+++ b/lib/db/firestore-adapter.ts
@@ -11,6 +11,11 @@ import {
   validateSubmissionDocumentIds,
   validateSubmissionPolicy,
 } from "@/lib/applications/submission";
+import {
+  deriveEventProjection,
+  encodeEventCursor,
+  validateApplicationSummary,
+} from "@/lib/applications/events";
 import type { DatabaseAdapter } from "./adapter";
 import type {
   ApplicationRecord,
@@ -42,6 +47,10 @@ import type {
   RecordSubmissionInput,
   RecordSubmissionResult,
   CreateApplicationEventInput,
+  RecordApplicationEventInput,
+  RecordApplicationEventResult,
+  ListApplicationEventsFilter,
+  ApplicationEventPage,
   ListDocumentsFilter,
   UpdateDocumentMetadataInput,
 } from "./types";
@@ -184,6 +193,13 @@ function mapSubmission(
   };
 }
 
+function publicEventMetadata(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const metadata = { ...(value as Record<string, unknown>) };
+  delete metadata.requestHash;
+  return metadata;
+}
+
 function mapEvent(id: string, data: FirebaseFirestore.DocumentData): ApplicationEventRecord {
   return {
     id,
@@ -194,8 +210,11 @@ function mapEvent(id: string, data: FirebaseFirestore.DocumentData): Application
     occurredAt: toDate(data.occurredAt) ?? new Date(),
     source: data.source ?? null,
     actor: data.actor ?? null,
-    metadata: data.metadata ?? null,
+    contactId: data.contactId ?? null,
+    outcome: data.outcome ?? null,
+    metadata: publicEventMetadata(data.metadata),
     createdAt: toDate(data.createdAt) ?? new Date(),
+    application: data._application,
   };
 }
 
@@ -302,6 +321,7 @@ export class FirestoreAdapter implements DatabaseAdapter {
   }
 
   async createApplication(userId: string, data: CreateApplicationInput): Promise<ApplicationRecord> {
+    validateApplicationSummary(data.notes);
     const now = Timestamp.now();
     const reference = this.apps.doc();
     const payload = {
@@ -352,6 +372,7 @@ export class FirestoreAdapter implements DatabaseAdapter {
   }
 
   async updateApplication(id: string, userId: string, data: UpdateApplicationInput): Promise<ApplicationRecord> {
+    if (data.notes !== undefined) validateApplicationSummary(data.notes);
     const ref = this.apps.doc(id);
     const update: Record<string, unknown> = { updatedAt: FieldValue.serverTimestamp() };
     if (data.company !== undefined) update.company = data.company;
@@ -546,7 +567,7 @@ export class FirestoreAdapter implements DatabaseAdapter {
       }
       const existingNotes = appSnapshot.data()!.notes as string | null | undefined;
       const notes = existingNotes ? `${existingNotes}\n\n${note}` : note;
-      if (notes.length > 50_000) throw new Error("notes_too_large");
+      if (notes.length > 10_000) throw new Error("notes_too_long");
       const now = Timestamp.now();
       const eventData = {
         userId,
@@ -557,10 +578,7 @@ export class FirestoreAdapter implements DatabaseAdapter {
         occurredAt: toTimestamp(eventInput.occurredAt),
         source: eventInput.source ?? null,
         actor: eventInput.actor ?? null,
-        metadata: {
-          ...(eventInput.metadata ?? {}),
-          requestHash,
-        },
+        metadata: eventInput.metadata ?? {},
         createdAt: now,
       };
       transaction.update(appRef, { notes, updatedAt: now });
@@ -899,6 +917,158 @@ export class FirestoreAdapter implements DatabaseAdapter {
     return mapEvent(eventId, eventData);
   }
 
+  async recordApplicationEvent(
+    applicationId: string,
+    userId: string,
+    input: RecordApplicationEventInput,
+  ): Promise<RecordApplicationEventResult> {
+    const requestHash = submissionRequestHash({
+      applicationId,
+      type: input.type,
+      occurredAt: input.occurredAt,
+      source: input.source ?? null,
+      actor: input.actor ?? null,
+      metadata: input.metadata ?? {},
+      contactId: input.contactId ?? null,
+      outcome: input.outcome ?? null,
+      expectedUpdatedAt: input.expectedUpdatedAt ?? null,
+    });
+    const legacyRequestHash = submissionRequestHash({
+      applicationId,
+      type: input.type,
+      occurredAt: input.occurredAt,
+      metadata: input.metadata ?? {},
+    });
+    const acceptedRequestHashes = new Set([requestHash, legacyRequestHash]);
+    const eventId = input.idempotencyKey
+      ? submissionRequestHash({ userId, key: input.idempotencyKey }).slice(0, 40)
+      : this.events.doc().id;
+    const eventRef = this.events.doc(eventId);
+    const appRef = this.apps.doc(applicationId);
+
+    const transactionResult = await this.db.runTransaction(async (transaction) => {
+      const [application, existing] = await Promise.all([
+        transaction.get(appRef),
+        transaction.get(eventRef),
+      ]);
+      if (!application.exists || application.data()!.userId !== userId) throw new Error("not_found");
+      const applicationData = application.data()!;
+      if (applicationData.deletionState === "in_progress") throw new Error("application_deleting");
+      if (existing.exists) {
+        const existingData = existing.data()!;
+        const persistedRequestHash = existingData.requestHash ?? existingData.metadata?.requestHash;
+        if (
+          !input.idempotencyKey
+          || existingData.userId !== userId
+          || typeof persistedRequestHash !== "string"
+          || !acceptedRequestHashes.has(persistedRequestHash)
+        ) throw new Error("idempotency_conflict");
+        return { replayed: true, eventData: existingData };
+      }
+      const updatedAt = toDate(applicationData.updatedAt);
+      if (input.expectedUpdatedAt && updatedAt?.getTime() !== input.expectedUpdatedAt.getTime()) {
+        throw new Error("conflict");
+      }
+      const { patch, metadata } = deriveEventProjection(
+        { type: input.type, occurredAt: input.occurredAt, metadata: input.metadata ?? {} },
+        {
+        status: applicationData.status,
+        currentStage: applicationData.currentStage ?? null,
+        followUpAt: toDate(applicationData.followUpAt),
+      });
+      const firestorePatch = Object.fromEntries(
+        Object.entries(patch).map(([key, value]) => [
+          key,
+          value instanceof Date ? toTimestamp(value) : value,
+        ]),
+      );
+      if (Object.keys(firestorePatch).length) {
+        transaction.update(appRef, { ...firestorePatch, updatedAt: Timestamp.now() });
+      }
+      const eventData = {
+        userId,
+        applicationId,
+        type: input.type,
+        idempotencyKey: input.idempotencyKey ?? null,
+        requestHash,
+        occurredAt: toTimestamp(input.occurredAt),
+        source: input.source ?? null,
+        actor: input.actor ?? null,
+        contactId: input.contactId ?? null,
+        outcome: input.outcome ?? null,
+        metadata,
+        createdAt: Timestamp.now(),
+      };
+      transaction.create(eventRef, eventData);
+      return { replayed: false, eventData };
+    });
+
+    const application = await this.getApplication(applicationId, userId);
+    if (!application) throw new Error("verification_failed");
+    const eventSnapshot = await eventRef.get();
+    if (!eventSnapshot.exists) throw new Error("verification_failed");
+    return {
+      event: mapEvent(eventId, eventSnapshot.data() ?? transactionResult.eventData),
+      application,
+      replayed: transactionResult.replayed,
+    };
+  }
+
+  async listApplicationEventsFiltered(
+    userId: string,
+    filter: ListApplicationEventsFilter,
+  ): Promise<ApplicationEventPage> {
+    const snapshot = await this.events
+      .where("userId", "==", userId)
+      .orderBy("occurredAt", filter.order === "oldest" ? "asc" : "desc")
+      .get();
+    let events = snapshot.docs.map((document) => mapEvent(document.id, document.data()));
+    events.sort((left, right) => {
+      const time = left.occurredAt.getTime() - right.occurredAt.getTime();
+      const id = left.id === right.id ? 0 : left.id < right.id ? -1 : 1;
+      const comparison = time || id;
+      return filter.order === "oldest" ? comparison : -comparison;
+    });
+    if (filter.company) {
+      const companyApps = await this.loadAppRefs([...new Set(events.map((event) => event.applicationId))]);
+      for (const event of events) event.application = companyApps.get(event.applicationId);
+    }
+    events = events.filter((event) =>
+      (!filter.applicationId || event.applicationId === filter.applicationId)
+      && (!filter.company || event.application?.company.toLocaleLowerCase().includes(filter.company.toLocaleLowerCase()))
+      && (!filter.types?.length || filter.types.includes(event.type))
+      && (!filter.occurredAfter || event.occurredAt >= filter.occurredAfter)
+      && (!filter.occurredBefore || event.occurredAt <= filter.occurredBefore)
+      && (!filter.source || event.source === filter.source)
+      && (!filter.actor || event.actor === filter.actor)
+      && (!filter.contactId || event.contactId === filter.contactId)
+      && (!filter.outcome || event.outcome === filter.outcome)
+    );
+    if (filter.cursor) {
+      const cursorTime = new Date(filter.cursor.occurredAt).getTime();
+      events = events.filter((event) => {
+        const time = event.occurredAt.getTime();
+        const idComparison = event.id === filter.cursor!.id
+          ? 0
+          : event.id < filter.cursor!.id ? -1 : 1;
+        return filter.order === "oldest"
+          ? time > cursorTime || (time === cursorTime && idComparison > 0)
+          : time < cursorTime || (time === cursorTime && idComparison < 0);
+      });
+    }
+    const hasMore = events.length > filter.limit;
+    const items = events.slice(0, filter.limit);
+    const appMap = await this.loadAppRefs([...new Set(items.map((event) => event.applicationId))]);
+    for (const event of items) event.application = appMap.get(event.applicationId);
+    const last = items.at(-1);
+    return {
+      items,
+      nextCursor: hasMore && last
+        ? encodeEventCursor({ version: 1, occurredAt: last.occurredAt.toISOString(), id: last.id })
+        : null,
+    };
+  }
+
   async listApplicationEvents(
     applicationId: string,
     userId: string,
@@ -910,9 +1080,13 @@ export class FirestoreAdapter implements DatabaseAdapter {
       .where("applicationId", "==", applicationId)
       .where("userId", "==", userId)
       .orderBy("occurredAt", "desc")
-      .limit(Math.max(1, Math.min(500, limit)))
       .get();
-    return snapshot.docs.map((document) => mapEvent(document.id, document.data()));
+    const events = snapshot.docs.map((document) => mapEvent(document.id, document.data()));
+    return events.sort((left, right) => {
+      const time = right.occurredAt.getTime() - left.occurredAt.getTime();
+      if (time) return time;
+      return left.id === right.id ? 0 : left.id < right.id ? 1 : -1;
+    }).slice(0, Math.max(1, Math.min(500, limit)));
   }
 
   async listApplicationsFiltered(

--- a/lib/db/firestore-adapter.ts
+++ b/lib/db/firestore-adapter.ts
@@ -1019,9 +1019,7 @@ export class FirestoreAdapter implements DatabaseAdapter {
           value instanceof Date ? toTimestamp(value) : value,
         ]),
       );
-      if (Object.keys(firestorePatch).length) {
-        transaction.update(appRef, { ...firestorePatch, updatedAt: Timestamp.now() });
-      }
+      transaction.update(appRef, { ...firestorePatch, updatedAt: Timestamp.now() });
       const eventData = {
         userId,
         applicationId,

--- a/lib/db/firestore-adapter.ts
+++ b/lib/db/firestore-adapter.ts
@@ -965,6 +965,37 @@ export class FirestoreAdapter implements DatabaseAdapter {
         ) throw new Error("idempotency_conflict");
         return { replayed: true, eventData: existingData };
       }
+      const metadataInput = input.metadata ?? {};
+      if (input.contactId) {
+        const contact = await transaction.get(this.contacts.doc(input.contactId));
+        if (!contact.exists || contact.data()!.applicationId !== applicationId) {
+          throw new Error("contact_not_found");
+        }
+      }
+      const documentId = typeof metadataInput.documentId === "string" ? metadataInput.documentId : null;
+      if (documentId) {
+        const document = await transaction.get(this.docs.doc(documentId));
+        const documentData = document.exists ? document.data()! : null;
+        if (
+          !documentData
+          || documentData.userId !== userId
+          || !Array.isArray(documentData.applicationIds)
+          || !documentData.applicationIds.includes(applicationId)
+        ) {
+          throw new Error("document_not_found");
+        }
+      }
+      const submissionId = typeof metadataInput.submissionId === "string" ? metadataInput.submissionId : null;
+      if (submissionId) {
+        const submission = await transaction.get(this.submissions.doc(submissionId));
+        if (
+          !submission.exists
+          || submission.data()!.userId !== userId
+          || submission.data()!.applicationId !== applicationId
+        ) {
+          throw new Error("submission_not_found");
+        }
+      }
       const updatedAt = toDate(applicationData.updatedAt);
       if (input.expectedUpdatedAt && updatedAt?.getTime() !== input.expectedUpdatedAt.getTime()) {
         throw new Error("conflict");

--- a/lib/db/firestore-adapter.ts
+++ b/lib/db/firestore-adapter.ts
@@ -1,4 +1,4 @@
-import { getFirestore, Timestamp, FieldValue } from "firebase-admin/firestore";
+import { getFirestore, Timestamp, FieldValue, FieldPath } from "firebase-admin/firestore";
 import { getApps, initializeApp, applicationDefault } from "firebase-admin/app";
 import { prisma } from "@/lib/prisma";
 import { normalizeStatus } from "@/types";
@@ -372,7 +372,6 @@ export class FirestoreAdapter implements DatabaseAdapter {
   }
 
   async updateApplication(id: string, userId: string, data: UpdateApplicationInput): Promise<ApplicationRecord> {
-    if (data.notes !== undefined) validateApplicationSummary(data.notes);
     const ref = this.apps.doc(id);
     const update: Record<string, unknown> = { updatedAt: FieldValue.serverTimestamp() };
     if (data.company !== undefined) update.company = data.company;
@@ -404,6 +403,13 @@ export class FirestoreAdapter implements DatabaseAdapter {
       const existing = await transaction.get(ref);
       if (!existing.exists || existing.data()!.userId !== userId) throw new Error("not_found");
       if (existing.data()!.deletionState === "in_progress") throw new Error("application_deleting");
+      if (data.notes !== undefined) {
+        if (existing.data()!.notes === data.notes) delete update.notes;
+        else {
+          validateApplicationSummary(data.notes);
+          update.notes = data.notes;
+        }
+      }
       const currentCanonicalJobUrl = existing.data()!.canonicalJobUrl as string | null | undefined;
       let nextCanonicalIndex: FirebaseFirestore.DocumentReference | null = null;
       let nextCanonicalIndexExists = false;
@@ -1049,22 +1055,48 @@ export class FirestoreAdapter implements DatabaseAdapter {
     userId: string,
     filter: ListApplicationEventsFilter,
   ): Promise<ApplicationEventPage> {
-    const snapshot = await this.events
-      .where("userId", "==", userId)
-      .orderBy("occurredAt", filter.order === "oldest" ? "asc" : "desc")
-      .get();
-    let events = snapshot.docs.map((document) => mapEvent(document.id, document.data()));
-    events.sort((left, right) => {
-      const time = left.occurredAt.getTime() - right.occurredAt.getTime();
-      const id = left.id === right.id ? 0 : left.id < right.id ? -1 : 1;
-      const comparison = time || id;
-      return filter.order === "oldest" ? comparison : -comparison;
-    });
-    if (filter.company) {
-      const companyApps = await this.loadAppRefs([...new Set(events.map((event) => event.applicationId))]);
-      for (const event of events) event.application = companyApps.get(event.applicationId);
+    const direction = filter.order === "oldest" ? "asc" : "desc";
+    let query: FirebaseFirestore.Query = this.events.where("userId", "==", userId);
+
+    // Use one indexed equality dimension as the native narrowing predicate.
+    // Remaining filters are applied to the bounded page below so arbitrary
+    // combinations do not require a combinatorial set of Firestore indexes.
+    if (filter.applicationId) query = query.where("applicationId", "==", filter.applicationId);
+    else if (filter.types?.length) query = query.where("type", "in", filter.types);
+    else if (filter.source) query = query.where("source", "==", filter.source);
+    else if (filter.actor) query = query.where("actor", "==", filter.actor);
+    else if (filter.contactId) query = query.where("contactId", "==", filter.contactId);
+    else if (filter.outcome) query = query.where("outcome", "==", filter.outcome);
+
+    if (filter.occurredAfter) {
+      query = query.where("occurredAt", ">=", Timestamp.fromDate(filter.occurredAfter));
     }
-    events = events.filter((event) =>
+    if (filter.occurredBefore) {
+      query = query.where("occurredAt", "<=", Timestamp.fromDate(filter.occurredBefore));
+    }
+    query = query
+      .orderBy("occurredAt", direction)
+      .orderBy(FieldPath.documentId(), direction);
+    if (filter.cursor) {
+      query = query.startAfter(
+        Timestamp.fromDate(new Date(filter.cursor.occurredAt)),
+        filter.cursor.id,
+      );
+    }
+
+    const scanLimit = Math.min(1_000, Math.max(filter.limit * 5, filter.limit + 1));
+    const snapshot = await query.limit(scanLimit + 1).get();
+    const hasUnscannedRows = snapshot.docs.length > scanLimit;
+    const scannedDocuments = hasUnscannedRows ? snapshot.docs.slice(0, scanLimit) : snapshot.docs;
+    const scannedEvents = scannedDocuments.map((document) => ({
+      document,
+      event: mapEvent(document.id, document.data()),
+    }));
+    const appMap = await this.loadVerifiedAppRefs([
+      ...new Set(scannedEvents.map(({ event }) => event.applicationId)),
+    ], userId);
+    for (const { event } of scannedEvents) event.application = appMap.get(event.applicationId);
+    const matchingEvents = scannedEvents.filter(({ event }) =>
       (!filter.applicationId || event.applicationId === filter.applicationId)
       && (!filter.company || event.application?.company.toLocaleLowerCase().includes(filter.company.toLocaleLowerCase()))
       && (!filter.types?.length || filter.types.includes(event.type))
@@ -1075,27 +1107,26 @@ export class FirestoreAdapter implements DatabaseAdapter {
       && (!filter.contactId || event.contactId === filter.contactId)
       && (!filter.outcome || event.outcome === filter.outcome)
     );
-    if (filter.cursor) {
-      const cursorTime = new Date(filter.cursor.occurredAt).getTime();
-      events = events.filter((event) => {
-        const time = event.occurredAt.getTime();
-        const idComparison = event.id === filter.cursor!.id
-          ? 0
-          : event.id < filter.cursor!.id ? -1 : 1;
-        return filter.order === "oldest"
-          ? time > cursorTime || (time === cursorTime && idComparison > 0)
-          : time < cursorTime || (time === cursorTime && idComparison < 0);
-      });
-    }
-    const hasMore = events.length > filter.limit;
-    const items = events.slice(0, filter.limit);
-    const appMap = await this.loadAppRefs([...new Set(items.map((event) => event.applicationId))]);
-    for (const event of items) event.application = appMap.get(event.applicationId);
-    const last = items.at(-1);
+    const items = matchingEvents.slice(0, filter.limit).map(({ event }) => event);
+    // When another matching row was already scanned, resume after the last
+    // returned match. Otherwise resume after the bounded scan window so sparse
+    // in-memory filters can continue without re-reading examined rows.
+    const cursorDocument = matchingEvents.length > filter.limit
+      ? matchingEvents[filter.limit - 1]?.document
+      : hasUnscannedRows
+        ? scannedDocuments.at(-1)
+        : null;
+    const cursorEvent = cursorDocument
+      ? mapEvent(cursorDocument.id, cursorDocument.data())
+      : null;
     return {
       items,
-      nextCursor: hasMore && last
-        ? encodeEventCursor({ version: 1, occurredAt: last.occurredAt.toISOString(), id: last.id })
+      nextCursor: cursorEvent
+        ? encodeEventCursor({
+          version: 1,
+          occurredAt: cursorEvent.occurredAt.toISOString(),
+          id: cursorEvent.id,
+        })
         : null,
     };
   }

--- a/lib/db/firestore-adapter.ts
+++ b/lib/db/firestore-adapter.ts
@@ -1082,38 +1082,51 @@ export class FirestoreAdapter implements DatabaseAdapter {
       );
     }
 
-    const scanLimit = Math.min(1_000, Math.max(filter.limit * 5, filter.limit + 1));
-    const snapshot = await query.limit(scanLimit + 1).get();
-    const hasUnscannedRows = snapshot.docs.length > scanLimit;
-    const scannedDocuments = hasUnscannedRows ? snapshot.docs.slice(0, scanLimit) : snapshot.docs;
-    const scannedEvents = scannedDocuments.map((document) => ({
-      document,
-      event: mapEvent(document.id, document.data()),
-    }));
-    const appMap = await this.loadVerifiedAppRefs([
-      ...new Set(scannedEvents.map(({ event }) => event.applicationId)),
-    ], userId);
-    for (const { event } of scannedEvents) event.application = appMap.get(event.applicationId);
-    const matchingEvents = scannedEvents.filter(({ event }) =>
-      (!filter.applicationId || event.applicationId === filter.applicationId)
-      && (!filter.company || event.application?.company.toLocaleLowerCase().includes(filter.company.toLocaleLowerCase()))
-      && (!filter.types?.length || filter.types.includes(event.type))
-      && (!filter.occurredAfter || event.occurredAt >= filter.occurredAfter)
-      && (!filter.occurredBefore || event.occurredAt <= filter.occurredBefore)
-      && (!filter.source || event.source === filter.source)
-      && (!filter.actor || event.actor === filter.actor)
-      && (!filter.contactId || event.contactId === filter.contactId)
-      && (!filter.outcome || event.outcome === filter.outcome)
-    );
+    const scanLimit = Math.min(500, Math.max(filter.limit * 2, 50));
+    const matchingEvents: Array<{
+      document: FirebaseFirestore.QueryDocumentSnapshot;
+      event: ApplicationEventRecord;
+    }> = [];
+
+    // Residual filters (notably company and arbitrary filter combinations) are
+    // evaluated in memory. Keep advancing the indexed query until this logical
+    // page has a real match/lookahead or the query is exhausted; never expose
+    // internal scan windows as empty client pages.
+    while (matchingEvents.length <= filter.limit) {
+      const snapshot = await query.limit(scanLimit).get();
+      if (!snapshot.docs.length) break;
+      const scannedEvents = snapshot.docs.map((document) => ({
+        document,
+        event: mapEvent(document.id, document.data()),
+      }));
+      const appMap = await this.loadVerifiedAppRefs([
+        ...new Set(scannedEvents.map(({ event }) => event.applicationId)),
+      ], userId);
+      for (const { event } of scannedEvents) event.application = appMap.get(event.applicationId);
+      matchingEvents.push(...scannedEvents.filter(({ event }) =>
+        (!filter.applicationId || event.applicationId === filter.applicationId)
+        && (!filter.company || event.application?.company.toLocaleLowerCase().includes(filter.company.toLocaleLowerCase()))
+        && (!filter.types?.length || filter.types.includes(event.type))
+        && (!filter.occurredAfter || event.occurredAt >= filter.occurredAfter)
+        && (!filter.occurredBefore || event.occurredAt <= filter.occurredBefore)
+        && (!filter.source || event.source === filter.source)
+        && (!filter.actor || event.actor === filter.actor)
+        && (!filter.contactId || event.contactId === filter.contactId)
+        && (!filter.outcome || event.outcome === filter.outcome)
+      ));
+      if (matchingEvents.length > filter.limit || snapshot.docs.length < scanLimit) break;
+      const lastDocument = snapshot.docs.at(-1)!;
+      const lastEvent = mapEvent(lastDocument.id, lastDocument.data());
+      query = query.startAfter(
+        Timestamp.fromDate(lastEvent.occurredAt),
+        lastEvent.id,
+      );
+    }
+
     const items = matchingEvents.slice(0, filter.limit).map(({ event }) => event);
-    // When another matching row was already scanned, resume after the last
-    // returned match. Otherwise resume after the bounded scan window so sparse
-    // in-memory filters can continue without re-reading examined rows.
     const cursorDocument = matchingEvents.length > filter.limit
       ? matchingEvents[filter.limit - 1]?.document
-      : hasUnscannedRows
-        ? scannedDocuments.at(-1)
-        : null;
+      : null;
     const cursorEvent = cursorDocument
       ? mapEvent(cursorDocument.id, cursorDocument.data())
       : null;

--- a/lib/db/firestore-adapter.ts
+++ b/lib/db/firestore-adapter.ts
@@ -1256,6 +1256,12 @@ export class FirestoreAdapter implements DatabaseAdapter {
       const item = items[i];
       try {
         if (item.id) {
+          const lifecycleFields = ["status", "appliedAt", "lastContact", "followUpAt", "currentStage"] as const;
+          if (lifecycleFields.some((field) => item[field] !== undefined)) {
+            results.push({ index: i, id: item.id, operation: "updated", error: "lifecycle_event_required" });
+            failed++;
+            continue;
+          }
           const update = { ...item } as BatchUpsertItem & { id?: string };
           delete update.id;
           const application = await this.updateApplication(

--- a/lib/db/prisma-adapter.ts
+++ b/lib/db/prisma-adapter.ts
@@ -1013,8 +1013,45 @@ export class PrismaAdapter implements DatabaseAdapter {
           }
         }
 
+        const metadataInput = input.metadata ?? {};
+        const referenceId = (value: string, errorCode: string) => {
+          try {
+            return nid(value);
+          } catch {
+            throw new Error(errorCode);
+          }
+        };
+        if (input.contactId) {
+          const count = await tx.contact.count({
+            where: { id: referenceId(input.contactId, "contact_not_found"), applicationId: applicationNumericId },
+          });
+          if (count !== 1) throw new Error("contact_not_found");
+        }
+        const documentId = typeof metadataInput.documentId === "string" ? metadataInput.documentId : null;
+        if (documentId) {
+          const count = await tx.document.count({
+            where: {
+              id: referenceId(documentId, "document_not_found"),
+              userId,
+              applications: { some: { id: applicationNumericId } },
+            },
+          });
+          if (count !== 1) throw new Error("document_not_found");
+        }
+        const submissionId = typeof metadataInput.submissionId === "string" ? metadataInput.submissionId : null;
+        if (submissionId) {
+          const count = await tx.applicationSubmission.count({
+            where: {
+              id: referenceId(submissionId, "submission_not_found"),
+              userId,
+              applicationId: applicationNumericId,
+            },
+          });
+          if (count !== 1) throw new Error("submission_not_found");
+        }
+
         const { patch, metadata } = deriveEventProjection(
-          { type: input.type, occurredAt: input.occurredAt, metadata: input.metadata ?? {} },
+          { type: input.type, occurredAt: input.occurredAt, metadata: metadataInput },
           {
           status: application.status,
           currentStage: application.currentStage,

--- a/lib/db/prisma-adapter.ts
+++ b/lib/db/prisma-adapter.ts
@@ -342,9 +342,18 @@ export class PrismaAdapter implements DatabaseAdapter {
   }
 
   async updateApplication(id: string, userId: string, data: UpdateApplicationInput): Promise<ApplicationRecord> {
-    if (data.notes !== undefined) validateApplicationSummary(data.notes);
-    const { expectedUpdatedAt, ...update } = data;
     const applicationId = nid(id);
+    const mutableData = { ...data };
+    if (data.notes !== undefined) {
+      const current = await prisma.application.findFirst({
+        where: { id: applicationId, userId },
+        select: { notes: true },
+      });
+      if (!current) throw new Error("not_found");
+      if (current.notes === data.notes) delete mutableData.notes;
+      else validateApplicationSummary(data.notes);
+    }
+    const { expectedUpdatedAt, ...update } = mutableData;
     try {
       if (expectedUpdatedAt) {
         const result = await prisma.application.updateMany({
@@ -352,6 +361,7 @@ export class PrismaAdapter implements DatabaseAdapter {
           data: {
             ...update,
             ...(update.status !== undefined ? { status: normalizeStatus(update.status) } : {}),
+            eventVersion: { increment: 1 },
           },
         });
         if (result.count !== 1) {
@@ -373,6 +383,7 @@ export class PrismaAdapter implements DatabaseAdapter {
         data: {
           ...update,
           ...(update.status !== undefined ? { status: normalizeStatus(update.status) } : {}),
+          eventVersion: { increment: 1 },
         },
         include: { contacts: true },
       });
@@ -484,7 +495,8 @@ export class PrismaAdapter implements DatabaseAdapter {
                     WHEN "notes" IS NULL OR "notes" = '' THEN ${note}
                     ELSE "notes" || E'\n\n' || ${note}
                   END,
-                  "updatedAt" = NOW()
+                  "updatedAt" = NOW(),
+                  "eventVersion" = "eventVersion" + 1
               WHERE "id" = ${nid(id)}
                 AND "userId" = ${userId}
                 AND "updatedAt" = ${expectedUpdatedAt}
@@ -501,7 +513,8 @@ export class PrismaAdapter implements DatabaseAdapter {
                     WHEN "notes" IS NULL OR "notes" = '' THEN ${note}
                     ELSE "notes" || E'\n\n' || ${note}
                   END,
-                  "updatedAt" = NOW()
+                  "updatedAt" = NOW(),
+                  "eventVersion" = "eventVersion" + 1
               WHERE "id" = ${nid(id)}
                 AND "userId" = ${userId}
                 AND char_length(
@@ -772,6 +785,7 @@ export class PrismaAdapter implements DatabaseAdapter {
       const applicationUpdate = {
         status: "applied",
         appliedAt: input.submittedAt,
+        eventVersion: { increment: 1 },
         ...(input.followUpAt !== undefined ? { followUpAt: input.followUpAt } : {}),
         ...(input.atsName !== undefined ? { atsName: input.atsName } : {}),
         ...(input.requisitionId !== undefined ? { requisitionId: input.requisitionId } : {}),
@@ -913,18 +927,25 @@ export class PrismaAdapter implements DatabaseAdapter {
     const replay = await loadReplay();
     if (replay) return replay;
     try {
-      const row = await prisma.applicationEvent.create({
-        data: {
-          userId,
-          applicationId: nid(applicationId),
-          type: input.type,
-          idempotencyKey: input.idempotencyKey ?? null,
-          requestHash,
-          occurredAt: input.occurredAt,
-          source: input.source ?? null,
-          actor: input.actor ?? null,
-          metadata: (input.metadata ?? {}) as Prisma.InputJsonValue,
-        },
+      const row = await prisma.$transaction(async (tx) => {
+        const bumped = await tx.application.updateMany({
+          where: { id: nid(applicationId), userId },
+          data: { eventVersion: { increment: 1 } },
+        });
+        if (bumped.count !== 1) throw new Error("not_found");
+        return tx.applicationEvent.create({
+          data: {
+            userId,
+            applicationId: nid(applicationId),
+            type: input.type,
+            idempotencyKey: input.idempotencyKey ?? null,
+            requestHash,
+            occurredAt: input.occurredAt,
+            source: input.source ?? null,
+            actor: input.actor ?? null,
+            metadata: (input.metadata ?? {}) as Prisma.InputJsonValue,
+          },
+        });
       });
       return mapEvent(row);
     } catch (error) {
@@ -1057,21 +1078,17 @@ export class PrismaAdapter implements DatabaseAdapter {
           currentStage: application.currentStage,
           followUpAt: application.followUpAt,
         });
-        let updatedApplication = application;
-        const hasProjectionPatch = Object.keys(patch).length > 0;
+        const eventVersion = application.eventVersion;
         const updated = await tx.application.updateMany({
-          where: { id: applicationNumericId, userId, updatedAt: application.updatedAt },
-          data: hasProjectionPatch ? patch : { updatedAt: application.updatedAt },
+          where: { id: applicationNumericId, userId, eventVersion },
+          data: { ...patch, eventVersion: { increment: 1 } },
         });
         if (updated.count !== 1) throw new Error("conflict");
-        if (hasProjectionPatch) {
-          const refreshed = await tx.application.findFirst({
-            where: { id: applicationNumericId, userId },
-            include: { contacts: true },
-          });
-          if (!refreshed) throw new Error("not_found");
-          updatedApplication = refreshed;
-        }
+        const updatedApplication = await tx.application.findFirst({
+          where: { id: applicationNumericId, userId },
+          include: { contacts: true },
+        });
+        if (!updatedApplication) throw new Error("not_found");
         const event = await tx.applicationEvent.create({
           data: {
             userId,
@@ -1275,6 +1292,7 @@ export class PrismaAdapter implements DatabaseAdapter {
           if (item.resumeId !== undefined) data.resumeId = item.resumeId;
           Object.assign(data, structuredApplicationData(item as unknown as Record<string, unknown>));
           Object.assign(data, sanitizeTriageFields(item as Record<string, unknown>));
+          data.eventVersion = { increment: 1 };
 
           const row = await prisma.application.update({
             where: { id: nid(item.id), userId },

--- a/lib/db/prisma-adapter.ts
+++ b/lib/db/prisma-adapter.ts
@@ -1263,6 +1263,12 @@ export class PrismaAdapter implements DatabaseAdapter {
       const item = items[i];
       try {
         if (item.id) {
+          const lifecycleFields = ["status", "appliedAt", "lastContact", "followUpAt", "currentStage"] as const;
+          if (lifecycleFields.some((field) => item[field] !== undefined)) {
+            results.push({ index: i, id: item.id, operation: "updated", error: "lifecycle_event_required" });
+            failed++;
+            continue;
+          }
           // Pre-check ownership to avoid a throwing update on missing rows
           const existing = await prisma.application.findFirst({
             where: { id: nid(item.id), userId },

--- a/lib/db/prisma-adapter.ts
+++ b/lib/db/prisma-adapter.ts
@@ -11,6 +11,11 @@ import {
   validateSubmissionDocumentIds,
   validateSubmissionPolicy,
 } from "@/lib/applications/submission";
+import {
+  deriveEventProjection,
+  encodeEventCursor,
+  validateApplicationSummary,
+} from "@/lib/applications/events";
 import type { DatabaseAdapter } from "./adapter";
 import type {
   ApplicationRecord,
@@ -42,6 +47,10 @@ import type {
   RecordSubmissionInput,
   RecordSubmissionResult,
   CreateApplicationEventInput,
+  RecordApplicationEventInput,
+  RecordApplicationEventResult,
+  ListApplicationEventsFilter,
+  ApplicationEventPage,
   ListDocumentsFilter,
   UpdateDocumentMetadataInput,
 } from "./types";
@@ -109,12 +118,34 @@ function mapSubmission(
   };
 }
 
-function mapEvent(row: ApplicationEvent): ApplicationEventRecord {
+type EventWithApplication = ApplicationEvent & {
+  application?: { id: number; company: string; role: string };
+};
+
+function publicEventMetadata(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const metadata = { ...(value as Record<string, unknown>) };
+  delete metadata.requestHash;
+  return metadata;
+}
+
+function mapEvent(row: EventWithApplication): ApplicationEventRecord {
   return {
-    ...row,
     id: sid(row.id),
+    userId: row.userId,
     applicationId: sid(row.applicationId),
-    metadata: row.metadata as unknown as Record<string, unknown> | null,
+    type: row.type,
+    idempotencyKey: row.idempotencyKey,
+    occurredAt: row.occurredAt,
+    source: row.source,
+    actor: row.actor,
+    contactId: row.contactId ?? null,
+    outcome: row.outcome ?? null,
+    metadata: publicEventMetadata(row.metadata),
+    createdAt: row.createdAt,
+    application: row.application
+      ? { id: sid(row.application.id), company: row.application.company, role: row.application.role }
+      : undefined,
   };
 }
 
@@ -286,6 +317,7 @@ export class PrismaAdapter implements DatabaseAdapter {
   }
 
   async createApplication(userId: string, data: CreateApplicationInput): Promise<ApplicationRecord> {
+    validateApplicationSummary(data.notes);
     try {
       const row = await prisma.application.create({
         data: {
@@ -310,6 +342,7 @@ export class PrismaAdapter implements DatabaseAdapter {
   }
 
   async updateApplication(id: string, userId: string, data: UpdateApplicationInput): Promise<ApplicationRecord> {
+    if (data.notes !== undefined) validateApplicationSummary(data.notes);
     const { expectedUpdatedAt, ...update } = data;
     const applicationId = nid(id);
     try {
@@ -408,8 +441,8 @@ export class PrismaAdapter implements DatabaseAdapter {
         },
       });
       if (!event) return null;
-      const metadata = (event.metadata ?? {}) as Record<string, unknown>;
-      if (metadata.requestHash !== requestHash) throw new Error("idempotency_conflict");
+      const legacyHash = ((event.metadata ?? {}) as Record<string, unknown>).requestHash;
+      if ((event.requestHash ?? legacyHash) !== requestHash) throw new Error("idempotency_conflict");
       const application = await prisma.application.findFirst({
         where: { id: nid(id), userId },
         include: { contacts: true },
@@ -437,8 +470,8 @@ export class PrismaAdapter implements DatabaseAdapter {
             },
           });
           if (replay) {
-            const metadata = (replay.metadata ?? {}) as Record<string, unknown>;
-            if (metadata.requestHash !== requestHash) throw new Error("idempotency_conflict");
+            const legacyHash = ((replay.metadata ?? {}) as Record<string, unknown>).requestHash;
+            if ((replay.requestHash ?? legacyHash) !== requestHash) throw new Error("idempotency_conflict");
             return { application: mapApp(existing), event: mapEvent(replay) };
           }
         }
@@ -460,7 +493,7 @@ export class PrismaAdapter implements DatabaseAdapter {
                     WHEN "notes" IS NULL OR "notes" = '' THEN ${note}
                     ELSE "notes" || E'\n\n' || ${note}
                   END
-                ) <= 50000
+                ) <= 10000
             `
           : await tx.$executeRaw`
               UPDATE "Application"
@@ -476,7 +509,7 @@ export class PrismaAdapter implements DatabaseAdapter {
                     WHEN "notes" IS NULL OR "notes" = '' THEN ${note}
                     ELSE "notes" || E'\n\n' || ${note}
                   END
-                ) <= 50000
+                ) <= 10000
             `;
         if (changed !== 1) {
           const current = await tx.application.findFirst({ where: { id: nid(id), userId } });
@@ -484,7 +517,7 @@ export class PrismaAdapter implements DatabaseAdapter {
           if (expectedUpdatedAt && current.updatedAt.getTime() !== expectedUpdatedAt.getTime()) {
             throw new Error("conflict");
           }
-          throw new Error("notes_too_large");
+          throw new Error("notes_too_long");
         }
         const application = await tx.application.findFirstOrThrow({
           where: { id: nid(id), userId },
@@ -496,13 +529,11 @@ export class PrismaAdapter implements DatabaseAdapter {
             applicationId: nid(id),
             type: eventInput.type,
             idempotencyKey: eventInput.idempotencyKey ?? null,
+            requestHash,
             occurredAt: eventInput.occurredAt,
             source: eventInput.source ?? null,
             actor: eventInput.actor ?? null,
-            metadata: {
-              ...(eventInput.metadata ?? {}),
-              requestHash,
-            } as Prisma.InputJsonValue,
+            metadata: (eventInput.metadata ?? {}) as Prisma.InputJsonValue,
           },
         });
         return { application: mapApp(application), event: mapEvent(event) };
@@ -875,8 +906,8 @@ export class PrismaAdapter implements DatabaseAdapter {
         },
       });
       if (!replay) return null;
-      const metadata = (replay.metadata ?? {}) as Record<string, unknown>;
-      if (metadata.requestHash !== requestHash) throw new Error("idempotency_conflict");
+      const legacyHash = ((replay.metadata ?? {}) as Record<string, unknown>).requestHash;
+      if ((replay.requestHash ?? legacyHash) !== requestHash) throw new Error("idempotency_conflict");
       return mapEvent(replay);
     };
     const replay = await loadReplay();
@@ -888,13 +919,11 @@ export class PrismaAdapter implements DatabaseAdapter {
           applicationId: nid(applicationId),
           type: input.type,
           idempotencyKey: input.idempotencyKey ?? null,
+          requestHash,
           occurredAt: input.occurredAt,
           source: input.source ?? null,
           actor: input.actor ?? null,
-          metadata: {
-            ...(input.metadata ?? {}),
-            requestHash,
-          } as Prisma.InputJsonValue,
+          metadata: (input.metadata ?? {}) as Prisma.InputJsonValue,
         },
       });
       return mapEvent(row);
@@ -907,6 +936,188 @@ export class PrismaAdapter implements DatabaseAdapter {
     }
   }
 
+  async recordApplicationEvent(
+    applicationId: string,
+    userId: string,
+    input: RecordApplicationEventInput,
+  ): Promise<RecordApplicationEventResult> {
+    const applicationNumericId = nid(applicationId);
+    const requestHash = submissionRequestHash({
+      applicationId,
+      type: input.type,
+      occurredAt: input.occurredAt,
+      source: input.source ?? null,
+      actor: input.actor ?? null,
+      metadata: input.metadata ?? {},
+      contactId: input.contactId ?? null,
+      outcome: input.outcome ?? null,
+      expectedUpdatedAt: input.expectedUpdatedAt ?? null,
+    });
+    const legacyRequestHash = submissionRequestHash({
+      applicationId,
+      type: input.type,
+      occurredAt: input.occurredAt,
+      metadata: input.metadata ?? {},
+    });
+    const acceptedRequestHashes = new Set([requestHash, legacyRequestHash]);
+
+    const loadReplay = async (): Promise<RecordApplicationEventResult | null> => {
+      if (!input.idempotencyKey) return null;
+      const event = await prisma.applicationEvent.findUnique({
+        where: { userId_idempotencyKey: { userId, idempotencyKey: input.idempotencyKey } },
+      });
+      if (!event) return null;
+      const persistedRequestHash = event.requestHash ?? (
+        event.metadata && typeof event.metadata === "object" && !Array.isArray(event.metadata)
+          ? (event.metadata as Record<string, unknown>).requestHash
+          : undefined
+      );
+      if (typeof persistedRequestHash !== "string" || !acceptedRequestHashes.has(persistedRequestHash)) {
+        throw new Error("idempotency_conflict");
+      }
+      const application = await prisma.application.findFirst({
+        where: { id: applicationNumericId, userId },
+        include: { contacts: true },
+      });
+      if (!application) throw new Error("not_found");
+      return { event: mapEvent(event), application: mapApp(application), replayed: true };
+    };
+
+    const replay = await loadReplay();
+    if (replay) return replay;
+
+    try {
+      return await prisma.$transaction(async (tx) => {
+        const application = await tx.application.findFirst({
+          where: { id: applicationNumericId, userId },
+          include: { contacts: true },
+        });
+        if (!application) throw new Error("not_found");
+        if (input.expectedUpdatedAt && application.updatedAt.getTime() !== input.expectedUpdatedAt.getTime()) {
+          throw new Error("conflict");
+        }
+        if (input.idempotencyKey) {
+          const existing = await tx.applicationEvent.findUnique({
+            where: { userId_idempotencyKey: { userId, idempotencyKey: input.idempotencyKey } },
+          });
+          if (existing) {
+            const persistedRequestHash = existing.requestHash ?? (
+              existing.metadata && typeof existing.metadata === "object" && !Array.isArray(existing.metadata)
+                ? (existing.metadata as Record<string, unknown>).requestHash
+                : undefined
+            );
+            if (typeof persistedRequestHash !== "string" || !acceptedRequestHashes.has(persistedRequestHash)) {
+              throw new Error("idempotency_conflict");
+            }
+            return { event: mapEvent(existing), application: mapApp(application), replayed: true };
+          }
+        }
+
+        const { patch, metadata } = deriveEventProjection(
+          { type: input.type, occurredAt: input.occurredAt, metadata: input.metadata ?? {} },
+          {
+          status: application.status,
+          currentStage: application.currentStage,
+          followUpAt: application.followUpAt,
+        });
+        let updatedApplication = application;
+        const hasProjectionPatch = Object.keys(patch).length > 0;
+        const updated = await tx.application.updateMany({
+          where: { id: applicationNumericId, userId, updatedAt: application.updatedAt },
+          data: hasProjectionPatch ? patch : { updatedAt: application.updatedAt },
+        });
+        if (updated.count !== 1) throw new Error("conflict");
+        if (hasProjectionPatch) {
+          const refreshed = await tx.application.findFirst({
+            where: { id: applicationNumericId, userId },
+            include: { contacts: true },
+          });
+          if (!refreshed) throw new Error("not_found");
+          updatedApplication = refreshed;
+        }
+        const event = await tx.applicationEvent.create({
+          data: {
+            userId,
+            applicationId: applicationNumericId,
+            type: input.type,
+            idempotencyKey: input.idempotencyKey ?? null,
+            requestHash,
+            occurredAt: input.occurredAt,
+            source: input.source ?? null,
+            actor: input.actor ?? null,
+            contactId: input.contactId ?? null,
+            outcome: input.outcome ?? null,
+            metadata: metadata as Prisma.InputJsonValue,
+          },
+        });
+        return {
+          event: mapEvent(event),
+          application: mapApp(updatedApplication),
+          replayed: false,
+        };
+      });
+    } catch (error) {
+      if (
+        input.idempotencyKey
+        && error instanceof Error
+        && error.message === "conflict"
+      ) {
+        const concurrentReplay = await loadReplay();
+        if (concurrentReplay) return concurrentReplay;
+      }
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+        const concurrentReplay = await loadReplay();
+        if (concurrentReplay) return concurrentReplay;
+      }
+      throw error;
+    }
+  }
+
+  async listApplicationEventsFiltered(
+    userId: string,
+    filter: ListApplicationEventsFilter,
+  ): Promise<ApplicationEventPage> {
+    const direction = filter.order === "oldest" ? "asc" : "desc";
+    const where: Prisma.ApplicationEventWhereInput = {
+      userId,
+      ...(filter.applicationId ? { applicationId: nid(filter.applicationId) } : {}),
+      ...(filter.company ? { application: { company: { contains: filter.company, mode: "insensitive" } } } : {}),
+      ...(filter.types?.length ? { type: { in: filter.types } } : {}),
+      ...(filter.source ? { source: filter.source } : {}),
+      ...(filter.actor ? { actor: filter.actor } : {}),
+      ...(filter.contactId ? { contactId: filter.contactId } : {}),
+      ...(filter.outcome ? { outcome: filter.outcome } : {}),
+    };
+    const occurredAt: Prisma.DateTimeFilter = {};
+    if (filter.occurredAfter) occurredAt.gte = filter.occurredAfter;
+    if (filter.occurredBefore) occurredAt.lte = filter.occurredBefore;
+    if (Object.keys(occurredAt).length) where.occurredAt = occurredAt;
+    if (filter.cursor) {
+      const cursorDate = new Date(filter.cursor.occurredAt);
+      const cursorId = nid(filter.cursor.id);
+      const cursorPredicate: Prisma.ApplicationEventWhereInput = filter.order === "oldest"
+        ? { OR: [{ occurredAt: { gt: cursorDate } }, { occurredAt: cursorDate, id: { gt: cursorId } }] }
+        : { OR: [{ occurredAt: { lt: cursorDate } }, { occurredAt: cursorDate, id: { lt: cursorId } }] };
+      where.AND = [cursorPredicate];
+    }
+    const rows = await prisma.applicationEvent.findMany({
+      where,
+      orderBy: [{ occurredAt: direction }, { id: direction }],
+      take: filter.limit + 1,
+      include: { application: { select: { id: true, company: true, role: true } } },
+    });
+    const hasMore = rows.length > filter.limit;
+    const pageRows = hasMore ? rows.slice(0, filter.limit) : rows;
+    const items = pageRows.map(mapEvent);
+    const last = items.at(-1);
+    return {
+      items,
+      nextCursor: hasMore && last
+        ? encodeEventCursor({ version: 1, occurredAt: last.occurredAt.toISOString(), id: last.id })
+        : null,
+    };
+  }
+
   async listApplicationEvents(
     applicationId: string,
     userId: string,
@@ -916,7 +1127,7 @@ export class PrismaAdapter implements DatabaseAdapter {
     if (!owns) throw new Error("not_found");
     const rows = await prisma.applicationEvent.findMany({
       where: { applicationId: nid(applicationId), userId },
-      orderBy: { occurredAt: "desc" },
+      orderBy: [{ occurredAt: "desc" }, { id: "desc" }],
       take: Math.max(1, Math.min(500, limit)),
     });
     return rows.map(mapEvent);
@@ -1016,7 +1227,7 @@ export class PrismaAdapter implements DatabaseAdapter {
           if (item.appliedAt !== undefined) data.appliedAt = item.appliedAt;
           if (item.lastContact !== undefined) data.lastContact = item.lastContact;
           if (item.followUpAt !== undefined) data.followUpAt = item.followUpAt;
-          if (item.notes !== undefined) data.notes = item.notes;
+          if (item.notes !== undefined) data.notes = validateApplicationSummary(item.notes);
           if (item.jobDescription !== undefined) data.jobDescription = item.jobDescription;
           if (item.source !== undefined) data.source = item.source;
           if (item.remote !== undefined) data.remote = item.remote;
@@ -1050,7 +1261,7 @@ export class PrismaAdapter implements DatabaseAdapter {
               appliedAt: resolveAppliedAtForCreate(item.status || "inbound", item.appliedAt),
               lastContact: item.lastContact ?? null,
               followUpAt: item.followUpAt ?? null,
-              notes: item.notes ?? null,
+              notes: validateApplicationSummary(item.notes),
               jobDescription: item.jobDescription ?? null,
               source: item.source ?? null,
               remote: item.remote ?? false,

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -1,3 +1,5 @@
+import type { ApplicationEventType } from "@/lib/applications/events";
+
 // ── Submission policy contract ───────────────────────────────────────────────
 
 export type ProfileConsistencyStatus = "verified" | "unavailable_reviewed";
@@ -156,8 +158,51 @@ export interface ApplicationEventRecord {
   occurredAt: Date;
   source: string | null;
   actor: string | null;
+  contactId: string | null;
+  outcome: string | null;
   metadata: Record<string, unknown> | null;
   createdAt: Date;
+  application?: ApplicationRef;
+}
+
+export interface ApplicationEventCursor {
+  version: 1;
+  occurredAt: string;
+  id: string;
+}
+
+export interface ListApplicationEventsFilter {
+  applicationId?: string;
+  company?: string;
+  types?: string[];
+  occurredAfter?: Date;
+  occurredBefore?: Date;
+  source?: string;
+  actor?: string;
+  contactId?: string;
+  outcome?: string;
+  cursor?: ApplicationEventCursor;
+  order: "newest" | "oldest";
+  limit: number;
+}
+
+export interface ApplicationEventPage {
+  items: ApplicationEventRecord[];
+  nextCursor: string | null;
+}
+
+export interface RecordApplicationEventInput extends CreateApplicationEventInput {
+  type: ApplicationEventType;
+  idempotencyKey?: string;
+  expectedUpdatedAt?: Date;
+  contactId?: string | null;
+  outcome?: string | null;
+}
+
+export interface RecordApplicationEventResult {
+  event: ApplicationEventRecord;
+  application: ApplicationRecord;
+  replayed: boolean;
 }
 
 export interface ApplicationRef {

--- a/lib/email/__tests__/application-events.test.ts
+++ b/lib/email/__tests__/application-events.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ recordApplicationEvent: vi.fn() }));
+
+vi.mock("@/lib/db/prisma-adapter", () => ({
+  PrismaAdapter: class {
+    recordApplicationEvent = mocks.recordApplicationEvent;
+  },
+}));
+
+import { recordEmailLifecycleTransition } from "../application-events";
+
+const base = {
+  applicationId: 42,
+  userId: "owner-1",
+  occurredAt: new Date("2026-07-24T10:00:00Z"),
+  scannedEmailId: 7,
+  expectedUpdatedAt: new Date("2026-07-24T09:00:00Z"),
+};
+
+describe("recordEmailLifecycleTransition", () => {
+  beforeEach(() => mocks.recordApplicationEvent.mockReset());
+
+  it.each([
+    ["interview", "stage_changed", { toStatus: "interview", toStage: "interview" }],
+    ["offer", "offer_received", {}],
+    ["rejected", "application_rejected", {}],
+  ])("records %s atomically as %s", async (status, type, metadata) => {
+    await recordEmailLifecycleTransition({ ...base, status });
+
+    expect(mocks.recordApplicationEvent).toHaveBeenCalledWith("42", "owner-1", {
+      type,
+      occurredAt: base.occurredAt,
+      source: "email",
+      actor: "system",
+      metadata,
+      idempotencyKey: `email-lifecycle:7:${status}`,
+      expectedUpdatedAt: base.expectedUpdatedAt,
+    });
+  });
+});

--- a/lib/email/__tests__/application-events.test.ts
+++ b/lib/email/__tests__/application-events.test.ts
@@ -1,14 +1,28 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mocks = vi.hoisted(() => ({ recordApplicationEvent: vi.fn() }));
+const mocks = vi.hoisted(() => ({
+  recordApplicationEvent: vi.fn(),
+  applicationCreate: vi.fn(),
+  applicationUpdate: vi.fn(),
+  eventCreate: vi.fn(),
+  transaction: vi.fn(),
+}));
 
 vi.mock("@/lib/db/prisma-adapter", () => ({
   PrismaAdapter: class {
     recordApplicationEvent = mocks.recordApplicationEvent;
   },
 }));
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    $transaction: mocks.transaction,
+  },
+}));
 
-import { recordEmailLifecycleTransition } from "../application-events";
+import {
+  createEmailApplicationWithLifecycle,
+  recordEmailLifecycleTransition,
+} from "../application-events";
 
 const base = {
   applicationId: 42,
@@ -19,7 +33,19 @@ const base = {
 };
 
 describe("recordEmailLifecycleTransition", () => {
-  beforeEach(() => mocks.recordApplicationEvent.mockReset());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.applicationCreate.mockResolvedValue({ id: 99 });
+    mocks.applicationUpdate.mockResolvedValue({ id: 99 });
+    mocks.eventCreate.mockResolvedValue({ id: 1 });
+    mocks.transaction.mockImplementation(async (callback) => callback({
+      application: {
+        create: mocks.applicationCreate,
+        update: mocks.applicationUpdate,
+      },
+      applicationEvent: { create: mocks.eventCreate },
+    }));
+  });
 
   it.each([
     ["interview", "stage_changed", { toStatus: "interview", toStage: "interview" }],
@@ -36,6 +62,38 @@ describe("recordEmailLifecycleTransition", () => {
       metadata,
       idempotencyKey: `email-lifecycle:7:${status}`,
       expectedUpdatedAt: base.expectedUpdatedAt,
+    });
+  });
+
+  it.each([
+    ["interview", "stage_changed", "interview"],
+    ["offer", "offer_received", "offer"],
+    ["rejected", "application_rejected", "rejected"],
+  ])("creates a new %s application and its %s event atomically", async (status, type, projectedStatus) => {
+    const id = await createEmailApplicationWithLifecycle({
+      userId: "owner-1",
+      company: "Acme",
+      role: "Engineer",
+      status,
+      occurredAt: base.occurredAt,
+      scannedEmailId: 7,
+    });
+
+    expect(id).toBe(99);
+    expect(mocks.applicationCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({ status: "applied", source: "email" }),
+    });
+    expect(mocks.applicationUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ status: projectedStatus, eventVersion: { increment: 1 } }),
+    }));
+    expect(mocks.eventCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        applicationId: 99,
+        type,
+        source: "email",
+        actor: "system",
+        requestHash: expect.any(String),
+      }),
     });
   });
 });

--- a/lib/email/__tests__/scanner.test.ts
+++ b/lib/email/__tests__/scanner.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  integrationFind: vi.fn(),
+  integrationUpdate: vi.fn(),
+  scannedFindMany: vi.fn(),
+  scannedCreate: vi.fn(),
+  scannedDelete: vi.fn(),
+  scannedUpdate: vi.fn(),
+  applicationFind: vi.fn(),
+  applicationCreate: vi.fn(),
+  fetchNewMessages: vi.fn(),
+  getMessageDetail: vi.fn(),
+  classifyEmail: vi.fn(),
+  recordLifecycle: vi.fn(),
+  loggerError: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    emailIntegration: {
+      findUnique: mocks.integrationFind,
+      update: mocks.integrationUpdate,
+    },
+    scannedEmail: {
+      findMany: mocks.scannedFindMany,
+      create: mocks.scannedCreate,
+      delete: mocks.scannedDelete,
+      update: mocks.scannedUpdate,
+    },
+    application: {
+      findFirst: mocks.applicationFind,
+      create: mocks.applicationCreate,
+    },
+  },
+}));
+vi.mock("../gmail", () => ({
+  fetchNewMessages: mocks.fetchNewMessages,
+  getMessageDetail: mocks.getMessageDetail,
+}));
+vi.mock("../classifier", () => ({ classifyEmail: mocks.classifyEmail }));
+vi.mock("../application-events", () => ({
+  recordEmailLifecycleTransition: mocks.recordLifecycle,
+}));
+vi.mock("@/lib/logger", () => ({ logger: { error: mocks.loggerError } }));
+
+import { scanUserInbox } from "../scanner";
+
+const receivedAt = new Date("2026-07-24T09:00:00Z");
+
+describe("scanUserInbox auto-import retries", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.integrationFind.mockResolvedValue({
+      enabled: true,
+      encryptedToken: "encrypted",
+      lastHistoryId: "history-old",
+      scanDaysBack: 7,
+      autoImport: "auto",
+    });
+    mocks.fetchNewMessages.mockResolvedValue({
+      messages: [{ id: "message-1" }],
+      latestHistoryId: "history-new",
+    });
+    mocks.scannedFindMany.mockResolvedValue([]);
+    mocks.getMessageDetail.mockResolvedValue({
+      messageId: "message-1",
+      subject: "Interview invitation",
+      sender: "recruiter@example.com",
+      bodySnippet: "Let us schedule an interview",
+      receivedAt,
+    });
+    mocks.classifyEmail.mockReturnValue({
+      classification: "interview",
+      confidence: "high",
+      company: "Acme",
+      role: "Engineer",
+    });
+    mocks.scannedCreate.mockResolvedValue({ id: 7 });
+    mocks.applicationFind.mockResolvedValue({
+      id: 42,
+      status: "applied",
+      updatedAt: new Date("2026-07-24T08:00:00Z"),
+    });
+    mocks.scannedDelete.mockResolvedValue({});
+    mocks.scannedUpdate.mockResolvedValue({});
+    mocks.integrationUpdate.mockResolvedValue({});
+  });
+
+  it("keeps the Gmail history cursor on an auto-import conflict", async () => {
+    mocks.recordLifecycle.mockRejectedValueOnce(new Error("conflict"));
+
+    const result = await scanUserInbox("owner-1");
+
+    expect(result.autoImported).toBe(0);
+    expect(mocks.scannedDelete).toHaveBeenCalledWith({ where: { id: 7 } });
+    expect(mocks.integrationUpdate).toHaveBeenCalledWith({
+      where: { userId: "owner-1" },
+      data: {
+        lastHistoryId: "history-old",
+        lastScanAt: expect.any(Date),
+      },
+    });
+  });
+
+  it("advances the Gmail history cursor after a successful auto-import", async () => {
+    mocks.recordLifecycle.mockResolvedValueOnce(undefined);
+
+    const result = await scanUserInbox("owner-1");
+
+    expect(result.autoImported).toBe(1);
+    expect(mocks.scannedDelete).not.toHaveBeenCalled();
+    expect(mocks.integrationUpdate).toHaveBeenCalledWith({
+      where: { userId: "owner-1" },
+      data: {
+        lastHistoryId: "history-new",
+        lastScanAt: expect.any(Date),
+      },
+    });
+  });
+});

--- a/lib/email/__tests__/scanner.test.ts
+++ b/lib/email/__tests__/scanner.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   getMessageDetail: vi.fn(),
   classifyEmail: vi.fn(),
   recordLifecycle: vi.fn(),
+  createLifecycle: vi.fn(),
   loggerError: vi.fn(),
 }));
 
@@ -41,6 +42,7 @@ vi.mock("../gmail", () => ({
 vi.mock("../classifier", () => ({ classifyEmail: mocks.classifyEmail }));
 vi.mock("../application-events", () => ({
   recordEmailLifecycleTransition: mocks.recordLifecycle,
+  createEmailApplicationWithLifecycle: mocks.createLifecycle,
 }));
 vi.mock("@/lib/logger", () => ({ logger: { error: mocks.loggerError } }));
 
@@ -84,6 +86,7 @@ describe("scanUserInbox auto-import retries", () => {
     });
     mocks.scannedDelete.mockResolvedValue({});
     mocks.scannedUpdate.mockResolvedValue({});
+    mocks.createLifecycle.mockResolvedValue(42);
     mocks.integrationUpdate.mockResolvedValue({});
   });
 
@@ -116,6 +119,25 @@ describe("scanUserInbox auto-import retries", () => {
         lastHistoryId: "history-new",
         lastScanAt: expect.any(Date),
       },
+    });
+  });
+
+  it("creates a new interview application through the atomic lifecycle workflow", async () => {
+    mocks.applicationFind.mockResolvedValueOnce(null);
+
+    await scanUserInbox("owner-1");
+
+    expect(mocks.createLifecycle).toHaveBeenCalledWith({
+      userId: "owner-1",
+      company: "Acme",
+      role: "Engineer",
+      status: "interview",
+      occurredAt: receivedAt,
+      scannedEmailId: 7,
+    });
+    expect(mocks.scannedUpdate).toHaveBeenCalledWith({
+      where: { id: 7 },
+      data: { applicationId: 42, status: "imported" },
     });
   });
 });

--- a/lib/email/application-events.ts
+++ b/lib/email/application-events.ts
@@ -1,0 +1,37 @@
+import { PrismaAdapter } from "@/lib/db/prisma-adapter";
+
+const events = new PrismaAdapter();
+
+type EmailLifecycleStatus = "interview" | "offer" | "rejected";
+
+export async function recordEmailLifecycleTransition(input: {
+  applicationId: number;
+  userId: string;
+  status: string;
+  occurredAt: Date;
+  scannedEmailId: number;
+  expectedUpdatedAt: Date;
+}): Promise<void> {
+  if (!["interview", "offer", "rejected"].includes(input.status)) {
+    throw new Error("invalid_email_lifecycle_status");
+  }
+  const status = input.status as EmailLifecycleStatus;
+  const type = status === "offer"
+    ? "offer_received"
+    : status === "rejected"
+      ? "application_rejected"
+      : "stage_changed";
+  const metadata = status === "interview"
+    ? { toStatus: "interview", toStage: "interview" }
+    : {};
+
+  await events.recordApplicationEvent(String(input.applicationId), input.userId, {
+    type,
+    occurredAt: input.occurredAt,
+    source: "email",
+    actor: "system",
+    metadata,
+    idempotencyKey: `email-lifecycle:${input.scannedEmailId}:${input.status}`,
+    expectedUpdatedAt: input.expectedUpdatedAt,
+  });
+}

--- a/lib/email/application-events.ts
+++ b/lib/email/application-events.ts
@@ -1,8 +1,22 @@
 import { PrismaAdapter } from "@/lib/db/prisma-adapter";
+import { prisma } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+import { deriveEventProjection } from "@/lib/applications/events";
+import { submissionRequestHash } from "@/lib/applications/submission";
 
 const events = new PrismaAdapter();
 
-type EmailLifecycleStatus = "interview" | "offer" | "rejected";
+function lifecycleEvent(status: string): {
+  type: "stage_changed" | "offer_received" | "application_rejected";
+  metadata: Record<string, unknown>;
+} | null {
+  if (status === "interview") {
+    return { type: "stage_changed", metadata: { toStatus: "interview", toStage: "interview" } };
+  }
+  if (status === "offer") return { type: "offer_received", metadata: {} };
+  if (status === "rejected") return { type: "application_rejected", metadata: {} };
+  return null;
+}
 
 export async function recordEmailLifecycleTransition(input: {
   applicationId: number;
@@ -12,26 +26,74 @@ export async function recordEmailLifecycleTransition(input: {
   scannedEmailId: number;
   expectedUpdatedAt: Date;
 }): Promise<void> {
-  if (!["interview", "offer", "rejected"].includes(input.status)) {
+  const command = lifecycleEvent(input.status);
+  if (!command) {
     throw new Error("invalid_email_lifecycle_status");
   }
-  const status = input.status as EmailLifecycleStatus;
-  const type = status === "offer"
-    ? "offer_received"
-    : status === "rejected"
-      ? "application_rejected"
-      : "stage_changed";
-  const metadata = status === "interview"
-    ? { toStatus: "interview", toStage: "interview" }
-    : {};
 
   await events.recordApplicationEvent(String(input.applicationId), input.userId, {
-    type,
+    type: command.type,
     occurredAt: input.occurredAt,
     source: "email",
     actor: "system",
-    metadata,
+    metadata: command.metadata,
     idempotencyKey: `email-lifecycle:${input.scannedEmailId}:${input.status}`,
     expectedUpdatedAt: input.expectedUpdatedAt,
+  });
+}
+
+export async function createEmailApplicationWithLifecycle(input: {
+  userId: string;
+  company: string;
+  role: string;
+  status: string;
+  occurredAt: Date;
+  scannedEmailId: number;
+}): Promise<number> {
+  const command = lifecycleEvent(input.status);
+  return prisma.$transaction(async (tx) => {
+    const application = await tx.application.create({
+      data: {
+        userId: input.userId,
+        company: input.company,
+        role: input.role,
+        status: command ? "applied" : input.status,
+        source: "email",
+        appliedAt: input.occurredAt,
+      },
+    });
+    if (!command) return application.id;
+
+    const { patch, metadata } = deriveEventProjection(
+      { type: command.type, occurredAt: input.occurredAt, metadata: command.metadata },
+      { status: "applied", currentStage: null, followUpAt: null },
+    );
+    await tx.application.update({
+      where: { id: application.id, userId: input.userId },
+      data: { ...patch, eventVersion: { increment: 1 } },
+    });
+    const idempotencyKey = `email-lifecycle:new:${input.scannedEmailId}:${input.status}`;
+    const requestHash = submissionRequestHash({
+      applicationId: String(application.id),
+      type: command.type,
+      occurredAt: input.occurredAt,
+      source: "email",
+      actor: "system",
+      metadata,
+    });
+    await tx.applicationEvent.create({
+      data: {
+        userId: input.userId,
+        applicationId: application.id,
+        type: command.type,
+        idempotencyKey,
+        requestHash,
+        occurredAt: input.occurredAt,
+        source: "email",
+        actor: "system",
+        metadata: metadata as Prisma.InputJsonValue,
+      },
+    });
+    return application.id;
   });
 }

--- a/lib/email/scanner.ts
+++ b/lib/email/scanner.ts
@@ -50,6 +50,7 @@ export async function scanUserInbox(userId: string): Promise<ScanResult> {
     select: { messageId: true },
   });
   const existingMessageIds = new Set(existingScans.map(scan => scan.messageId));
+  let retryFromCurrentHistory = false;
 
   for (const msg of messages) {
     result.processed++;
@@ -107,6 +108,7 @@ export async function scanUserInbox(userId: string): Promise<ScanResult> {
         } catch (error) {
           // Leave the Gmail message retryable instead of stranding an
           // "imported" row without an application or lifecycle event.
+          retryFromCurrentHistory = true;
           await prisma.scannedEmail.delete({ where: { id: scanned.id } });
           throw error;
         }
@@ -120,7 +122,9 @@ export async function scanUserInbox(userId: string): Promise<ScanResult> {
   await prisma.emailIntegration.update({
     where: { userId },
     data: {
-      lastHistoryId: latestHistoryId ?? integration.lastHistoryId,
+      lastHistoryId: retryFromCurrentHistory
+        ? integration.lastHistoryId
+        : latestHistoryId ?? integration.lastHistoryId,
       lastScanAt: new Date(),
     },
   });

--- a/lib/email/scanner.ts
+++ b/lib/email/scanner.ts
@@ -155,7 +155,7 @@ async function autoImportAsApplication(
     if (isProgression && existing.status !== "rejected") {
       await prisma.application.update({
         where: { id: existing.id },
-        data: { status: appStatus },
+        data: { status: appStatus, eventVersion: { increment: 1 } },
       });
     }
 

--- a/lib/email/scanner.ts
+++ b/lib/email/scanner.ts
@@ -2,7 +2,10 @@ import { prisma } from "@/lib/prisma";
 import { fetchNewMessages, getMessageDetail } from "./gmail";
 import { classifyEmail } from "./classifier";
 import { logger } from "@/lib/logger";
-import { recordEmailLifecycleTransition } from "./application-events";
+import {
+  createEmailApplicationWithLifecycle,
+  recordEmailLifecycleTransition,
+} from "./application-events";
 
 export interface ScanResult {
   userId: string;
@@ -181,21 +184,21 @@ async function autoImportAsApplication(
     return;
   }
 
-  // Create new application
-  const app = await prisma.application.create({
-    data: {
-      userId,
-      company: data.company,
-      role: data.role ?? "Unknown Role",
-      status: data.classification === "rejection" ? "rejected" : (data.classification ?? "applied"),
-      source: "email",
-      appliedAt: new Date(),
-    },
+  const status = data.classification === "rejection"
+    ? "rejected"
+    : data.classification ?? "applied";
+  const applicationId = await createEmailApplicationWithLifecycle({
+    userId,
+    company: data.company,
+    role: data.role ?? "Unknown Role",
+    status,
+    occurredAt,
+    scannedEmailId,
   });
 
   await prisma.scannedEmail.update({
     where: { id: scannedEmailId },
-    data: { applicationId: app.id, status: "imported" },
+    data: { applicationId, status: "imported" },
   });
 }
 

--- a/lib/email/scanner.ts
+++ b/lib/email/scanner.ts
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { fetchNewMessages, getMessageDetail } from "./gmail";
 import { classifyEmail } from "./classifier";
 import { logger } from "@/lib/logger";
+import { recordEmailLifecycleTransition } from "./application-events";
 
 export interface ScanResult {
   userId: string;
@@ -82,9 +83,6 @@ export async function scanUserInbox(userId: string): Promise<ScanResult> {
         role: classification.role,
       });
 
-      const status =
-        integration.autoImport === "auto" ? "imported" : "pending";
-
       const scanned = await prisma.scannedEmail.create({
         data: {
           userId,
@@ -95,7 +93,7 @@ export async function scanUserInbox(userId: string): Promise<ScanResult> {
           classification: classification.classification,
           confidence: classification.confidence,
           extractedData,
-          status,
+          status: "pending",
         },
       });
 
@@ -103,8 +101,15 @@ export async function scanUserInbox(userId: string): Promise<ScanResult> {
 
       // Auto-import if configured
       if (integration.autoImport === "auto" && classification.company) {
-        await autoImportAsApplication(userId, scanned.id, classification);
-        result.autoImported++;
+        try {
+          await autoImportAsApplication(userId, scanned.id, detail.receivedAt, classification);
+          result.autoImported++;
+        } catch (error) {
+          // Leave the Gmail message retryable instead of stranding an
+          // "imported" row without an application or lifecycle event.
+          await prisma.scannedEmail.delete({ where: { id: scanned.id } });
+          throw error;
+        }
       }
     } catch (err) {
       logger.error(`Failed to process message ${msg.id}:`, err);
@@ -126,6 +131,7 @@ export async function scanUserInbox(userId: string): Promise<ScanResult> {
 async function autoImportAsApplication(
   userId: string,
   scannedEmailId: number,
+  occurredAt: Date,
   data: { company: string | null; role: string | null; classification: string | null }
 ): Promise<void> {
   if (!data.company) return;
@@ -153,9 +159,13 @@ async function autoImportAsApplication(
     const isProgression = appStatus === "rejected" || (newRank > currentRank && currentRank >= 0);
 
     if (isProgression && existing.status !== "rejected") {
-      await prisma.application.update({
-        where: { id: existing.id },
-        data: { status: appStatus, eventVersion: { increment: 1 } },
+      await recordEmailLifecycleTransition({
+        applicationId: existing.id,
+        userId,
+        status: appStatus,
+        occurredAt,
+        scannedEmailId,
+        expectedUpdatedAt: existing.updatedAt,
       });
     }
 

--- a/messages/de.json
+++ b/messages/de.json
@@ -774,11 +774,10 @@
     },
     "metadata": {
       "fromStage": "Vorherige Phase", "toStage": "Neue Phase", "fromStatus": "Vorheriger Status", "toStatus": "Neuer Status",
-      "interviewType": "Interview-Typ", "scheduledAt": "Geplant für", "durationMinutes": "Dauer (Minuten)", "location": "Ort", "meetingUrl": "Meeting-Link",
+      "channel": "Kanal", "interviewType": "Interview-Typ", "scheduledAt": "Geplant für", "durationMinutes": "Dauer (Minuten)",
       "contactId": "Kontakt", "outcome": "Ergebnis", "nextAction": "Nächster Schritt", "followUpAt": "Follow-up", "reason": "Grund",
-      "offerType": "Angebotsart", "compensationSummary": "Vergütung", "documentId": "Dokument", "filename": "Dateiname", "note": "Zeitleisten-Notiz",
-      "policyVersion": "Richtlinienversion", "submittedDocumentIds": "Eingereichte Dokumente", "submissionId": "Einreichung", "atsName": "ATS", "requisitionId": "Ausschreibung",
-      "answersCount": "Antworten", "documentCount": "Dokumente", "dryRun": "Testlauf"
+      "documentId": "Dokument", "documentIds": "Eingereichte Dokumente", "documentType": "Dokumenttyp", "submissionId": "Einreichung",
+      "answerCount": "Antworten", "policy": "Einreichungsrichtlinie", "note": "Zeitleisten-Notiz"
     }
   },
   "timeline": {

--- a/messages/de.json
+++ b/messages/de.json
@@ -9,6 +9,7 @@
   "nav": {
     "logout": "Abmelden",
     "opportunities": "Opportunities",
+    "activity": "Aktivität",
     "account_menu": "Konto und Darstellung",
     "signed_in_as": "Angemeldet als",
     "theme": "Darstellung",
@@ -100,7 +101,11 @@
     "last_contact": "Letzter Kontakt",
     "follow_up": "Follow-up Datum",
     "notes": "Notizen",
+    "summary": "Zusammenfassung",
     "notes_placeholder": "Details, Links...",
+    "notes_summary_help": "Kurze aktuelle Zusammenfassung; chronologische Aktivitäten gehören in die Zeitleiste.",
+    "notes_limit_warning": "Die Zusammenfassung nähert sich der Grenze von 10.000 Zeichen.",
+    "lifecycle_timeline_help": "Status-, Phasen-, Kontakt- und Nachfassänderungen werden in der Zeitleiste erfasst.",
     "job_description": "Leistungsumfang",
     "job_description_placeholder": "Anforderungen oder Leistungsumfang hier einfügen...",
     "job_description_toggle_show": "📄 Leistungsumfang anzeigen",
@@ -750,5 +755,50 @@
     "create": "Neue Opportunity",
     "clear_filters": "Filter löschen",
     "dismiss_overdue": "Überfällige Wiedervorlage für {company} ausblenden"
+  },
+  "events": {
+    "eventTypes": {
+      "opportunity_discovered": "Opportunity entdeckt",
+      "application_submitted": "Bewerbung eingereicht",
+      "recruiter_contacted": "Recruiter kontaktiert",
+      "stage_changed": "Phase geändert",
+      "interview_invited": "Interview-Einladung erhalten",
+      "interview_scheduled": "Interview geplant",
+      "interview_completed": "Interview abgeschlossen",
+      "feedback_received": "Feedback erhalten",
+      "follow_up_scheduled": "Follow-up geplant",
+      "offer_received": "Angebot erhalten",
+      "application_rejected": "Bewerbung abgelehnt",
+      "document_attached": "Dokument angehängt",
+      "note_added": "Zeitleisten-Notiz hinzugefügt"
+    },
+    "metadata": {
+      "fromStage": "Vorherige Phase", "toStage": "Neue Phase", "fromStatus": "Vorheriger Status", "toStatus": "Neuer Status",
+      "interviewType": "Interview-Typ", "scheduledAt": "Geplant für", "durationMinutes": "Dauer (Minuten)", "location": "Ort", "meetingUrl": "Meeting-Link",
+      "contactId": "Kontakt", "outcome": "Ergebnis", "nextAction": "Nächster Schritt", "followUpAt": "Follow-up", "reason": "Grund",
+      "offerType": "Angebotsart", "compensationSummary": "Vergütung", "documentId": "Dokument", "filename": "Dateiname", "note": "Zeitleisten-Notiz",
+      "policyVersion": "Richtlinienversion", "submittedDocumentIds": "Eingereichte Dokumente", "submissionId": "Einreichung", "atsName": "ATS", "requisitionId": "Ausschreibung",
+      "answersCount": "Antworten", "documentCount": "Dokumente", "dryRun": "Testlauf"
+    }
+  },
+  "timeline": {
+    "title": "Bewerbungszeitleiste",
+    "description": "Unveränderlicher Aktivitätsverlauf; die Bewerbung bleibt der aktuelle Zustand.",
+    "order": "Reihenfolge der Zeitleiste", "newest": "Neueste zuerst", "oldest": "Älteste zuerst",
+    "record_activity": "Aktivität erfassen", "cancel": "Abbrechen", "save_first": "Bewerbungsänderungen vor dem Erfassen speichern",
+    "activity": "Aktivität", "occurred_at": "Zeitpunkt", "recorded_at": "Erfasst {date}",
+    "new_stage": "Neue Phase", "status_optional": "Status (optional)", "interview_type": "Interview-Typ", "scheduled_for": "Geplant für",
+    "follow_up": "Follow-up", "next_action": "Nächster Schritt", "preparation": "Vorbereitung / nächster Schritt", "outcome": "Ergebnis", "reason": "Grund", "timeline_note": "Zeitleisten-Notiz",
+    "record_event": "Ereignis erfassen", "recording": "Wird erfasst…", "loading": "Zeitleiste wird geladen…", "load_error": "Die Zeitleiste konnte nicht geladen werden.",
+    "empty": "Noch keine Ereignisse. Bestehende Notizen bleiben als Zusammenfassung erhalten und werden nicht rückwirkend umgewandelt.", "load_more": "Mehr laden", "loading_more": "Wird geladen…",
+    "contact_link": "Kontakt {id}", "document_link": "Dokument {id}", "submission_link": "Einreichung {id}"
+  },
+  "activityFeed": {
+    "title": "Aktivität", "description": "Eigentümerbezogener Verlauf über alle Bewerbungen.",
+    "company": "Unternehmen", "application_id": "Bewerbungs-ID", "event_type": "Ereignistyp", "all_types": "Alle Ereignistypen", "order": "Reihenfolge",
+    "newest": "Neueste zuerst", "oldest": "Älteste zuerst", "source": "Quelle", "actor": "Akteur", "contact_id": "Kontakt-ID", "outcome": "Ergebnis",
+    "from": "Von", "to": "Bis", "clear": "Löschen", "apply": "Filter anwenden", "loading": "Aktivität wird geladen…",
+    "empty": "Keine Ereignisse entsprechen diesen Filtern. Der Verlauf wurde nicht gelöscht.", "load_more": "Mehr laden", "loading_more": "Wird geladen…",
+    "more_available": "Weitere Aktivitäten sind verfügbar", "load_error": "Aktivität konnte nicht geladen werden.", "application_link": "Bewerbung {id}"
   }
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -784,6 +784,7 @@
   "timeline": {
     "title": "Bewerbungszeitleiste",
     "description": "Unveränderlicher Aktivitätsverlauf; die Bewerbung bleibt der aktuelle Zustand.",
+    "unknown_event": "Unbekanntes Ereignis ({type})",
     "order": "Reihenfolge der Zeitleiste", "newest": "Neueste zuerst", "oldest": "Älteste zuerst",
     "record_activity": "Aktivität erfassen", "cancel": "Abbrechen", "save_first": "Bewerbungsänderungen vor dem Erfassen speichern",
     "activity": "Aktivität", "occurred_at": "Zeitpunkt", "recorded_at": "Erfasst {date}",

--- a/messages/en.json
+++ b/messages/en.json
@@ -784,6 +784,7 @@
   "timeline": {
     "title": "Application timeline",
     "description": "Immutable activity history; the application remains the current state.",
+    "unknown_event": "Unknown event ({type})",
     "order": "Timeline order", "newest": "Newest first", "oldest": "Oldest first",
     "record_activity": "Record activity", "cancel": "Cancel", "save_first": "Save application edits before recording activity",
     "activity": "Activity", "occurred_at": "Occurred at", "recorded_at": "Recorded {date}",

--- a/messages/en.json
+++ b/messages/en.json
@@ -9,6 +9,7 @@
   "nav": {
     "logout": "Sign out",
     "opportunities": "Opportunities",
+    "activity": "Activity",
     "account_menu": "Account and display",
     "signed_in_as": "Signed in as",
     "theme": "Appearance",
@@ -100,7 +101,11 @@
     "last_contact": "Last Contact",
     "follow_up": "Follow-up Date",
     "notes": "Notes",
+    "summary": "Summary",
     "notes_placeholder": "Details, links...",
+    "notes_summary_help": "Keep a compact current summary; record chronological activity in the timeline.",
+    "notes_limit_warning": "This summary is approaching the 10,000-character limit.",
+    "lifecycle_timeline_help": "Record status, stage, contact, and follow-up changes in the timeline.",
     "job_description": "Scope of Work",
     "job_description_placeholder": "Paste the requirements or scope here...",
     "job_description_toggle_show": "📄 Show scope of work",
@@ -750,5 +755,50 @@
     "create": "New opportunity",
     "clear_filters": "Clear filters",
     "dismiss_overdue": "Dismiss overdue follow-up for {company}"
+  },
+  "events": {
+    "eventTypes": {
+      "opportunity_discovered": "Opportunity discovered",
+      "application_submitted": "Application submitted",
+      "recruiter_contacted": "Recruiter contacted",
+      "stage_changed": "Stage changed",
+      "interview_invited": "Interview invitation received",
+      "interview_scheduled": "Interview scheduled",
+      "interview_completed": "Interview completed",
+      "feedback_received": "Feedback received",
+      "follow_up_scheduled": "Follow-up scheduled",
+      "offer_received": "Offer received",
+      "application_rejected": "Application rejected",
+      "document_attached": "Document attached",
+      "note_added": "Timeline note added"
+    },
+    "metadata": {
+      "fromStage": "Previous stage", "toStage": "New stage", "fromStatus": "Previous status", "toStatus": "New status",
+      "interviewType": "Interview type", "scheduledAt": "Scheduled for", "durationMinutes": "Duration (minutes)", "location": "Location", "meetingUrl": "Meeting link",
+      "contactId": "Contact", "outcome": "Outcome", "nextAction": "Next action", "followUpAt": "Follow up", "reason": "Reason",
+      "offerType": "Offer type", "compensationSummary": "Compensation", "documentId": "Document", "filename": "Filename", "note": "Timeline note",
+      "policyVersion": "Policy version", "submittedDocumentIds": "Submitted documents", "submissionId": "Submission", "atsName": "ATS", "requisitionId": "Requisition",
+      "answersCount": "Answers", "documentCount": "Documents", "dryRun": "Dry run"
+    }
+  },
+  "timeline": {
+    "title": "Application timeline",
+    "description": "Immutable activity history; the application remains the current state.",
+    "order": "Timeline order", "newest": "Newest first", "oldest": "Oldest first",
+    "record_activity": "Record activity", "cancel": "Cancel", "save_first": "Save application edits before recording activity",
+    "activity": "Activity", "occurred_at": "Occurred at", "recorded_at": "Recorded {date}",
+    "new_stage": "New stage", "status_optional": "Status (optional)", "interview_type": "Interview type", "scheduled_for": "Scheduled for",
+    "follow_up": "Follow up", "next_action": "Next action", "preparation": "Preparation / next action", "outcome": "Outcome", "reason": "Reason", "timeline_note": "Timeline note",
+    "record_event": "Record event", "recording": "Recording…", "loading": "Loading timeline…", "load_error": "Could not load the timeline.",
+    "empty": "No timeline events yet. Existing notes are preserved as summary text and are not backfilled.", "load_more": "Load more", "loading_more": "Loading…",
+    "contact_link": "Contact {id}", "document_link": "Document {id}", "submission_link": "Submission {id}"
+  },
+  "activityFeed": {
+    "title": "Activity", "description": "Owner-scoped history across all applications.",
+    "company": "Company", "application_id": "Application ID", "event_type": "Event type", "all_types": "All event types", "order": "Order",
+    "newest": "Newest first", "oldest": "Oldest first", "source": "Source", "actor": "Actor", "contact_id": "Contact ID", "outcome": "Outcome",
+    "from": "From", "to": "To", "clear": "Clear", "apply": "Apply filters", "loading": "Loading activity…",
+    "empty": "No events match these filters. Your history has not been deleted.", "load_more": "Load more", "loading_more": "Loading…",
+    "more_available": "More activity is available", "load_error": "Could not load activity.", "application_link": "Application {id}"
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -774,11 +774,10 @@
     },
     "metadata": {
       "fromStage": "Previous stage", "toStage": "New stage", "fromStatus": "Previous status", "toStatus": "New status",
-      "interviewType": "Interview type", "scheduledAt": "Scheduled for", "durationMinutes": "Duration (minutes)", "location": "Location", "meetingUrl": "Meeting link",
+      "channel": "Channel", "interviewType": "Interview type", "scheduledAt": "Scheduled for", "durationMinutes": "Duration (minutes)",
       "contactId": "Contact", "outcome": "Outcome", "nextAction": "Next action", "followUpAt": "Follow up", "reason": "Reason",
-      "offerType": "Offer type", "compensationSummary": "Compensation", "documentId": "Document", "filename": "Filename", "note": "Timeline note",
-      "policyVersion": "Policy version", "submittedDocumentIds": "Submitted documents", "submissionId": "Submission", "atsName": "ATS", "requisitionId": "Requisition",
-      "answersCount": "Answers", "documentCount": "Documents", "dryRun": "Dry run"
+      "documentId": "Document", "documentIds": "Submitted documents", "documentType": "Document type", "submissionId": "Submission",
+      "answerCount": "Answers", "policy": "Submission policy", "note": "Timeline note"
     }
   },
   "timeline": {

--- a/openspec/changes/first-class-application-events/.openspec.yaml
+++ b/openspec/changes/first-class-application-events/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/first-class-application-events/design.md
+++ b/openspec/changes/first-class-application-events/design.md
@@ -1,0 +1,94 @@
+## Context
+
+`ApplicationEvent` already exists in Prisma and Firestore and is exposed through append/list REST and MCP operations. It currently accepts arbitrary strings and generic metadata, updates no application projection, has no cross-application query, and is absent from the UI. Submission recording is the one mature compound transaction: it creates an immutable package and canonical event while updating application state. The new detail page provides a stable surface for an event-first experience, but its application PATCH route still silently truncates notes and mutates lifecycle fields without history.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make lifecycle history typed, immutable, visible, owner-scoped, and queryable.
+- Keep application projection and event history consistent through backend transactions.
+- Provide deterministic replay, concurrency control, cursor pagination, REST/MCP parity, and Prisma/Firestore parity.
+- Preserve all existing notes/events and keep submission evidence immutable.
+- Give users per-application and global activity experiences without turning notes into a hidden log.
+
+**Non-Goals:**
+
+- Rebuild application state by replaying events or introduce full event sourcing.
+- Claim existing prose or legacy event metadata is authoritative structured history.
+- Replace immutable submission/document records with event metadata.
+- Build compliance-grade auditing or unrestricted metadata search.
+- Remove legacy application fields or existing event endpoints.
+
+## Decisions
+
+### Decision 1: Canonical commands sit above the shared adapter
+
+A shared domain module owns event constants, event-specific metadata normalization, controlled validation codes, and derivation of the allowed projection patch. REST and MCP call the same parser. The adapter accepts only normalized commands.
+
+Alternative: validate independently in each boundary. Rejected because REST/MCP behavior would drift and backend code would receive untrusted shapes.
+
+### Decision 2: Add `recordApplicationEvent` rather than overload append-only creation
+
+The adapter gains a compound command returning `{ event, application, replayed }`. Existing `createApplicationEvent` remains for compatibility and non-projecting legacy callers, but new lifecycle REST/MCP tools use the compound method. The submission transaction remains specialized and emits the canonical submission type.
+
+The compound command transaction boundaries are:
+
+- Prisma: owner-scoped transaction, application row concurrency check/update, unique event insert, and replay lookup within one transaction.
+- Firestore: transaction reads the application and deterministic event document, verifies owner/concurrency/hash, then creates the event and updates the application.
+
+Alternative: create an event and call `updateApplication` separately. Rejected because partial success recreates the consistency problem.
+
+### Decision 3: Projection updates are derived, not arbitrary
+
+Event metadata never contains a free-form application patch. The domain parser derives a whitelist limited to `status`, `currentStage`, `lastContact`, and `followUpAt` for the relevant event type. Before/after values are enriched from the transaction's current projection so clients cannot forge the previous state.
+
+Alternative: accept arbitrary projection fields. Rejected because it would make event commands a second unsafe general update API.
+
+### Decision 4: Denormalize query dimensions on events
+
+Add nullable `contactId` and `outcome` event columns/fields derived from validated metadata. This supports equivalent filters across PostgreSQL and Firestore without backend-specific JSON query behavior. Existing events leave these fields null and remain visible in unfiltered queries.
+
+Alternative: query JSON metadata directly. Rejected because Firestore/PostgreSQL query semantics and indexes differ.
+
+### Decision 5: Opaque cursor is occurrence time plus event identity
+
+Pages order by `(occurredAt, id)` in the selected direction. The cursor is a versioned base64url JSON payload and is validated centrally. Page size is bounded to 1–100. Each adapter fetches one extra matching row to decide whether to emit `nextCursor`. This avoids offset drift when new events arrive.
+
+For Firestore, compound queries order by `occurredAt` and document identity. Required composite indexes are additive. Prisma adds owner/occurrence and application/occurrence/id indexes.
+
+### Decision 6: Preserve old endpoints and add explicit paged surfaces
+
+The current application-events GET/list MCP behavior remains compatible. New timeline and global activity endpoints/tools expose paged results and filters. Event POST is upgraded to the canonical compound command response. OpenAPI documents both compatibility and new contracts.
+
+Alternative: change existing list response from an array to a page object. Rejected as an unnecessary breaking change.
+
+### Decision 7: Server-load the first UI page, then increment client-side
+
+The application page and new `/activity` page load the initial owner-scoped event page on the server. Reusable client components render events, change filters/order, and fetch subsequent opaque cursors. Application references are included in global results; linked resource IDs render as safe internal links only when present.
+
+### Decision 8: Notes validation is fail-closed at every mutation boundary
+
+Shared summary validation accepts null/empty values and rejects strings over 10,000 characters. Existing storage is untouched. UI presents a counter and warning threshold; it does not silently cut input. REST and MCP update tools call the same validation.
+
+## Risks / Trade-offs
+
+- [Broad cross-layer PR] → Implement and review vertical slices: domain contract, adapter transaction, query, API/MCP, then UI.
+- [Existing arbitrary event producers] → Preserve reads and append compatibility while requiring canonical types only on new compound commands.
+- [Firestore index deployment lag] → Commit indexes with the code and keep rollback compatible with old unpaged reads.
+- [Replay after later projection changes] → Return the original immutable event plus the current projection and mark `replayed`; never reapply an old projection patch.
+- [Filter combinations can require many Firestore indexes] → Use normalized dimensions and a documented primary owner/time ordering; apply secondary filters in bounded adapter scans only where Firestore cannot compose them safely.
+- [Event UI leaks sensitive metadata] → Render a fixed allowlist of human-readable metadata fields and linked identifiers; never dump arbitrary JSON by default.
+
+## Migration Plan
+
+1. Deploy the additive Prisma migration and Firestore indexes.
+2. Deploy readers that tolerate missing normalized dimensions.
+3. Deploy canonical command/query APIs and MCP tools while preserving existing list/read behavior.
+4. Deploy timeline/activity UI and notes guidance.
+5. Do not backfill or rewrite notes/events automatically.
+6. Rollback may leave additive nullable columns/indexes unused; old readers and data remain compatible.
+
+## Open Questions
+
+None blocking. A future explicit migration tool may let a user review and approve selected legacy-note events, but that is intentionally outside this change.

--- a/openspec/changes/first-class-application-events/proposal.md
+++ b/openspec/changes/first-class-application-events/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+Nexus already stores immutable `ApplicationEvent` rows, but event creation is an untyped append operation that is disconnected from application projection updates and invisible in the product UI. As a result, mutable notes still act as a fragile timeline, direct state changes can drift from history, and neither users nor agents can query a reliable cross-application activity stream.
+
+## What Changes
+
+- Define canonical application event types with bounded, event-specific metadata and controlled validation errors shared by REST and MCP.
+- Add an atomic event command that appends an immutable event and updates the owning `Application` projection in one Prisma or Firestore transaction, with deterministic replay/conflict behavior.
+- Route lifecycle operations for stage changes, interview scheduling/completion, follow-ups, rejections, and submissions through atomic event-plus-projection writes.
+- Add cursor-paginated, owner-scoped application and global event queries with filters for time, type, application, source, actor, contact, and outcome.
+- Add a per-application timeline that distinguishes occurrence from ingestion time and renders structured links/metadata.
+- Add a global activity page with filter controls and incremental loading.
+- Reframe `notes` as a current summary, show an explicit 10,000-character counter/warning, and reject oversized values rather than silently truncating them.
+- Preserve legacy notes and events without destructive parsing or inferred historical claims.
+- Update OpenAPI, MCP schemas, Prisma indexes/migration, Firestore indexes, localization, and parity tests.
+
+## Capabilities
+
+### New Capabilities
+
+- `application-event-commands`: Canonical event taxonomy, metadata validation, and atomic event-plus-projection lifecycle commands.
+- `application-event-queries`: Owner-scoped per-application and global activity queries with deterministic cursor pagination and filters.
+- `application-timeline-experience`: Application timeline, global activity UI, and notes-as-summary guidance/limits.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Data contracts and adapters: `lib/db/types.ts`, `lib/db/adapter.ts`, Prisma and Firestore adapters.
+- Persistence: additive Prisma/Firestore indexes; no destructive data migration.
+- Domain validation: shared application-event command and metadata helpers.
+- APIs: application event routes, a global events route, application update behavior, MCP tools, and `public/openapi.json`.
+- UI: application detail page, new activity page, header navigation, reusable timeline components, and English/German messages.
+- Tests: domain validation, REST routes, adapter parity/transactions, MCP contract parity, timeline/activity rendering, note limits, OpenAPI, TypeScript, lint, and production build.

--- a/openspec/changes/first-class-application-events/specs/application-event-commands/spec.md
+++ b/openspec/changes/first-class-application-events/specs/application-event-commands/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: Canonical application event taxonomy
+Nexus SHALL expose the canonical event types `opportunity_discovered`, `application_submitted`, `recruiter_contacted`, `stage_changed`, `interview_invited`, `interview_scheduled`, `interview_completed`, `feedback_received`, `follow_up_scheduled`, `offer_received`, `application_rejected`, `document_attached`, and `note_added`. REST and MCP boundaries MUST reject unknown event types with the controlled code `event_type_invalid` while existing stored legacy types remain readable.
+
+#### Scenario: Unknown type is submitted
+- **WHEN** an owner submits a new event with a type outside the canonical taxonomy
+- **THEN** Nexus rejects the command with `event_type_invalid`
+- **AND** does not mutate the event history or application projection
+
+#### Scenario: Legacy type is read
+- **WHEN** an existing event contains a pre-taxonomy type
+- **THEN** Nexus returns it as an unrecognized legacy event without rewriting or dropping it
+
+### Requirement: Event-specific bounded metadata
+Nexus SHALL validate event metadata against the selected event type, reject missing or malformed command fields with controlled validation codes, and enforce the existing 100-key, 100-character-key, and 32,000-byte aggregate metadata limits. Common optional link fields SHALL include contact, document, submission, outcome, next action, and evidence identifiers where applicable.
+
+#### Scenario: Interview schedule is valid
+- **WHEN** an `interview_scheduled` command contains a valid interview type, scheduled timestamp, optional duration, contact, and next action
+- **THEN** Nexus stores normalized structured metadata
+
+#### Scenario: Required command metadata is missing
+- **WHEN** `follow_up_scheduled` omits a valid `followUpAt` timestamp
+- **THEN** Nexus rejects the command with `event_metadata_invalid`
+
+### Requirement: Atomic event and projection command
+Nexus SHALL append the immutable event and update the owning `Application` projection in one backend transaction. The command result SHALL include the stored event, resulting application projection, and replay status. PostgreSQL and Firestore implementations MUST have equivalent observable behavior.
+
+#### Scenario: Stage changes
+- **WHEN** an owner records `stage_changed` with a new stage and optional new application status
+- **THEN** Nexus appends the event and updates `currentStage` and the supplied status atomically
+- **AND** metadata preserves the prior and resulting values
+
+#### Scenario: Interview is scheduled
+- **WHEN** an owner records `interview_scheduled`
+- **THEN** Nexus atomically sets status to `interview`, records the current interview stage, updates `lastContact`, and sets the next actionable time from the schedule
+
+#### Scenario: Interview is completed
+- **WHEN** an owner records `interview_completed`
+- **THEN** Nexus atomically records completion in the current stage, updates `lastContact`, and applies any explicit next follow-up
+
+#### Scenario: Follow-up is scheduled
+- **WHEN** an owner records `follow_up_scheduled`
+- **THEN** Nexus atomically appends the event and updates `followUpAt`
+
+#### Scenario: Application is rejected
+- **WHEN** an owner records `application_rejected`
+- **THEN** Nexus atomically sets status and current stage to rejected, updates `lastContact`, and clears stale follow-up state
+
+#### Scenario: Submission is recorded
+- **WHEN** an application submission package is successfully recorded
+- **THEN** the existing submission transaction appends the canonical `application_submitted` event and updates the projection in the same transaction
+
+### Requirement: Idempotent and concurrency-safe commands
+Event commands SHALL accept an owner-scoped idempotency key and stable occurrence time. The same key and normalized payload SHALL return the original event without applying the projection twice; the same key with a different payload SHALL fail with `idempotency_conflict`. Commands SHALL support an optional expected application update timestamp and fail with `conflict` before writing when stale.
+
+#### Scenario: Exact command replay
+- **WHEN** the same owner repeats a command with the same idempotency key and normalized payload
+- **THEN** Nexus returns the stored event with `replayed: true`
+- **AND** does not append another event or reapply the projection mutation
+
+#### Scenario: Conflicting command replay
+- **WHEN** the same owner reuses an idempotency key for a different payload
+- **THEN** Nexus returns `idempotency_conflict`
+
+#### Scenario: Concurrent projection update
+- **WHEN** `expectedUpdatedAt` differs from the current application timestamp
+- **THEN** Nexus returns `conflict`
+- **AND** writes neither the event nor the projection update
+
+### Requirement: Owner-scoped contract parity
+REST and MCP SHALL expose equivalent command semantics, metadata validation, idempotency, and controlled error codes. Every command MUST verify application ownership before reading or writing event or projection state.
+
+#### Scenario: Cross-owner command
+- **WHEN** a user targets another owner's application
+- **THEN** REST and MCP return a not-found response without revealing the record
+- **AND** no event or projection mutation occurs

--- a/openspec/changes/first-class-application-events/specs/application-event-queries/spec.md
+++ b/openspec/changes/first-class-application-events/specs/application-event-queries/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Deterministic application timeline query
+Nexus SHALL provide an owner-scoped per-application event query ordered by occurrence time and a deterministic tie-breaker. The query SHALL support opaque cursor pagination, bounded page sizes, and both newest-first and oldest-first ordering.
+
+#### Scenario: Timeline page is loaded
+- **WHEN** an owner requests a timeline page with a valid limit
+- **THEN** Nexus returns ordered events and an opaque next cursor only when more matching events exist
+
+#### Scenario: Equal occurrence timestamps
+- **WHEN** multiple events share the same occurrence timestamp
+- **THEN** pagination returns each event exactly once in deterministic order
+
+### Requirement: Global owner activity query
+Nexus SHALL provide a global owner-scoped activity query across applications. The query SHALL support filters for time range, one or more canonical event types, application, source, actor, contact, and outcome, with the same cursor and ordering semantics as the application timeline.
+
+#### Scenario: Activity is filtered
+- **WHEN** an owner filters activity by application, event type, and time range
+- **THEN** every returned event satisfies all requested filters
+- **AND** no event owned by another user is returned
+
+#### Scenario: Linked dimensions are filtered
+- **WHEN** an owner filters by contact or outcome
+- **THEN** Nexus matches normalized indexed event dimensions rather than searching arbitrary metadata prose
+
+### Requirement: Query contract parity
+REST and MCP SHALL expose equivalent global and per-application event filters, result fields, limits, cursors, and controlled validation errors. Event query results SHALL include occurrence time, ingestion time, source, actor, application reference, normalized link dimensions, and structured metadata.
+
+#### Scenario: Invalid query is supplied
+- **WHEN** REST or MCP receives an invalid cursor, timestamp, order, type, or limit
+- **THEN** it returns a controlled `event_query_invalid` error
+
+### Requirement: Backend-equivalent indexed ordering
+Prisma/PostgreSQL and Firestore SHALL implement equivalent owner-scoped ordering and filtering. Additive indexes SHALL support the primary owner/time and application/time query shapes without rewriting existing event records.
+
+#### Scenario: Existing event lacks normalized dimensions
+- **WHEN** a legacy event has no normalized contact or outcome fields
+- **THEN** it remains visible in unfiltered timeline and activity queries
+- **AND** is excluded only from filters whose normalized dimension is absent

--- a/openspec/changes/first-class-application-events/specs/application-timeline-experience/spec.md
+++ b/openspec/changes/first-class-application-events/specs/application-timeline-experience/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: Per-application timeline
+The application detail experience SHALL display a chronological event timeline with human-readable event titles, occurrence and ingestion times, source, actor, relevant structured metadata, and links to the application, contact, document, or submission when present. Unknown legacy event types SHALL use a safe fallback label and expose their stored type.
+
+#### Scenario: Application detail is opened
+- **WHEN** an owner opens an application with events
+- **THEN** the first timeline page is visible without inspecting the summary textarea
+- **AND** additional pages can be loaded incrementally
+
+#### Scenario: Timeline order changes
+- **WHEN** an owner switches between newest-first and oldest-first
+- **THEN** the timeline reloads in the requested deterministic order
+
+### Requirement: Global activity experience
+Nexus SHALL provide a navigable global activity page that lists events across the owner's applications and provides filters for time, type, application, source, actor, contact, and outcome. Active filters SHALL be visible and removable, and additional results SHALL load incrementally.
+
+#### Scenario: User filters global activity
+- **WHEN** an owner selects an application and event type
+- **THEN** the displayed activity and subsequent pages use those filters
+
+#### Scenario: Activity is empty
+- **WHEN** no events match the selected filters
+- **THEN** Nexus displays a clear empty state without implying that the application history was deleted
+
+### Requirement: Notes are a bounded current summary
+The UI SHALL label the legacy notes field as a current summary, explain that chronological activity belongs in the timeline, display the current character count against the 10,000-character limit, and warn before the limit. REST and MCP application mutations MUST reject oversized summaries with `notes_too_long` instead of truncating them.
+
+#### Scenario: Summary approaches its limit
+- **WHEN** the summary reaches the configured warning threshold
+- **THEN** the UI presents a visible warning and character count
+
+#### Scenario: Oversized summary is submitted
+- **WHEN** a client submits more than 10,000 characters
+- **THEN** Nexus returns `notes_too_long`
+- **AND** preserves the previously stored summary unchanged
+
+### Requirement: Legacy history is preserved
+Nexus SHALL preserve existing notes and events as-is. It MUST NOT automatically parse prose into authoritative events or fabricate occurrence times, actors, contacts, or outcomes.
+
+#### Scenario: Existing summary contains chronological prose
+- **WHEN** the feature is deployed over an existing application
+- **THEN** the text remains unchanged
+- **AND** no inferred events are created automatically
+
+### Requirement: Localized and accessible event surfaces
+Timeline, activity, filter, summary guidance, loading, empty, and error states SHALL have English and German messages and keyboard-accessible controls with programmatic labels and live loading/error feedback.
+
+#### Scenario: Timeline is used with assistive technology
+- **WHEN** a keyboard or screen-reader user loads or filters events
+- **THEN** controls have accessible names, focus remains predictable, and status changes are announced

--- a/openspec/changes/first-class-application-events/tasks.md
+++ b/openspec/changes/first-class-application-events/tasks.md
@@ -33,4 +33,4 @@
 - [x] 5.1 Run focused tests after each RED-GREEN slice and the complete Vitest suite
 - [x] 5.2 Run Prisma validation/generation, TypeScript, lint, production build, OpenAPI validation, and strict OpenSpec validation
 - [x] 5.3 Complete independent security/spec/code review and resolve every blocking finding
-- [ ] 5.4 Commit, push, open a PR that closes #153, and verify GitHub CI
+- [x] 5.4 Commit, push, open a PR that closes #153, and verify GitHub CI

--- a/openspec/changes/first-class-application-events/tasks.md
+++ b/openspec/changes/first-class-application-events/tasks.md
@@ -1,0 +1,36 @@
+## 1. Domain contract
+
+- [x] 1.1 RED: add tests for canonical event types, event-specific metadata normalization, projection derivation, bounded metadata, and controlled errors
+- [x] 1.2 GREEN: implement the shared application-event domain module and notes-summary validator
+- [x] 1.3 RED/GREEN: add cursor/filter normalization tests and implement deterministic opaque event cursors
+
+## 2. Persistence and atomic commands
+
+- [x] 2.1 RED: add Prisma command tests for ownership, projection consistency, exact replay, conflicting replay, stale concurrency, and rollback
+- [x] 2.2 GREEN: extend shared types/adapter and implement the atomic Prisma event command
+- [x] 2.3 RED: add Firestore parity tests for the same command and transaction behavior
+- [x] 2.4 GREEN: implement the atomic Firestore event command and verify parity
+- [x] 2.5 Add normalized event query dimensions plus additive Prisma migration and Firestore indexes
+
+## 3. Event queries
+
+- [x] 3.1 RED: add adapter tests for deterministic per-application pagination, equal timestamps, global owner scoping, filters, and both sort orders
+- [x] 3.2 GREEN: implement paged event queries in Prisma and Firestore
+- [x] 3.3 RED/GREEN: add REST tests and implement per-application timeline and global activity endpoints
+- [x] 3.4 RED/GREEN: add MCP contract tests and implement equivalent command/timeline/activity tools
+- [x] 3.5 Update OpenAPI schemas/operations and runtime parity tests
+
+## 4. Event-first user experience
+
+- [x] 4.1 RED: add component tests for event rendering, legacy fallbacks, order switching, incremental loading, filters, empty/error states, and links
+- [x] 4.2 GREEN: implement reusable event timeline/activity components with cursor-loaded initial pages
+- [x] 4.3 Add the global `/activity` page and desktop/mobile navigation entry
+- [x] 4.4 RED/GREEN: add notes counter/warning tests, relabel notes as Summary, and reject oversized summaries without truncation
+- [x] 4.5 Add complete English/German timeline, activity, filter, and summary messages
+
+## 5. Verification and delivery
+
+- [x] 5.1 Run focused tests after each RED-GREEN slice and the complete Vitest suite
+- [x] 5.2 Run Prisma validation/generation, TypeScript, lint, production build, OpenAPI validation, and strict OpenSpec validation
+- [x] 5.3 Complete independent security/spec/code review and resolve every blocking finding
+- [ ] 5.4 Commit, push, open a PR that closes #153, and verify GitHub CI

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,1 +1,16 @@
 schema: spec-driven
+
+context: |
+  Nexus CRM is a Next.js/TypeScript career-operations CRM with a shared DatabaseAdapter implemented by Prisma/PostgreSQL and Firestore. REST, MCP, and UI behavior must remain owner-scoped and backend-equivalent. Application is the authoritative current-state projection; immutable ApplicationSubmission and ApplicationEvent records preserve evidence and history. Changes require test-first implementation, OpenAPI/MCP runtime parity, English/German localization, and additive migrations without destructive legacy-note rewrites.
+
+rules:
+  proposal:
+    - Keep Application as the current operational projection; do not introduce full event sourcing.
+    - Identify REST, MCP, Prisma, Firestore, UI, migration, and compatibility impact.
+  specs:
+    - Require owner scoping, bounded inputs, deterministic idempotency, and controlled error codes.
+    - Include backend parity and legacy-preservation scenarios.
+  design:
+    - Document transaction boundaries, cursor semantics, metadata validation, and rollback.
+  tasks:
+    - Order implementation as RED-GREEN vertical slices and include full verification gates.

--- a/prisma/migrations/20260724070000_first_class_application_events/migration.sql
+++ b/prisma/migrations/20260724070000_first_class_application_events/migration.sql
@@ -1,0 +1,24 @@
+ALTER TABLE "ApplicationEvent"
+  ADD COLUMN "requestHash" TEXT,
+  ADD COLUMN "contactId" TEXT,
+  ADD COLUMN "outcome" TEXT;
+
+UPDATE "ApplicationEvent"
+SET "requestHash" = "metadata"->>'requestHash'
+WHERE "requestHash" IS NULL
+  AND "metadata" IS NOT NULL
+  AND "metadata" ? 'requestHash';
+
+DROP INDEX IF EXISTS "ApplicationEvent_applicationId_occurredAt_idx";
+DROP INDEX IF EXISTS "ApplicationEvent_userId_type_idx";
+
+CREATE INDEX "ApplicationEvent_applicationId_occurredAt_id_idx"
+  ON "ApplicationEvent"("applicationId", "occurredAt", "id");
+CREATE INDEX "ApplicationEvent_userId_occurredAt_id_idx"
+  ON "ApplicationEvent"("userId", "occurredAt", "id");
+CREATE INDEX "ApplicationEvent_userId_type_occurredAt_idx"
+  ON "ApplicationEvent"("userId", "type", "occurredAt");
+CREATE INDEX "ApplicationEvent_userId_contactId_occurredAt_idx"
+  ON "ApplicationEvent"("userId", "contactId", "occurredAt");
+CREATE INDEX "ApplicationEvent_userId_outcome_occurredAt_idx"
+  ON "ApplicationEvent"("userId", "outcome", "occurredAt");

--- a/prisma/migrations/20260724160000_add_application_event_version/migration.sql
+++ b/prisma/migrations/20260724160000_add_application_event_version/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "Application"
+ADD COLUMN "eventVersion" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -142,15 +142,21 @@ model ApplicationEvent {
   application    Application @relation(fields: [applicationId], references: [id], onDelete: Cascade)
   type           String
   idempotencyKey String?
+  requestHash    String?
   occurredAt     DateTime
   source         String?
   actor          String?
+  contactId      String?
+  outcome        String?
   metadata       Json?
   createdAt      DateTime    @default(now())
 
   @@unique([userId, idempotencyKey])
-  @@index([applicationId, occurredAt])
-  @@index([userId, type])
+  @@index([applicationId, occurredAt, id])
+  @@index([userId, occurredAt, id])
+  @@index([userId, type, occurredAt])
+  @@index([userId, contactId, occurredAt])
+  @@index([userId, outcome, occurredAt])
 }
 
 model User {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -56,6 +56,7 @@ model Application {
   jobLiveness         String? // unknown | live | closed | expired
   jobSummary          String?
   currentStage        String?
+  eventVersion        Int                     @default(0)
   createdAt           DateTime                @default(now())
   updatedAt           DateTime                @updatedAt
   documents           Document[]

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -612,7 +612,8 @@
           },
           "400": { "$ref": "#/components/responses/BadRequest" },
           "401": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" }
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "description": "An unexpected storage failure was sanitized as `event_query_failed`.", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
         }
       },
       "post": {
@@ -644,7 +645,8 @@
           "400": { "$ref": "#/components/responses/BadRequest" },
           "401": { "$ref": "#/components/responses/Unauthorized" },
           "404": { "$ref": "#/components/responses/NotFound" },
-          "409": { "description": "Idempotency or optimistic-concurrency conflict.", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "409": { "description": "Idempotency or optimistic-concurrency conflict.", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
+          "500": { "description": "Verification or an unexpected event write failed and was returned as a controlled error.", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
         }
       }
     },
@@ -671,7 +673,8 @@
         "responses": {
           "200": { "description": "Deterministically ordered, owner-scoped activity page.", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ApplicationEventPage" } } } },
           "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthorized" }
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "500": { "description": "An unexpected storage failure was sanitized as `event_query_failed`.", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
         }
       }
     },

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -674,6 +674,7 @@
           "200": { "description": "Deterministically ordered, owner-scoped activity page.", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ApplicationEventPage" } } } },
           "400": { "$ref": "#/components/responses/BadRequest" },
           "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "description": "The selected application is outside the authenticated read scope.", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
           "500": { "description": "An unexpected storage failure was sanitized as `event_query_failed`.", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
         }
       }

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -69,7 +69,7 @@
           "appliedAt":      { "type": ["string", "null"],     "format": "date-time" },
           "lastContact":    { "type": ["string", "null"],     "format": "date-time" },
           "followUpAt":     { "type": ["string", "null"],     "format": "date-time" },
-          "notes":          { "type": ["string", "null"],     "example": "Had a great first call." },
+          "notes":          { "type": ["string", "null"],     "maxLength": 10000, "description": "Compact current-state summary; chronological activity belongs in ApplicationEvent history.", "example": "Had a great first call." },
           "jobDescription": { "type": ["string", "null"],     "example": "We are looking for…" },
           "canonicalJobUrl": { "type": ["string", "null"], "format": "uri" },
           "workMode": { "type": ["string", "null"], "enum": ["remote", "hybrid", "onsite", "flexible", null] },
@@ -194,16 +194,37 @@
       },
       "ApplicationEvent": {
         "type": "object",
-        "required": ["id", "applicationId", "type", "occurredAt"],
+        "required": ["id", "applicationId", "type", "occurredAt", "createdAt"],
         "properties": {
           "id": { "type": "string" },
           "applicationId": { "type": "string" },
-          "type": { "type": "string" },
+          "type": { "type": "string", "enum": ["opportunity_discovered", "application_submitted", "recruiter_contacted", "stage_changed", "interview_invited", "interview_scheduled", "interview_completed", "feedback_received", "follow_up_scheduled", "offer_received", "application_rejected", "document_attached", "note_added"] },
           "idempotencyKey": { "type": ["string", "null"] },
           "occurredAt": { "type": "string", "format": "date-time" },
           "source": { "type": ["string", "null"] },
           "actor": { "type": ["string", "null"] },
-          "metadata": { "type": ["object", "null"], "additionalProperties": true }
+          "contactId": { "type": ["string", "null"] },
+          "outcome": { "type": ["string", "null"] },
+          "metadata": { "type": ["object", "null"], "additionalProperties": true },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "application": { "anyOf": [{ "$ref": "#/components/schemas/ApplicationRef" }, { "type": "null" }] }
+        }
+      },
+      "ApplicationEventPage": {
+        "type": "object",
+        "required": ["items", "nextCursor"],
+        "properties": {
+          "items": { "type": "array", "items": { "$ref": "#/components/schemas/ApplicationEvent" } },
+          "nextCursor": { "type": ["string", "null"], "description": "Opaque deterministic cursor for the next page." }
+        }
+      },
+      "RecordApplicationEventResult": {
+        "type": "object",
+        "required": ["event", "application", "replayed"],
+        "properties": {
+          "event": { "$ref": "#/components/schemas/ApplicationEvent" },
+          "application": { "$ref": "#/components/schemas/Application" },
+          "replayed": { "type": "boolean" }
         }
       },
       "RecordSubmissionResult": {
@@ -401,7 +422,7 @@
       "patch": {
         "operationId": "updateApplication",
         "summary": "Update application",
-        "description": "Partially updates an application. All fields are optional. **Requires a session.**",
+        "description": "Partially updates non-lifecycle application fields. Status, stage, contact, follow-up, and submission changes must use typed event or submission endpoints. Unchanged legacy lifecycle fields are tolerated for compatibility. **Requires a session.**",
         "tags": ["Applications"],
         "security": [
           { "BearerAuth": [] },
@@ -416,10 +437,6 @@
                 "properties": {
                   "company":        { "type": "string", "maxLength": 255 },
                   "role":           { "type": "string", "maxLength": 255 },
-                  "status":         { "$ref": "#/components/schemas/ApplicationStatus" },
-                  "appliedAt":      { "type": ["string", "null"], "format": "date-time" },
-                  "lastContact":    { "type": ["string", "null"], "format": "date-time" },
-                  "followUpAt":     { "type": ["string", "null"], "format": "date-time" },
                   "notes":          { "type": ["string", "null"], "maxLength": 10000 },
                   "jobDescription": { "type": ["string", "null"], "maxLength": 50000 }
                 }
@@ -576,18 +593,31 @@
         "summary": "List append-only application timeline events",
         "tags": ["Applications"],
         "security": [{ "BearerAuth": [] }, { "CookieAuth": [] }],
+        "parameters": [
+          { "name": "type", "in": "query", "style": "form", "explode": true, "schema": { "type": "array", "items": { "type": "string", "enum": ["opportunity_discovered", "application_submitted", "recruiter_contacted", "stage_changed", "interview_invited", "interview_scheduled", "interview_completed", "feedback_received", "follow_up_scheduled", "offer_received", "application_rejected", "document_attached", "note_added"] } } },
+          { "name": "occurredAfter", "in": "query", "schema": { "type": "string", "format": "date-time" } },
+          { "name": "occurredBefore", "in": "query", "schema": { "type": "string", "format": "date-time" } },
+          { "name": "source", "in": "query", "schema": { "type": "string", "maxLength": 255 } },
+          { "name": "actor", "in": "query", "schema": { "type": "string", "maxLength": 255 } },
+          { "name": "contactId", "in": "query", "schema": { "type": "string", "maxLength": 255 } },
+          { "name": "outcome", "in": "query", "schema": { "type": "string", "maxLength": 255 } },
+          { "name": "order", "in": "query", "schema": { "type": "string", "enum": ["newest", "oldest"], "default": "newest" } },
+          { "name": "cursor", "in": "query", "schema": { "type": "string" } },
+          { "name": "limit", "in": "query", "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 50 } }
+        ],
         "responses": {
           "200": {
-            "description": "Timeline events.",
-            "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/ApplicationEvent" } } } }
+            "description": "Deterministically ordered application timeline page.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ApplicationEventPage" } } }
           },
+          "400": { "$ref": "#/components/responses/BadRequest" },
           "401": { "$ref": "#/components/responses/Unauthorized" },
           "404": { "$ref": "#/components/responses/NotFound" }
         }
       },
       "post": {
         "operationId": "recordApplicationEvent",
-        "summary": "Append an application timeline event",
+        "summary": "Atomically append a typed event and update the application projection",
         "tags": ["Applications"],
         "security": [{ "BearerAuth": [] }, { "CookieAuth": [] }],
         "requestBody": {
@@ -598,20 +628,50 @@
                 "type": "object",
                 "required": ["type"],
                 "properties": {
-                  "type": { "type": "string", "maxLength": 100 },
-                  "idempotencyKey": { "type": ["string", "null"], "description": "When supplied, occurredAt is required so retries hash deterministically." },
-                  "occurredAt": { "type": "string", "format": "date-time", "description": "Required when idempotencyKey is supplied." },
-                  "metadata": { "type": "object", "additionalProperties": true }
+                  "type": { "type": "string", "enum": ["opportunity_discovered", "recruiter_contacted", "stage_changed", "interview_invited", "interview_scheduled", "interview_completed", "feedback_received", "follow_up_scheduled", "offer_received", "application_rejected", "document_attached", "note_added"], "description": "Submission events must use POST /api/applications/{id}/submissions." },
+                  "idempotencyKey": { "type": "string", "minLength": 8, "maxLength": 128, "description": "When supplied, occurredAt is required so retries hash deterministically." },
+                  "occurredAt": { "type": "string", "format": "date-time", "description": "Required when idempotencyKey is supplied; defaults to the server time otherwise." },
+                  "expectedUpdatedAt": { "type": "string", "format": "date-time", "description": "Optional optimistic-concurrency precondition for the current projection." },
+                  "metadata": { "type": "object", "additionalProperties": true, "description": "Validated per event type; bounded to 32,000 bytes after normalization." }
                 }
               }
             }
           }
         },
         "responses": {
-          "201": { "description": "Created timeline event." },
+          "200": { "description": "Idempotent replay.", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/RecordApplicationEventResult" } } } },
+          "201": { "description": "Event and projection recorded atomically.", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/RecordApplicationEventResult" } } } },
           "400": { "$ref": "#/components/responses/BadRequest" },
           "401": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" }
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "409": { "description": "Idempotency or optimistic-concurrency conflict.", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+        }
+      }
+    },
+    "/api/events": {
+      "get": {
+        "operationId": "listApplicationActivity",
+        "summary": "List the authenticated owner's application activity feed",
+        "tags": ["Applications"],
+        "security": [{ "BearerAuth": [] }, { "CookieAuth": [] }],
+        "parameters": [
+          { "name": "applicationId", "in": "query", "schema": { "type": "string" } },
+          { "name": "company", "in": "query", "schema": { "type": "string", "maxLength": 255 } },
+          { "name": "type", "in": "query", "style": "form", "explode": true, "schema": { "type": "array", "items": { "type": "string", "enum": ["opportunity_discovered", "application_submitted", "recruiter_contacted", "stage_changed", "interview_invited", "interview_scheduled", "interview_completed", "feedback_received", "follow_up_scheduled", "offer_received", "application_rejected", "document_attached", "note_added"] } } },
+          { "name": "occurredAfter", "in": "query", "schema": { "type": "string", "format": "date-time" } },
+          { "name": "occurredBefore", "in": "query", "schema": { "type": "string", "format": "date-time" } },
+          { "name": "source", "in": "query", "schema": { "type": "string" } },
+          { "name": "actor", "in": "query", "schema": { "type": "string" } },
+          { "name": "contactId", "in": "query", "schema": { "type": "string" } },
+          { "name": "outcome", "in": "query", "schema": { "type": "string" } },
+          { "name": "order", "in": "query", "schema": { "type": "string", "enum": ["newest", "oldest"], "default": "newest" } },
+          { "name": "cursor", "in": "query", "schema": { "type": "string" } },
+          { "name": "limit", "in": "query", "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 50 } }
+        ],
+        "responses": {
+          "200": { "description": "Deterministically ordered, owner-scoped activity page.", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ApplicationEventPage" } } } },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
         }
       }
     },

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -198,7 +198,7 @@
         "properties": {
           "id": { "type": "string" },
           "applicationId": { "type": "string" },
-          "type": { "type": "string", "enum": ["opportunity_discovered", "application_submitted", "recruiter_contacted", "stage_changed", "interview_invited", "interview_scheduled", "interview_completed", "feedback_received", "follow_up_scheduled", "offer_received", "application_rejected", "document_attached", "note_added"] },
+          "type": { "type": "string", "description": "Canonical event type or a legacy stored type returned for backwards compatibility." },
           "idempotencyKey": { "type": ["string", "null"] },
           "occurredAt": { "type": "string", "format": "date-time" },
           "source": { "type": ["string", "null"] },
@@ -607,8 +607,8 @@
         ],
         "responses": {
           "200": {
-            "description": "Deterministically ordered application timeline page.",
-            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ApplicationEventPage" } } }
+            "description": "Legacy bare array when no query parameters are supplied; otherwise a deterministic cursor page.",
+            "content": { "application/json": { "schema": { "oneOf": [{ "type": "array", "items": { "$ref": "#/components/schemas/ApplicationEvent" } }, { "$ref": "#/components/schemas/ApplicationEventPage" }] } } }
           },
           "400": { "$ref": "#/components/responses/BadRequest" },
           "401": { "$ref": "#/components/responses/Unauthorized" },


### PR DESCRIPTION
## Summary

- add a canonical, typed, immutable `ApplicationEvent` history while keeping `Application` as the mutable current-state projection
- atomically append events and update projections in both Prisma/PostgreSQL and Firestore, with owner isolation, optimistic concurrency, deterministic cursors, and idempotent replay (including legacy hashes)
- add paginated application timelines, an owner-scoped activity feed, REST and MCP tools, OpenAPI contracts, navigation, filtering, and English/German UI copy
- treat notes as a bounded current summary: preserve legacy values, reject changed summaries over 10,000 characters, and record chronological notes as events
- keep `application_submitted` reserved for the existing atomic submission workflow and route direct lifecycle changes through typed events

## Persistence and migration

- add dedicated internal `requestHash`, `contactId`, and `outcome` fields plus deterministic indexes
- backfill legacy idempotency hashes without exposing them through public event metadata
- add equivalent Firestore indexes and transactional behavior

## Verification

- `npm test -- --run` — 88 files / 591 tests passed
- `npm run lint` — passed
- `npx tsc --noEmit` — passed
- `npm run build` — passed
- `npx prisma generate && npx prisma validate` — passed
- strict OpenSpec validation — passed
- Redocly OpenAPI validation — passed
- independent backend/security, REST/MCP/OpenAPI, and frontend/accessibility reviews completed; blocking findings resolved, including reference ownership validation and sanitized unexpected failures

Closes #153


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Activity page with searchable, filterable, cursor-paginated application history.
  * Added an application timeline UI to view and record immutable event details with metadata, contextual links, and “load more”.
  * Updated event recording to support idempotent replay and consistent conflict handling.
* **Bug Fixes**
  * Enforced lifecycle immutability: lifecycle fields can’t be edited via application summary/notes update flows.
  * Tightened validation for event queries and notes updates, with improved error responses.
* **Localization**
  * Added/expanded English and German translations for the Activity and timeline UI (including Summary/help text).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->