### PR TITLE
fix(application-events): address post-merge review

### DIFF
--- a/hooks/__tests__/use-application-status-mutation.test.tsx
+++ b/hooks/__tests__/use-application-status-mutation.test.tsx
@@ -204,6 +204,40 @@ describe("useApplicationStatusMutation concurrency", () => {
     ).toBe("interview");
   });
 
+  it("uses the server-updated timestamp for the next settled status write", async () => {
+    const firstUpdated = {
+      ...application("a", "applied"),
+      updatedAt: "2026-07-02T00:00:00.000Z",
+    };
+    const secondUpdated = {
+      ...application("a", "interview"),
+      updatedAt: "2026-07-03T00:00:00.000Z",
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ application: firstUpdated }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ application: secondUpdated }),
+      } as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await act(async () => {
+      await mutationHandleRef.current!({ id: "a", status: "applied" });
+    });
+    await act(async () => {
+      await mutationHandleRef.current!({ id: "a", status: "interview" });
+    });
+
+    const secondEvent = JSON.parse(
+      (fetchMock.mock.calls[1][1] as RequestInit).body as string,
+    );
+    expect(secondEvent.expectedUpdatedAt).toBe(firstUpdated.updatedAt);
+  });
+
   it("does not let an older failed write roll back a newer pending intent", async () => {
     const firstRequest = deferred<Response>();
     const secondRequest = deferred<Response>();

--- a/hooks/use-application-status-mutation.ts
+++ b/hooks/use-application-status-mutation.ts
@@ -127,7 +127,11 @@ export function useApplicationStatusMutation(options?: {
         (current: Application[] | undefined) =>
           (current ?? []).map((application: Application) =>
             application.id === updated.id
-              ? { ...application, status: updated.status }
+              ? {
+                ...application,
+                status: updated.status,
+                updatedAt: updated.updatedAt,
+              }
               : application,
           ),
       );

--- a/lib/db/__tests__/firestore-adapter.test.ts
+++ b/lib/db/__tests__/firestore-adapter.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ── Hoisted mocks (available inside vi.mock factories) ──────────────────────
 
-const { mockGetAll, stores, mockTimestamp, batchState, applyUpdate } = vi.hoisted(() => {
+const { mockGetAll, stores, mockTimestamp, batchState, queryStats, applyUpdate } = vi.hoisted(() => {
   const stores = {
     applications: new Map<string, Record<string, unknown>>(),
     documents: new Map<string, Record<string, unknown>>(),
@@ -18,6 +18,10 @@ const { mockGetAll, stores, mockTimestamp, batchState, applyUpdate } = vi.hoiste
     commitCount: 0,
     failOnCommit: null as number | null,
     beforeCommit: null as (() => void) | null,
+  };
+  const queryStats = {
+    eventLimits: [] as number[],
+    eventReadSizes: [] as number[],
   };
   const applyUpdate = (
     current: Record<string, unknown>,
@@ -36,7 +40,7 @@ const { mockGetAll, stores, mockTimestamp, batchState, applyUpdate } = vi.hoiste
     return next;
   };
 
-  return { mockGetAll, stores, mockTimestamp, batchState, applyUpdate };
+  return { mockGetAll, stores, mockTimestamp, batchState, queryStats, applyUpdate };
 });
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -105,6 +109,7 @@ function makeQuery(
       return makeQuery(store, filters, [...sorts, { field, direction }], max, after);
     },
     limit(value: number) {
+      if (store === stores.applicationEvents) queryStats.eventLimits.push(value);
       return makeQuery(store, filters, sorts, value, after);
     },
     startAfter(...values: unknown[]) {
@@ -145,6 +150,7 @@ function makeQuery(
         });
       }
       if (max !== undefined) entries = entries.slice(0, max);
+      if (store === stores.applicationEvents) queryStats.eventReadSizes.push(entries.length);
       return {
         empty: entries.length === 0,
         docs: entries.map(([id, data]) => ({
@@ -314,6 +320,8 @@ beforeEach(() => {
   batchState.commitCount = 0;
   batchState.failOnCommit = null;
   batchState.beforeCommit = null;
+  queryStats.eventLimits = [];
+  queryStats.eventReadSizes = [];
 });
 
 describe("FirestoreAdapter — application metadata", () => {
@@ -1337,6 +1345,30 @@ describe("FirestoreAdapter — first-class application events", () => {
     });
     expect(page.items.map((event) => event.id)).toEqual(["1"]);
     expect(page.nextCursor).toBeNull();
+  });
+
+  it("applies legacy timeline limits before reading Firestore events", async () => {
+    seedApps([{ id: "app-1", userId, company: "Acme", role: "Engineer" }]);
+    const timestamp = { toDate: () => new Date("2026-07-24T09:00:00Z") };
+    for (let id = 1; id <= 5; id += 1) {
+      stores.applicationEvents.set(String(id), {
+        userId,
+        applicationId: "app-1",
+        type: "stage_changed",
+        occurredAt: timestamp,
+        createdAt: timestamp,
+      });
+    }
+
+    const events = await new FirestoreAdapter().listApplicationEvents(
+      "app-1",
+      userId,
+      2,
+    );
+
+    expect(events).toHaveLength(2);
+    expect(queryStats.eventLimits).toEqual([2]);
+    expect(queryStats.eventReadSizes).toEqual([2]);
   });
 
   it("uses the same lexical ID tie-breaker for sorting and cursors", async () => {

--- a/lib/db/firestore-adapter.ts
+++ b/lib/db/firestore-adapter.ts
@@ -1149,17 +1149,15 @@ export class FirestoreAdapter implements DatabaseAdapter {
   ): Promise<ApplicationEventRecord[]> {
     const application = await this.getApplication(applicationId, userId);
     if (!application) throw new Error("not_found");
+    const queryLimit = Math.max(1, Math.min(500, limit));
     const snapshot = await this.events
       .where("applicationId", "==", applicationId)
       .where("userId", "==", userId)
       .orderBy("occurredAt", "desc")
+      .orderBy(FieldPath.documentId(), "desc")
+      .limit(queryLimit)
       .get();
-    const events = snapshot.docs.map((document) => mapEvent(document.id, document.data()));
-    return events.sort((left, right) => {
-      const time = right.occurredAt.getTime() - left.occurredAt.getTime();
-      if (time) return time;
-      return left.id === right.id ? 0 : left.id < right.id ? 1 : -1;
-    }).slice(0, Math.max(1, Math.min(500, limit)));
+    return snapshot.docs.map((document) => mapEvent(document.id, document.data()));
   }
 
   async listApplicationsFiltered(


### PR DESCRIPTION
## Summary
- refresh the cached application `updatedAt` after status-event writes so immediate follow-up changes use the current optimistic-concurrency baseline
- apply legacy Firestore timeline limits in the query with a deterministic document-ID tie-breaker
- add regressions for both post-merge review findings from #154

## Verification
- 623 tests across 91 files
- ESLint
- TypeScript (`npx tsc --noEmit`)
- production build

## Review follow-ups
- https://github.com/5queezer/nexus-crm/pull/154#discussion_r3647375767
- https://github.com/5queezer/nexus-crm/pull/154#discussion_r3647375772


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved application status updates to preserve the latest server timestamp, helping prevent conflicting changes during rapid successive updates.
  - Improved application event timeline retrieval with consistent ordering and more reliable pagination when events share the same timestamp.

- **Tests**
  - Added coverage for successive status updates and event timeline query limits to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->