### PR TITLE
fix(oauth): avoid global fallback rate limit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,11 @@ GOOGLE_CLIENT_ID="your-google-client-id-from-console.cloud.google.com"
 GOOGLE_CLIENT_SECRET="your-google-client-secret-from-console.cloud.google.com"
 ALLOWED_EMAIL="you@example.com"
 
+# Optional OAuth token-endpoint rate limiting. Set this only to a header that
+# your trusted ingress strips from client requests and replaces with the source
+# address. Limiting stays disabled when this is unset or the header is absent.
+# OAUTH_TRUSTED_IP_HEADER="x-trusted-client-ip"
+
 # Required before users can save model keys or MCP authorization values.
 # Generate with: openssl rand -hex 32
 # Exactly 64 hexadecimal characters (32 bytes). Server-side only: never NEXT_PUBLIC_*.

--- a/app/api/mcp/token/__tests__/route.test.ts
+++ b/app/api/mcp/token/__tests__/route.test.ts
@@ -12,13 +12,14 @@ vi.mock("@/lib/mcp-oauth", () => mocks);
 
 import { POST } from "../route";
 
-function tokenRequest(spoofedIp: string) {
+function tokenRequest(spoofedIp: string, trustedIp?: string) {
   return new NextRequest("https://nexus.example/api/mcp/token", {
     method: "POST",
     headers: {
       "content-type": "application/x-www-form-urlencoded",
       "x-forwarded-for": spoofedIp,
       "x-real-ip": spoofedIp,
+      ...(trustedIp ? { "x-trusted-client-ip": trustedIp } : {}),
     },
     body: new URLSearchParams({
       grant_type: "authorization_code",
@@ -46,13 +47,22 @@ describe("POST /api/mcp/token rate limiting", () => {
     });
   });
 
-  it("does not let untrusted forwarding headers rotate the limiter key", async () => {
-    for (let attempt = 0; attempt < 20; attempt += 1) {
+  it("does not enable a global fallback limiter without a trusted IP header", async () => {
+    for (let attempt = 0; attempt < 21; attempt += 1) {
       const response = await POST(tokenRequest(`198.51.100.${attempt}`));
       expect(response.status).toBe(200);
     }
+  });
 
-    const blocked = await POST(tokenRequest("203.0.113.250"));
+  it("does not let untrusted forwarding headers rotate a configured limiter key", async () => {
+    vi.stubEnv("OAUTH_TRUSTED_IP_HEADER", "X-Trusted-Client-IP");
+
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      const response = await POST(tokenRequest(`198.51.100.${attempt}`, "192.0.2.10"));
+      expect(response.status).toBe(200);
+    }
+
+    const blocked = await POST(tokenRequest("203.0.113.250", "192.0.2.10"));
     expect(blocked.status).toBe(429);
     expect(blocked.headers.get("retry-after")).toBeTruthy();
   });

--- a/app/api/mcp/token/route.ts
+++ b/app/api/mcp/token/route.ts
@@ -72,17 +72,21 @@ export async function POST(req: NextRequest) {
   }
 
   // Only trust an address header that the deployment explicitly configures its
-  // ingress to strip and set. Generic forwarding headers are client-spoofable.
+  // ingress to strip and set. Without a configured and populated trusted header,
+  // skip per-source limiting rather than pooling every client into one global
+  // fallback bucket that an attacker could exhaust.
   const trustedIpHeader = process.env.OAUTH_TRUSTED_IP_HEADER?.trim().toLowerCase();
-  const requestIp = trustedIpHeader ? req.headers.get(trustedIpHeader)?.trim() || "unknown" : "unknown";
-  // Limit the endpoint across all client IDs for the trusted source address.
-  const limit = checkRateLimit(requestIp, "oauth");
-  if (!limit.allowed) {
-    const retryAfter = Math.max(1, Math.ceil((limit.resetAt - Date.now()) / 1000));
-    return NextResponse.json(
-      { error: "temporarily_unavailable", error_description: "Too many token requests" },
-      { status: 429, headers: { "Retry-After": String(retryAfter), "Cache-Control": "no-store" } },
-    );
+  const requestIp = trustedIpHeader ? req.headers.get(trustedIpHeader)?.trim() : undefined;
+  if (requestIp) {
+    // Limit the endpoint across all client IDs for the trusted source address.
+    const limit = checkRateLimit(requestIp, "oauth");
+    if (!limit.allowed) {
+      const retryAfter = Math.max(1, Math.ceil((limit.resetAt - Date.now()) / 1000));
+      return NextResponse.json(
+        { error: "temporarily_unavailable", error_description: "Too many token requests" },
+        { status: 429, headers: { "Retry-After": String(retryAfter), "Cache-Control": "no-store" } },
+      );
+    }
   }
 
   if (!clientId) {


### PR DESCRIPTION
## Summary
- skip OAuth token endpoint rate limiting unless a trusted ingress header is configured and populated
- preserve per-source limiting when a deployment-provided trusted address is available
- document the optional trusted-header configuration

## Why
Follow-up to #156. The previous `unknown` fallback pooled all requests into one process-wide bucket, allowing any client to exhaust token exchanges for every user.

## Validation
- `npm run lint`
- `npm test -- --run` — 95 files, 650 tests passed
- `npm run build`

Addresses the unresolved post-merge review finding on #156.