### PR TITLE
feat: add secure demo workspace onboarding

### DIFF
--- a/.github/workflows/recover-production-db.yml
+++ b/.github/workflows/recover-production-db.yml
@@ -77,6 +77,7 @@ jobs:
           transition_count_container="nexus-transition-count"
           transition_backup_container="nexus-transition-backup"
           transition_migration_container="nexus-transition-migration"
+          service_stopped=0
 
           cleanup_transition_containers() {
             for container in \
@@ -109,6 +110,9 @@ jobs:
             rc=$?
             trap - EXIT
             cleanup_transition_containers
+            if [ "${service_stopped}" -eq 1 ]; then
+              echo "Service remains stopped; recovery did not reach verified activation." >&2
+            fi
             exit "${rc}"
           }
 
@@ -119,6 +123,12 @@ jobs:
             compose_run_bounded "${transition_count_container}" 120 \
               sh -c 'PG_DATABASE_URL="$(node -e "const u=new URL(process.env.DATABASE_URL); for (const key of [\"schema\",\"connection_limit\",\"pool_timeout\",\"socket_timeout\",\"pgbouncer\"]) u.searchParams.delete(key); process.stdout.write(u.toString())")"; exec psql "$PG_DATABASE_URL" --no-psqlrc -v ON_ERROR_STOP=1 -Atc "SELECT COUNT(*) FROM \"Application\";"'
           }
+
+          # Hold all application and MCP writes outside the dump/migration recovery
+          # boundary. Any later failure deliberately leaves the service stopped.
+          timeout 45 docker compose -f docker-compose.yaml stop --timeout 30 "${service}"
+          service_stopped=1
+          echo "Production writes quiesced for database recovery."
 
           count_before="$(db_count)"
           case "${count_before}" in
@@ -154,7 +164,11 @@ jobs:
           fi
           echo "Applications after migration: ${count_after}"
 
-          docker compose -f docker-compose.yaml up -d "${service}"
+          # Activation is allowed only after backup, migration, and post-migration
+          # verification. Keep it bounded; a timeout or error leaves the trap armed
+          # and the service fail-closed instead of retrying an unbounded restart.
+          timeout 120 docker compose -f docker-compose.yaml up -d "${service}"
+          service_stopped=0
           cleanup_transition_containers
           trap - EXIT
           docker ps --filter "name=${service}" --format '{{.Names}} {{.Image}} {{.Status}}'

--- a/.github/workflows/recover-production-db.yml
+++ b/.github/workflows/recover-production-db.yml
@@ -111,6 +111,7 @@ jobs:
             trap - EXIT
             cleanup_transition_containers
             if [ "${service_stopped}" -eq 1 ]; then
+              timeout 45 docker compose -f docker-compose.yaml stop --timeout 30 "${service}" >/dev/null 2>&1 || true
               echo "Service remains stopped; recovery did not reach verified activation." >&2
             fi
             exit "${rc}"
@@ -168,6 +169,15 @@ jobs:
           # verification. Keep it bounded; a timeout or error leaves the trap armed
           # and the service fail-closed instead of retrying an unbounded restart.
           timeout 120 docker compose -f docker-compose.yaml up -d "${service}"
+          readiness_deadline=$((SECONDS + 120))
+          until docker compose -f docker-compose.yaml exec -T "${service}" \
+            node -e 'const http=require("node:http"); const request=http.get({host:"127.0.0.1",port:Number(process.env.PORT||3000),path:"/login",timeout:3000},response=>{response.resume();process.exit(response.statusCode<500?0:1)}); request.on("timeout",()=>request.destroy()); request.on("error",()=>process.exit(1));'; do
+            if [ "${SECONDS}" -ge "${readiness_deadline}" ]; then
+              echo "Service readiness probe timed out; refusing activation." >&2
+              exit 1
+            fi
+            sleep 2
+          done
           service_stopped=0
           cleanup_transition_containers
           trap - EXIT

--- a/app/api/applications/[id]/__tests__/route.test.ts
+++ b/app/api/applications/[id]/__tests__/route.test.ts
@@ -4,13 +4,18 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   getApplication: vi.fn(),
   updateApplication: vi.fn(),
+  deleteApplication: vi.fn(),
   requireAuth: vi.fn(),
 }));
 
-vi.mock("@/lib/db", () => ({ getDb: () => ({ getApplication: mocks.getApplication, updateApplication: mocks.updateApplication }) }));
+vi.mock("@/lib/db", () => ({ getDb: () => ({
+  getApplication: mocks.getApplication,
+  updateApplication: mocks.updateApplication,
+  deleteApplication: mocks.deleteApplication,
+}) }));
 vi.mock("@/lib/session", () => ({ requireAuth: mocks.requireAuth }));
 
-import { PATCH } from "../route";
+import { DELETE, PATCH } from "../route";
 
 const current = {
   id: "1",
@@ -102,5 +107,25 @@ describe("PATCH /api/applications/:id event-first boundaries", () => {
     const response = await PATCH(request({ company: "Acme 2", status: "interview", currentStage: "technical" }), context);
     expect(response.status).toBe(200);
     expect(mocks.updateApplication).toHaveBeenCalledWith("1", "owner-1", expect.not.objectContaining({ status: expect.anything(), currentStage: expect.anything() }));
+  });
+});
+
+describe("DELETE /api/applications/:id demo workspace boundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.requireAuth.mockResolvedValue({ userId: "owner-1" });
+  });
+
+  it("rejects ordinary deletion of a demo application before mutation", async () => {
+    mocks.getApplication.mockResolvedValue({ ...current, isDemo: true, demoWorkspaceId: "workspace-1" });
+
+    const response = await DELETE(
+      new NextRequest("http://localhost/api/applications/1", { method: "DELETE" }),
+      context,
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({ error: "demo_workspace_removal_required" });
+    expect(mocks.deleteApplication).not.toHaveBeenCalled();
   });
 });

--- a/app/api/applications/[id]/route.ts
+++ b/app/api/applications/[id]/route.ts
@@ -204,6 +204,16 @@ export async function DELETE(
 
   const { id } = await params;
   try {
+    const application = await getDb().getApplication(id, auth.userId);
+    if (!application) {
+      return NextResponse.json({ error: "not_found" }, { status: 404 });
+    }
+    if (application.isDemo) {
+      return NextResponse.json(
+        { error: "demo_workspace_removal_required" },
+        { status: 409 },
+      );
+    }
     await getDb().deleteApplication(id, auth.userId);
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/app/api/applications/__tests__/route.test.ts
+++ b/app/api/applications/__tests__/route.test.ts
@@ -1,0 +1,36 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createApplication: vi.fn(),
+  requireAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({ getDb: () => ({ createApplication: mocks.createApplication }) }));
+vi.mock("@/lib/session", () => ({ requireAuth: mocks.requireAuth }));
+
+import { POST } from "../route";
+
+function request() {
+  return new NextRequest("http://localhost/api/applications", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ company: "Acme", role: "Engineer" }),
+  });
+}
+
+describe("POST /api/applications demo lifecycle conflict", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.requireAuth.mockResolvedValue({ userId: "owner-1" });
+  });
+
+  it("returns a controlled conflict requiring demo removal", async () => {
+    mocks.createApplication.mockRejectedValue(new Error("demo_workspace_exists"));
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({ error: "demo_workspace_removal_required" });
+  });
+});

--- a/app/api/applications/route.ts
+++ b/app/api/applications/route.ts
@@ -130,6 +130,9 @@ export async function POST(request: NextRequest) {
     if (error instanceof Error && error.message === "appliedAt_invalid") {
       return NextResponse.json({ error: error.message }, { status: 400 });
     }
+    if (error instanceof Error && error.message === "demo_workspace_exists") {
+      return NextResponse.json({ error: "demo_workspace_removal_required" }, { status: 409 });
+    }
     return NextResponse.json({ error: "Failed to create application" }, { status: 500 });
   }
 }

--- a/app/api/demo-workspace/__tests__/route.test.ts
+++ b/app/api/demo-workspace/__tests__/route.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   requireSessionAuth: vi.fn(),
   ensureDemoWorkspace: vi.fn(),
   deleteDemoWorkspace: vi.fn(),
+  listApplications: vi.fn(),
 }));
 
 vi.mock("@/lib/session", () => ({ requireSessionAuth: mocks.requireSessionAuth }));
@@ -11,10 +12,11 @@ vi.mock("@/lib/db", () => ({
   getDb: () => ({
     ensureDemoWorkspace: mocks.ensureDemoWorkspace,
     deleteDemoWorkspace: mocks.deleteDemoWorkspace,
+    listApplications: mocks.listApplications,
   }),
 }));
 
-import { DELETE, POST } from "../route";
+import { DELETE, GET, POST } from "../route";
 
 beforeEach(() => vi.clearAllMocks());
 
@@ -51,5 +53,31 @@ describe("/api/demo-workspace", () => {
     const response = await DELETE();
     expect(response.status).toBe(200);
     expect(mocks.deleteDemoWorkspace).toHaveBeenCalledWith("owner-1");
+  });
+
+  it("reports owner-scoped eligibility across active and archived rows", async () => {
+    mocks.requireSessionAuth.mockResolvedValue({ userId: "owner-1" });
+    mocks.listApplications.mockResolvedValue([{ id: "archived-real", isDemo: false, archivedAt: new Date() }]);
+
+    const response = await GET();
+
+    expect(mocks.listApplications).toHaveBeenCalledWith("owner-1", { demoVisibility: "include" });
+    await expect(response.json()).resolves.toEqual({
+      hasDemoWorkspace: false,
+      canCreateDemoWorkspace: false,
+    });
+  });
+
+  it("reports only the authenticated owner's demo workspace", async () => {
+    mocks.requireSessionAuth.mockResolvedValue({ userId: "admin-1" });
+    mocks.listApplications.mockResolvedValue([{ id: "own-demo", isDemo: true }]);
+
+    const response = await GET();
+
+    expect(mocks.listApplications).toHaveBeenCalledWith("admin-1", { demoVisibility: "include" });
+    await expect(response.json()).resolves.toEqual({
+      hasDemoWorkspace: true,
+      canCreateDemoWorkspace: false,
+    });
   });
 });

--- a/app/api/demo-workspace/__tests__/route.test.ts
+++ b/app/api/demo-workspace/__tests__/route.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  requireSessionAuth: vi.fn(),
+  ensureDemoWorkspace: vi.fn(),
+  deleteDemoWorkspace: vi.fn(),
+}));
+
+vi.mock("@/lib/session", () => ({ requireSessionAuth: mocks.requireSessionAuth }));
+vi.mock("@/lib/db", () => ({
+  getDb: () => ({
+    ensureDemoWorkspace: mocks.ensureDemoWorkspace,
+    deleteDemoWorkspace: mocks.deleteDemoWorkspace,
+  }),
+}));
+
+import { DELETE, POST } from "../route";
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("/api/demo-workspace", () => {
+  it("requires a browser session without development bypass", async () => {
+    mocks.requireSessionAuth.mockResolvedValue(null);
+    const response = await POST();
+    expect(response.status).toBe(401);
+    expect(mocks.requireSessionAuth).toHaveBeenCalledWith({ allowDevBypass: false });
+    expect(mocks.ensureDemoWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("creates and replays only for auth.userId with cache-safe responses", async () => {
+    mocks.requireSessionAuth.mockResolvedValue({ userId: "owner-1" });
+    mocks.ensureDemoWorkspace.mockResolvedValue({ workspace: { id: "ws-1" }, applications: [{ id: "demo-1" }], replayed: true });
+    const response = await POST();
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toContain("no-store");
+    expect(mocks.ensureDemoWorkspace).toHaveBeenCalledWith("owner-1", expect.objectContaining({ seedVersion: 1 }));
+    await expect(response.json()).resolves.toMatchObject({ replayed: true });
+  });
+
+  it("returns conflict without leaking persistence errors when real data exists", async () => {
+    mocks.requireSessionAuth.mockResolvedValue({ userId: "owner-1" });
+    mocks.ensureDemoWorkspace.mockRejectedValue(new Error("real_applications_exist"));
+    const response = await POST();
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({ error: "real_applications_exist" });
+  });
+
+  it("deletes using only auth.userId and treats replay as success", async () => {
+    mocks.requireSessionAuth.mockResolvedValue({ userId: "owner-1" });
+    mocks.deleteDemoWorkspace.mockResolvedValue({ deletedApplications: 0, deletedEvents: 0 });
+    const response = await DELETE();
+    expect(response.status).toBe(200);
+    expect(mocks.deleteDemoWorkspace).toHaveBeenCalledWith("owner-1");
+  });
+});

--- a/app/api/demo-workspace/route.ts
+++ b/app/api/demo-workspace/route.ts
@@ -5,6 +5,19 @@ import { requireSessionAuth } from "@/lib/session";
 
 const NO_STORE = { "Cache-Control": "private, no-store, max-age=0" };
 
+export async function GET() {
+  const auth = await requireSessionAuth({ allowDevBypass: false });
+  if (!auth) return NextResponse.json({ error: "unauthorized" }, { status: 401, headers: NO_STORE });
+
+  const applications = await getDb().listApplications(auth.userId, { demoVisibility: "include" });
+  const hasDemoWorkspace = applications.some((application) => application.isDemo === true);
+  const hasRealApplications = applications.some((application) => application.isDemo !== true);
+  return NextResponse.json(
+    { hasDemoWorkspace, canCreateDemoWorkspace: !hasDemoWorkspace && !hasRealApplications },
+    { headers: NO_STORE },
+  );
+}
+
 export async function POST() {
   const auth = await requireSessionAuth({ allowDevBypass: false });
   if (!auth) return NextResponse.json({ error: "unauthorized" }, { status: 401, headers: NO_STORE });

--- a/app/api/demo-workspace/route.ts
+++ b/app/api/demo-workspace/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import { createDemoFixtures } from "@/lib/demo-workspace/fixtures";
+import { requireSessionAuth } from "@/lib/session";
+
+const NO_STORE = { "Cache-Control": "private, no-store, max-age=0" };
+
+export async function POST() {
+  const auth = await requireSessionAuth({ allowDevBypass: false });
+  if (!auth) return NextResponse.json({ error: "unauthorized" }, { status: 401, headers: NO_STORE });
+  try {
+    const result = await getDb().ensureDemoWorkspace(auth.userId, createDemoFixtures());
+    return NextResponse.json(result, { status: result.replayed ? 200 : 201, headers: NO_STORE });
+  } catch (error) {
+    if (error instanceof Error && error.message === "real_applications_exist") {
+      return NextResponse.json({ error: "real_applications_exist" }, { status: 409, headers: NO_STORE });
+    }
+    if (error instanceof Error && error.message === "demo_version_conflict") {
+      return NextResponse.json({ error: "demo_version_conflict" }, { status: 409, headers: NO_STORE });
+    }
+    return NextResponse.json({ error: "demo_workspace_failed" }, { status: 500, headers: NO_STORE });
+  }
+}
+
+export async function DELETE() {
+  const auth = await requireSessionAuth({ allowDevBypass: false });
+  if (!auth) return NextResponse.json({ error: "unauthorized" }, { status: 401, headers: NO_STORE });
+  try {
+    const result = await getDb().deleteDemoWorkspace(auth.userId);
+    return NextResponse.json(result, { headers: NO_STORE });
+  } catch {
+    return NextResponse.json({ error: "demo_workspace_delete_failed" }, { status: 500, headers: NO_STORE });
+  }
+}

--- a/app/api/mcp/__tests__/auth.test.ts
+++ b/app/api/mcp/__tests__/auth.test.ts
@@ -1,0 +1,58 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getApiTokenByHash: vi.fn(),
+  touchApiTokenLastUsed: vi.fn(),
+  findUnique: vi.fn(),
+  hashApiToken: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  getDb: () => ({
+    getApiTokenByHash: mocks.getApiTokenByHash,
+    touchApiTokenLastUsed: mocks.touchApiTokenLastUsed,
+  }),
+}));
+vi.mock("@/lib/token", () => ({ hashApiToken: mocks.hashApiToken }));
+vi.mock("@/lib/prisma", () => ({
+  prisma: { user: { findUnique: mocks.findUnique } },
+}));
+vi.mock("@/lib/mcp-oauth", () => ({ verifyMcpAccessToken: vi.fn() }));
+vi.mock("@/lib/cv/generate", () => ({ generateAndStoreCv: vi.fn() }));
+vi.mock("@/lib/documents/download", () => ({ downloadDocumentContent: vi.fn() }));
+vi.mock("@/lib/documents/upload", () => ({
+  uploadDocumentContent: vi.fn(),
+  MAX_DOCUMENT_BASE64_SIZE: 1_000_000,
+}));
+vi.mock("@/lib/documents/service", () => ({ deleteDocumentWithContent: vi.fn() }));
+
+import { authenticateFromRequest } from "../route";
+
+describe("MCP CRM API-token authentication", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.hashApiToken.mockReturnValue("hashed-token");
+    mocks.getApiTokenByHash.mockResolvedValue({ id: "token-1", userId: "admin-1" });
+    mocks.findUnique.mockResolvedValue({
+      id: "admin-1",
+      name: "Admin",
+      email: "admin@example.com",
+      image: null,
+      isAdmin: true,
+    });
+    mocks.touchApiTokenLastUsed.mockResolvedValue(undefined);
+  });
+
+  it("scopes admin CRM API-token reads to the token owner", async () => {
+    const request = new NextRequest("https://crm.example/api/mcp", {
+      headers: { authorization: "Bearer jt_secret" },
+    });
+
+    await expect(authenticateFromRequest(request)).resolves.toMatchObject({
+      userId: "admin-1",
+      readScopeUserId: "admin-1",
+      authType: "api_token",
+    });
+  });
+});

--- a/app/api/mcp/__tests__/demo-boundaries.test.ts
+++ b/app/api/mcp/__tests__/demo-boundaries.test.ts
@@ -1,0 +1,395 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  listApplications: vi.fn(),
+  getApplication: vi.fn(),
+  listApplicationsFiltered: vi.fn(),
+  findApplicationByCanonicalJobUrl: vi.fn(),
+  listApplicationEventsFiltered: vi.fn(),
+  listApplicationSubmissions: vi.fn(),
+  getApplicationSubmission: vi.fn(),
+  listApplicationEvents: vi.fn(),
+  listDocumentsByApplication: vi.fn(),
+  listUserSubmissions: vi.fn(),
+  listDocuments: vi.fn(),
+  listDocumentsFiltered: vi.fn(),
+  updateApplication: vi.fn(),
+  deleteApplication: vi.fn(),
+  recordApplicationEvent: vi.fn(),
+  recordApplicationSubmission: vi.fn(),
+  createContact: vi.fn(),
+  updateDocumentLinks: vi.fn(),
+  updateDocumentMetadata: vi.fn(),
+  getDocument: vi.fn(),
+  getCvProfile: vi.fn(),
+  upsertCvPatch: vi.fn(),
+  batchUpsertApplications: vi.fn(),
+  batchDeleteApplications: vi.fn(),
+}));
+const generateAndStoreCv = vi.hoisted(() => vi.fn());
+const downloadDocumentContent = vi.hoisted(() => vi.fn());
+const uploadDocumentContent = vi.hoisted(() => vi.fn());
+const deleteDocumentWithContent = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/db", () => ({ getDb: () => mocks }));
+vi.mock("@/lib/prisma", () => ({ prisma: {} }));
+vi.mock("@/lib/cv/generate", () => ({ generateAndStoreCv }));
+vi.mock("@/lib/documents/download", () => ({ downloadDocumentContent }));
+vi.mock("@/lib/documents/upload", () => ({ uploadDocumentContent, MAX_DOCUMENT_BASE64_SIZE: 1_000_000 }));
+vi.mock("@/lib/documents/service", () => ({ deleteDocumentWithContent }));
+
+import { createMcpServer } from "../route";
+
+const DEMO_EXCLUDE = { demoVisibility: "exclude" };
+const GUARDED_DOCUMENT_MUTATION = { requireNonDemoProvenance: true };
+const auth = {
+  userId: "owner-1",
+  readScopeUserId: "owner-1",
+  user: { id: "owner-1", name: "Owner", email: "owner@example.com", image: null, isAdmin: false },
+  authType: "mcp_oauth" as const,
+  scopes: ["mcp:tools", "mcp:submissions"],
+};
+
+let client: Client;
+let server: ReturnType<typeof createMcpServer>;
+
+async function call(name: string, args: Record<string, unknown> = {}) {
+  return client.callTool({ name, arguments: args });
+}
+
+function textValue(result: Awaited<ReturnType<Client["callTool"]>>) {
+  const content = (result as { content: Array<{ type: string; text?: string }> }).content;
+  if (content[0]?.type !== "text" || typeof content[0].text !== "string") throw new Error("expected text");
+  return content[0].text;
+}
+
+function json(result: Awaited<ReturnType<Client["callTool"]>>) {
+  return JSON.parse(textValue(result)) as Record<string, unknown>;
+}
+
+describe("MCP demo application boundaries", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mocks.listApplications.mockResolvedValue([]);
+    mocks.getApplication.mockResolvedValue(null);
+    mocks.listApplicationsFiltered.mockResolvedValue([]);
+    mocks.findApplicationByCanonicalJobUrl.mockResolvedValue(null);
+    mocks.listApplicationEventsFiltered.mockResolvedValue({ items: [], nextCursor: null });
+    mocks.listApplicationSubmissions.mockResolvedValue([]);
+    mocks.getApplicationSubmission.mockResolvedValue(null);
+    mocks.listApplicationEvents.mockResolvedValue([]);
+    mocks.listDocumentsByApplication.mockResolvedValue([]);
+    mocks.listUserSubmissions.mockResolvedValue([]);
+    mocks.listDocuments.mockResolvedValue([]);
+    mocks.listDocumentsFiltered.mockResolvedValue([]);
+    mocks.getDocument.mockResolvedValue({ id: "doc-1", applications: [] });
+    mocks.getCvProfile.mockResolvedValue({ id: "profile-1" });
+    server = createMcpServer(auth);
+    client = new Client({ name: "demo-boundary-test", version: "1.0.0" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  });
+
+  afterEach(async () => {
+    await client.close();
+    await server.close();
+  });
+
+  it("excludes demos from application list, detail, filtered, and canonical URL reads", async () => {
+    await call("list_applications");
+    const detail = await call("get_application", { id: "demo-app" });
+    await call("list_applications_filtered", { search: "demo" });
+    const canonical = await call("find_application_by_job_url", { jobUrl: "https://example.com/jobs/demo" });
+
+    expect(mocks.listApplications).toHaveBeenCalledWith("owner-1", DEMO_EXCLUDE);
+    expect(mocks.getApplication).toHaveBeenCalledWith("demo-app", "owner-1", DEMO_EXCLUDE);
+    expect(detail.isError).toBe(true);
+    expect(mocks.listApplicationsFiltered).toHaveBeenCalledWith("owner-1", expect.any(Object), DEMO_EXCLUDE);
+    expect(json(canonical)).toMatchObject({ application: null });
+    expect(mocks.findApplicationByCanonicalJobUrl).toHaveBeenCalledWith(
+      "owner-1",
+      "https://example.com/jobs/demo",
+      DEMO_EXCLUDE,
+    );
+  });
+
+  it("excludes demos from activity and rejects demo recall before reading child records", async () => {
+    await call("list_application_activity", { applicationId: "demo-app" });
+    const recall = await call("get_interview_recall_package", { applicationId: "demo-app" });
+
+    expect(mocks.listApplicationEventsFiltered).toHaveBeenCalledWith(
+      "owner-1",
+      expect.objectContaining({ applicationId: "demo-app" }),
+      DEMO_EXCLUDE,
+    );
+    expect(recall.isError).toBe(true);
+    expect(mocks.getApplication).toHaveBeenCalledWith("demo-app", "owner-1", DEMO_EXCLUDE);
+    expect(mocks.listApplicationSubmissions).not.toHaveBeenCalled();
+    expect(mocks.listApplicationEvents).not.toHaveBeenCalled();
+    expect(mocks.listDocumentsByApplication).not.toHaveBeenCalled();
+  });
+
+  it("excludes demo-owned children from pipeline health findings", async () => {
+    mocks.listApplications.mockResolvedValue([{
+      id: "real-app", status: "inbound", appliedAt: null, followUpAt: null,
+    }]);
+    mocks.listUserSubmissions.mockResolvedValue([{
+      id: "demo-submission", applicationId: "demo-app", answers: [], documentIds: [],
+    }]);
+    mocks.listDocuments.mockResolvedValue([{
+      id: "demo-document", applications: [{ id: "demo-app" }],
+    }]);
+
+    const result = await call("pipeline_healthcheck");
+
+    expect(mocks.listApplications).toHaveBeenCalledWith("owner-1", DEMO_EXCLUDE);
+    expect(json(result)).toEqual({ healthy: true, findingCount: 0, findings: [] });
+  });
+
+  it("excludes documents owned only by a demo from list and detail reads", async () => {
+    const demoDocument = { id: "demo-document", applications: [{ id: "demo-app" }] };
+    mocks.listDocumentsFiltered.mockResolvedValue([demoDocument]);
+    mocks.getDocument.mockResolvedValue(demoDocument);
+
+    const listed = await call("list_documents");
+    const detail = await call("get_document", { id: "demo-document" });
+
+    expect(json(listed)).toEqual([]);
+    expect(detail.isError).toBe(true);
+    expect(textValue(detail)).toBe("Document not found");
+    expect(mocks.getApplication).toHaveBeenCalledWith("demo-app", "owner-1", DEMO_EXCLUDE);
+  });
+
+  it("fails closed for documents with unresolved raw parent links across machine reads", async () => {
+    const danglingDocument = {
+      id: "dangling-document",
+      applicationIds: ["deleted-demo-app"],
+      applications: [],
+    };
+    mocks.listDocumentsFiltered.mockResolvedValue([danglingDocument]);
+    mocks.listDocuments.mockResolvedValue([danglingDocument]);
+    mocks.getDocument.mockResolvedValue(danglingDocument);
+
+    const listed = await call("list_documents");
+    const orphaned = await call("list_documents", { orphaned: true });
+    const detail = await call("get_document", { id: danglingDocument.id });
+    const download = await call("download_document_content", { id: danglingDocument.id });
+    const health = await call("pipeline_healthcheck");
+
+    expect(json(listed)).toEqual([]);
+    expect(json(orphaned)).toEqual([]);
+    expect(detail.isError).toBe(true);
+    expect(download.isError).toBe(true);
+    expect(downloadDocumentContent).not.toHaveBeenCalled();
+    expect(json(health)).toEqual({ healthy: true, findingCount: 0, findings: [] });
+  });
+
+  it("strips raw and hidden parent IDs from mixed document responses and nested packages", async () => {
+    const mixedDocument = {
+      id: "mixed-document",
+      applicationIds: ["real-app", "demo-app", "foreign-app", "dangling-app"],
+      applications: [
+        { id: "real-app" },
+        { id: "demo-app" },
+        { id: "foreign-app" },
+      ],
+    };
+    const submission = { id: "submission-1", applicationId: "real-app", documents: [mixedDocument] };
+    mocks.getApplication.mockImplementation(async (id: string) => id === "real-app" ? { id } : null);
+    mocks.listDocumentsFiltered.mockResolvedValue([mixedDocument]);
+    mocks.getDocument.mockResolvedValue(mixedDocument);
+    mocks.listApplicationSubmissions.mockResolvedValue([submission]);
+    mocks.getApplicationSubmission.mockResolvedValue(submission);
+    mocks.listDocumentsByApplication.mockResolvedValue([mixedDocument]);
+
+    const listed = await call("list_documents");
+    const detail = await call("get_document", { id: mixedDocument.id });
+    const submissionList = await call("list_application_submissions", { applicationId: "real-app" });
+    const submissionDetail = await call("get_application_submission", { id: "submission-1" });
+    const recall = await call("get_interview_recall_package", { applicationId: "real-app" });
+
+    for (const result of [listed, detail, submissionList, submissionDetail, recall]) {
+      const text = textValue(result);
+      expect(text).toContain("real-app");
+      expect(text).not.toContain("applicationIds");
+      expect(text).not.toContain("demo-app");
+      expect(text).not.toContain("foreign-app");
+      expect(text).not.toContain("dangling-app");
+    }
+  });
+
+  it("scans forward across adapter pages to fill the first logical visible document page", async () => {
+    const hiddenPage = Array.from({ length: 200 }, (_, index) => ({
+      id: `demo-document-${index}`,
+      applications: [{ id: "demo-app" }],
+    }));
+    const realDocument = { id: "real-document", applications: [{ id: "real-app" }] };
+    mocks.listDocumentsFiltered
+      .mockResolvedValueOnce(hiddenPage)
+      .mockResolvedValueOnce([realDocument]);
+    mocks.getApplication.mockImplementation(async (id: string) =>
+      id === "real-app" ? { id } : null,
+    );
+
+    const listed = await call("list_documents", { page: 1, pageSize: 1 });
+
+    expect(json(listed)).toEqual([realDocument]);
+    expect(mocks.listDocumentsFiltered).toHaveBeenNthCalledWith(
+      1,
+      "owner-1",
+      expect.objectContaining({ page: 1, pageSize: 200, fields: undefined }),
+    );
+    expect(mocks.listDocumentsFiltered).toHaveBeenNthCalledWith(
+      2,
+      "owner-1",
+      expect.objectContaining({ page: 2, pageSize: 200, fields: undefined }),
+    );
+  });
+
+  const mutationCases = [
+    { name: "update", tool: "update_application", args: { id: "demo-app", company: "Changed" }, mutation: "updateApplication" },
+    { name: "delete", tool: "delete_application", args: { id: "demo-app" }, mutation: "deleteApplication" },
+    { name: "event", tool: "record_application_event", args: { applicationId: "demo-app", type: "note_added", metadata: { note: "x" } }, mutation: "recordApplicationEvent" },
+    { name: "note", tool: "append_application_note", args: { applicationId: "demo-app", note: "x", occurredAt: "2026-08-10T10:00:00.000Z", idempotencyKey: "demo-note" }, mutation: "recordApplicationEvent" },
+    { name: "contact", tool: "create_contact", args: { applicationId: "demo-app", name: "Recruiter" }, mutation: "createContact" },
+    { name: "submission", tool: "record_application_submission", args: { applicationId: "demo-app", submittedAt: "2026-08-10T10:00:00.000Z", idempotencyKey: "demo-submission", answers: [], documentIds: [] }, mutation: "recordApplicationSubmission" },
+    { name: "document link", tool: "update_document_links", args: { id: "doc-1", applicationIds: ["demo-app"] }, mutation: "updateDocumentLinks" },
+    { name: "document metadata", tool: "update_document_metadata", args: { id: "demo-document", documentType: "resume" }, mutation: "updateDocumentMetadata" },
+    { name: "CV", tool: "generate_tailored_cv", args: { applicationId: "demo-app", experienceIds: [], skillCategories: [] }, mutation: "upsertCvPatch" },
+    { name: "batch update", tool: "batch_upsert_applications", args: { items: [{ id: "demo-app", company: "Changed" }] }, mutation: "batchUpsertApplications" },
+    { name: "batch delete", tool: "batch_delete_applications", args: { ids: ["demo-app"] }, mutation: "batchDeleteApplications" },
+  ] as const;
+
+  it.each(mutationCases)("rejects demo-targeted $name before mutation", async ({ name, tool, args, mutation }) => {
+    if (name === "document metadata") {
+      mocks.getDocument.mockResolvedValue({ id: "demo-document", applications: [{ id: "demo-app" }] });
+    }
+    const result = await call(tool, args);
+
+    expect(result.isError).toBe(true);
+    expect(mocks.getApplication).toHaveBeenCalledWith("demo-app", "owner-1", DEMO_EXCLUDE);
+    expect(mocks[mutation]).not.toHaveBeenCalled();
+    expect(generateAndStoreCv).not.toHaveBeenCalled();
+  });
+
+  it("rejects uploading and linking a document to a demo before storage mutation", async () => {
+    const result = await call("upload_document_content", {
+      filename: "resume.pdf",
+      mimeType: "application/pdf",
+      contentBase64: "YQ==",
+      applicationIds: ["demo-app"],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(mocks.getApplication).toHaveBeenCalledWith("demo-app", "owner-1", DEMO_EXCLUDE);
+    expect(uploadDocumentContent).not.toHaveBeenCalled();
+  });
+
+  it("rejects relinking an existing demo-only document before checking replacement links", async () => {
+    mocks.getDocument.mockResolvedValue({
+      id: "demo-document",
+      applications: [{ id: "demo-app" }],
+    });
+
+    const result = await call("update_document_links", {
+      id: "demo-document",
+      applicationIds: [],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(mocks.getDocument).toHaveBeenCalledWith("demo-document", "owner-1");
+    expect(mocks.getApplication).toHaveBeenCalledWith("demo-app", "owner-1", DEMO_EXCLUDE);
+    expect(mocks.updateDocumentLinks).not.toHaveBeenCalled();
+  });
+
+  it("rejects downloading content for a demo-only document before storage access", async () => {
+    mocks.getDocument.mockResolvedValue({
+      id: "demo-document",
+      applications: [{ id: "demo-app" }],
+    });
+
+    const result = await call("download_document_content", { id: "demo-document" });
+
+    expect(result.isError).toBe(true);
+    expect(downloadDocumentContent).not.toHaveBeenCalled();
+  });
+
+  it("rejects deleting a document linked only to a demo before storage mutation", async () => {
+    mocks.getDocument.mockResolvedValue({ id: "demo-document", applications: [{ id: "demo-app" }] });
+
+    const result = await call("delete_document", { id: "demo-document" });
+
+    expect(result.isError).toBe(true);
+    expect(mocks.getApplication).toHaveBeenCalledWith("demo-app", "owner-1", DEMO_EXCLUDE);
+    expect(deleteDocumentWithContent).not.toHaveBeenCalled();
+  });
+
+  it("passes the transaction-time demo guard to every document mutation", async () => {
+    const realDocument = { id: "doc-1", applications: [] };
+    mocks.getDocument.mockResolvedValue(realDocument);
+    mocks.getApplication.mockResolvedValue({ id: "real-app" });
+    mocks.updateDocumentLinks.mockResolvedValue(realDocument);
+    mocks.updateDocumentMetadata.mockResolvedValue(realDocument);
+    deleteDocumentWithContent.mockResolvedValue(realDocument);
+
+    await call("update_document_links", { id: "doc-1", applicationIds: ["real-app"] });
+    await call("update_document_metadata", { id: "doc-1", documentType: "resume" });
+    await call("delete_document", { id: "doc-1" });
+
+    expect(mocks.updateDocumentLinks).toHaveBeenCalledWith(
+      "doc-1",
+      "owner-1",
+      ["real-app"],
+      GUARDED_DOCUMENT_MUTATION,
+    );
+    expect(mocks.updateDocumentMetadata).toHaveBeenCalledWith(
+      "doc-1",
+      "owner-1",
+      expect.objectContaining({ documentType: "resume" }),
+      GUARDED_DOCUMENT_MUTATION,
+    );
+    expect(deleteDocumentWithContent).toHaveBeenCalledWith(
+      mocks,
+      "doc-1",
+      "owner-1",
+      GUARDED_DOCUMENT_MUTATION,
+    );
+  });
+
+  it("sanitizes upload, relink, and metadata mutation document responses", async () => {
+    const mixedDocument = {
+      id: "doc-1",
+      applicationIds: ["real-app", "demo-app", "foreign-app", "dangling-app"],
+      applications: [{ id: "real-app" }, { id: "demo-app" }, { id: "foreign-app" }],
+    };
+    mocks.getDocument.mockResolvedValue(mixedDocument);
+    mocks.getApplication.mockImplementation(async (id: string) => id === "real-app" ? { id } : null);
+    mocks.updateDocumentLinks.mockResolvedValue(mixedDocument);
+    mocks.updateDocumentMetadata.mockResolvedValue(mixedDocument);
+    uploadDocumentContent.mockImplementation(async (
+      _args: unknown,
+      _userId: string,
+      sanitize: (document: typeof mixedDocument) => Promise<typeof mixedDocument | null>,
+    ) => {
+      const visible = await sanitize(mixedDocument);
+      return { content: [{ type: "text", text: JSON.stringify(visible) }] };
+    });
+
+    const relink = await call("update_document_links", { id: "doc-1", applicationIds: ["real-app"] });
+    const metadata = await call("update_document_metadata", { id: "doc-1", documentType: "resume" });
+    const upload = await call("upload_document_content", {
+      filename: "resume.pdf", mimeType: "application/pdf", contentBase64: "YQ==", applicationIds: ["real-app"],
+    });
+
+    for (const result of [relink, metadata, upload]) {
+      const text = textValue(result);
+      expect(text).toContain("real-app");
+      expect(text).not.toContain("applicationIds");
+      expect(text).not.toContain("demo-app");
+      expect(text).not.toContain("foreign-app");
+      expect(text).not.toContain("dangling-app");
+    }
+  });
+});

--- a/app/api/mcp/__tests__/demo-boundaries.test.ts
+++ b/app/api/mcp/__tests__/demo-boundaries.test.ts
@@ -246,6 +246,55 @@ describe("MCP demo application boundaries", () => {
       "owner-1",
       expect.objectContaining({ page: 2, pageSize: 200, fields: undefined }),
     );
+    expect(mocks.getApplication.mock.calls.filter(([id]) => id === "demo-app")).toHaveLength(1);
+    expect(mocks.getApplication.mock.calls.filter(([id]) => id === "real-app")).toHaveLength(1);
+  });
+
+  it("preserves logical pagination while scanning hidden document prefixes", async () => {
+    const hiddenPrefix = Array.from({ length: 198 }, (_, index) => ({
+      id: `demo-document-${index}`,
+      applications: [{ id: "demo-app" }],
+    }));
+    const visibleDocuments = [1, 2, 3, 4].map((index) => ({
+      id: `real-document-${index}`,
+      applications: [{ id: "real-app" }],
+    }));
+    mocks.listDocumentsFiltered
+      .mockResolvedValueOnce([...hiddenPrefix, ...visibleDocuments.slice(0, 2)])
+      .mockResolvedValueOnce(visibleDocuments.slice(2));
+    mocks.getApplication.mockImplementation(async (id: string) =>
+      id === "real-app" ? { id } : null,
+    );
+
+    const listed = await call("list_documents", { page: 2, pageSize: 2 });
+
+    expect(json(listed)).toEqual(visibleDocuments.slice(2));
+  });
+
+  it("rejects document pages beyond the declared logical pagination bound", async () => {
+    const listed = await call("list_documents", { page: 21, pageSize: 1 });
+
+    expect(listed.isError).toBe(true);
+    expect(mocks.listDocumentsFiltered).not.toHaveBeenCalled();
+  });
+
+  it("fails explicitly instead of returning an incomplete page at the scan bound", async () => {
+    const hiddenPage = Array.from({ length: 200 }, (_, index) => ({
+      id: `demo-document-${index}`,
+      applications: [{ id: "demo-app" }],
+    }));
+    for (let page = 0; page < 21; page += 1) {
+      mocks.listDocumentsFiltered.mockResolvedValueOnce(hiddenPage);
+    }
+    mocks.listDocumentsFiltered.mockResolvedValueOnce([]);
+
+    const listed = await call("list_documents", { page: 1, pageSize: 1 });
+
+    expect(listed.isError).toBe(true);
+    expect(json(listed)).toEqual({
+      error: { code: "document_scan_limit_exceeded", maxScannedDocuments: 4000 },
+    });
+    expect(mocks.listDocumentsFiltered).toHaveBeenCalledTimes(20);
   });
 
   const mutationCases = [

--- a/app/api/mcp/__tests__/events.test.ts
+++ b/app/api/mcp/__tests__/events.test.ts
@@ -68,6 +68,7 @@ describe("MCP application event contracts", () => {
   });
 
   it("records a typed event with MCP provenance and controlled replay output", async () => {
+    mocks.getApplication.mockResolvedValue({ id: "app-1" });
     mocks.recordApplicationEvent.mockResolvedValue({ event: { id: "event-1" }, application: { id: "app-1" }, replayed: false });
     const result = await client.callTool({
       name: "record_application_event",
@@ -98,7 +99,8 @@ describe("MCP application event contracts", () => {
     expect(text(result)).toEqual({ items: [{ id: "event-1" }], nextCursor: null });
     expect(mocks.listApplicationEventsFiltered).toHaveBeenCalledWith("owner-1", expect.objectContaining({
       applicationId: "app-1", order: "oldest", limit: 20,
-    }));
+    }), { demoVisibility: "exclude" });
+    expect(mocks.getApplication).toHaveBeenCalledWith("app-1", "owner-1", { demoVisibility: "exclude" });
   });
 
   it("does not let duplicate-safe upserts bypass lifecycle events", async () => {

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -62,6 +62,9 @@ const structuredApplicationToolFields = {
 
 const MACHINE_DEMO_READ = { demoVisibility: "exclude" } as const;
 const MACHINE_DOCUMENT_MUTATION = { requireNonDemoProvenance: true } as const;
+const DOCUMENT_LIST_MAX_PAGE = 20;
+const DOCUMENT_LIST_SCAN_PAGE_SIZE = 200;
+const DOCUMENT_LIST_MAX_SCAN_PAGES = 20;
 
 const APPLICATION_UPDATE_ERROR_CODES = new Set([
   "not_found",
@@ -121,7 +124,7 @@ function controlledErrorCode(error: unknown, allowed: Set<string>, fallback: str
 // ── Auth helper ──────────────────────────────────────────────────────────────
 // Tries MCP OAuth access token first, then falls back to CRM API token.
 
-async function authenticateFromRequest(
+export async function authenticateFromRequest(
   req: NextRequest
 ): Promise<SessionAuthResult | null> {
   const authHeader = req.headers.get("authorization");
@@ -158,7 +161,7 @@ async function authenticateFromRequest(
 
   return {
     userId: user.id,
-    readScopeUserId: user.isAdmin ? null : user.id,
+    readScopeUserId: user.id,
     user: sessionUser,
     authType: "api_token",
     scopes: ["mcp:tools", "mcp:submissions"],
@@ -1103,30 +1106,60 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
       submissionId: z.string().optional(),
       orphaned: z.boolean().optional(),
       fields: z.array(z.string()).max(30).optional(),
-      page: z.number().int().min(1).optional(),
+      page: z.number().int().min(1).max(DOCUMENT_LIST_MAX_PAGE).optional(),
       pageSize: z.number().int().min(1).max(200).optional(),
     },
     async (args) => {
       const requestedPage = args.page ?? 1;
       const requestedPageSize = args.pageSize ?? 50;
       const logicalPageEnd = requestedPage * requestedPageSize;
-      const scanPageSize = 200;
       const visibleDocs: Partial<DocumentRecord>[] = [];
+      const parentVisibility = new Map<string, ReturnType<typeof getRealApplication>>();
+      const resolveVisibleParent = (applicationId: string) => {
+        let visible = parentVisibility.get(applicationId);
+        if (!visible) {
+          visible = getRealApplication(applicationId, auth.readScopeUserId);
+          parentVisibility.set(applicationId, visible);
+        }
+        return visible;
+      };
       let scanPage = 1;
-      while (visibleDocs.length < logicalPageEnd) {
+      let sourceExhausted = false;
+      while (
+        visibleDocs.length < logicalPageEnd
+        && scanPage <= DOCUMENT_LIST_MAX_SCAN_PAGES
+      ) {
         const docs = await getDb().listDocumentsFiltered(auth.readScopeUserId, {
           ...args,
           page: scanPage,
-          pageSize: scanPageSize,
+          pageSize: DOCUMENT_LIST_SCAN_PAGE_SIZE,
           fields: undefined,
           excludeSubmissionArtifacts: !canAccessSubmissions,
         });
         const visibleBatch = (await Promise.all(
-          docs.map((document) => filterRealDocumentApplications(document)),
+          docs.map((document) => sanitizeDocumentAssociations(document, resolveVisibleParent)),
         )).filter((document): document is NonNullable<typeof document> => Boolean(document));
         visibleDocs.push(...visibleBatch);
-        if (docs.length < scanPageSize) break;
+        if (docs.length < DOCUMENT_LIST_SCAN_PAGE_SIZE) {
+          sourceExhausted = true;
+          break;
+        }
         scanPage += 1;
+      }
+      if (visibleDocs.length < logicalPageEnd && !sourceExhausted) {
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              error: {
+                code: "document_scan_limit_exceeded",
+                maxScannedDocuments:
+                  DOCUMENT_LIST_SCAN_PAGE_SIZE * DOCUMENT_LIST_MAX_SCAN_PAGES,
+              },
+            }),
+          }],
+          isError: true,
+        };
       }
       const logicalDocs = visibleDocs.slice(
         (requestedPage - 1) * requestedPageSize,

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -28,8 +28,13 @@ import {
 } from "@/lib/documents/access";
 import { uploadDocumentContent, MAX_DOCUMENT_BASE64_SIZE } from "@/lib/documents/upload";
 import { deleteDocumentWithContent } from "@/lib/documents/service";
+import { sanitizeDocumentAssociations } from "@/lib/documents/provenance";
 import type { SessionAuthResult, SessionUser } from "@/lib/session";
-import type { SubmissionPolicyInput, UpsertCvProfileInput } from "@/lib/db/types";
+import type {
+  DocumentRecord,
+  SubmissionPolicyInput,
+  UpsertCvProfileInput,
+} from "@/lib/db/types";
 
 const structuredApplicationToolFields = {
   workMode: z.enum(["remote", "hybrid", "onsite", "flexible"]).nullable().optional(),
@@ -54,6 +59,9 @@ const structuredApplicationToolFields = {
   jobSummary: z.string().max(10_000).nullable().optional(),
   currentStage: z.string().max(255).nullable().optional(),
 };
+
+const MACHINE_DEMO_READ = { demoVisibility: "exclude" } as const;
+const MACHINE_DOCUMENT_MUTATION = { requireNonDemoProvenance: true } as const;
 
 const APPLICATION_UPDATE_ERROR_CODES = new Set([
   "not_found",
@@ -176,6 +184,36 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
     content: [{ type: "text" as const, text: JSON.stringify({ error: { code: "insufficient_scope", required: "mcp:submissions" } }) }],
     isError: true,
   });
+  const getRealApplication = (id: string, userId: string | null = auth.userId) =>
+    getDb().getApplication(id, userId, MACHINE_DEMO_READ);
+  const requireRealApplication = async (id: string, userId: string | null = auth.userId) => {
+    const application = await getRealApplication(id, userId);
+    if (!application) throw new Error("not_found");
+    return application;
+  };
+  const filterRealDocumentApplications = async <T extends {
+    applicationIds?: string[];
+    applications?: Array<{ id: string }>;
+  }>(document: T, userId: string | null = auth.readScopeUserId): Promise<T | null> => {
+    return sanitizeDocumentAssociations(
+      document,
+      (applicationId) => getRealApplication(applicationId, userId),
+    );
+  };
+  const filterRealDocuments = async (documents: DocumentRecord[]) =>
+    (await Promise.all(documents.map((document) => filterRealDocumentApplications(document))))
+      .filter((document): document is DocumentRecord => document !== null);
+  const filterSubmissionDocuments = async <T extends { documents?: DocumentRecord[] }>(submission: T): Promise<T> =>
+    submission.documents
+      ? { ...submission, documents: await filterRealDocuments(submission.documents) }
+      : submission;
+  const requireExistingRealDocument = async (id: string) => {
+    const existing = await getDb().getDocument(id, auth.userId);
+    if (!existing || !await filterRealDocumentApplications(existing, auth.userId)) {
+      throw new Error("not_found");
+    }
+    return existing;
+  };
 
 
   // ── Applications ────────────────────────────────────────────────────────
@@ -185,7 +223,7 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
     "List all job applications for the authenticated user",
     {},
     async () => {
-      const apps = await getDb().listApplications(auth.readScopeUserId);
+      const apps = await getDb().listApplications(auth.readScopeUserId, MACHINE_DEMO_READ);
       return {
         content: [{ type: "text", text: JSON.stringify(apps, null, 2) }],
       };
@@ -197,7 +235,7 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
     "Get a single application by ID",
     { id: z.string().describe("Application ID") },
     async ({ id }) => {
-      const app = await getDb().getApplication(id, auth.readScopeUserId);
+      const app = await getRealApplication(id, auth.readScopeUserId);
       if (!app) {
         return {
           content: [{ type: "text", text: "Application not found" }],
@@ -303,6 +341,7 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
         };
       }
       try {
+        const current = await requireRealApplication(id);
         const update: Record<string, unknown> = {};
         if (data.company !== undefined) update.company = data.company.slice(0, 255);
         if (data.role !== undefined) update.role = data.role.slice(0, 255);
@@ -332,8 +371,6 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
         }
 
         if (data.dryRun) {
-          const current = await getDb().getApplication(id, auth.userId);
-          if (!current) throw new Error("not_found");
           if (
             data.expectedUpdatedAt &&
             current.updatedAt.getTime() !== new Date(data.expectedUpdatedAt).getTime()
@@ -372,6 +409,7 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
     async ({ id }) => {
       if (!canAccessSubmissions) return submissionScopeError();
       try {
+        await requireRealApplication(id);
         await getDb().deleteApplication(id, auth.userId);
         return { content: [{ type: "text", text: "Application deleted" }] };
       } catch {
@@ -416,6 +454,7 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
     async (args) => {
       if (!canAccessSubmissions) return submissionScopeError();
       try {
+        await requireRealApplication(args.applicationId);
         if (
           args.candidateSalaryMin != null &&
           args.candidateSalaryMax != null &&
@@ -447,7 +486,8 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
           source: "mcp",
           actor: auth.user.email,
         });
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        const sanitized = await filterSubmissionDocuments(result);
+        return { content: [{ type: "text", text: JSON.stringify(sanitized, null, 2) }] };
       } catch (error) {
         const code = controlledErrorCode(error, SUBMISSION_ERROR_CODES, "submission_failed");
         return { content: [{ type: "text", text: JSON.stringify({ error: { code } }) }], isError: true };
@@ -462,8 +502,10 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
     async ({ applicationId }) => {
       if (!canAccessSubmissions) return submissionScopeError();
       try {
+        await requireRealApplication(applicationId);
         const submissions = await getDb().listApplicationSubmissions(applicationId, auth.userId, false);
-        return { content: [{ type: "text", text: JSON.stringify(submissions, null, 2) }] };
+        const sanitized = await Promise.all(submissions.map(filterSubmissionDocuments));
+        return { content: [{ type: "text", text: JSON.stringify(sanitized, null, 2) }] };
       } catch {
         return { content: [{ type: "text", text: "Application not found or access denied" }], isError: true };
       }
@@ -478,7 +520,11 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
       if (!canAccessSubmissions) return submissionScopeError();
       const submission = await getDb().getApplicationSubmission(id, auth.userId);
       if (!submission) return { content: [{ type: "text", text: "Submission not found" }], isError: true };
-      return { content: [{ type: "text", text: JSON.stringify(submission, null, 2) }] };
+      if (!await getRealApplication(submission.applicationId)) {
+        return { content: [{ type: "text", text: "Submission not found" }], isError: true };
+      }
+      const sanitized = await filterSubmissionDocuments(submission);
+      return { content: [{ type: "text", text: JSON.stringify(sanitized, null, 2) }] };
     },
   );
 
@@ -494,6 +540,7 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
     },
     async (args) => {
       try {
+        await requireRealApplication(args.applicationId);
         const command = parseApplicationEventCommand({
           type: "note_added",
           idempotencyKey: args.idempotencyKey,
@@ -529,6 +576,7 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
     },
     async (args) => {
       try {
+        await requireRealApplication(args.applicationId);
         const command = parseApplicationEventCommand({
           type: args.type,
           idempotencyKey: args.idempotencyKey,
@@ -559,10 +607,10 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
     async ({ applicationId, cursor, order, limit }) => {
       try {
         const db = getDb();
-        const application = await db.getApplication(applicationId, auth.userId);
+        const application = await db.getApplication(applicationId, auth.userId, MACHINE_DEMO_READ);
         if (!application) throw new Error("not_found");
         const filter = parseEventQuery({ applicationId, cursor, order, limit });
-        const page = await db.listApplicationEventsFiltered(auth.userId, filter);
+        const page = await db.listApplicationEventsFiltered(auth.userId, filter, MACHINE_DEMO_READ);
         return { content: [{ type: "text", text: JSON.stringify(page, null, 2) }] };
       } catch (error) {
         const code = controlledErrorCode(error, EVENT_ERROR_CODES, "event_query_failed");
@@ -591,7 +639,7 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
     async (args) => {
       try {
         const filter = parseEventQuery(args);
-        const page = await getDb().listApplicationEventsFiltered(auth.userId, filter);
+        const page = await getDb().listApplicationEventsFiltered(auth.userId, filter, MACHINE_DEMO_READ);
         return { content: [{ type: "text", text: JSON.stringify(page, null, 2) }] };
       } catch (error) {
         const code = controlledErrorCode(error, EVENT_ERROR_CODES, "event_query_failed");
@@ -607,17 +655,21 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
     async ({ applicationId }) => {
       if (!canAccessSubmissions) return submissionScopeError();
       const db = getDb();
-      const application = await db.getApplication(applicationId, auth.userId);
+      const application = await db.getApplication(applicationId, auth.userId, MACHINE_DEMO_READ);
       if (!application) return { content: [{ type: "text", text: "Application not found" }], isError: true };
       const [submissions, events, documents] = await Promise.all([
         db.listApplicationSubmissions(applicationId, auth.userId, true),
-        db.listApplicationEvents(applicationId, auth.userId, 500),
+        db.listApplicationEvents(applicationId, auth.userId, 500, MACHINE_DEMO_READ),
         db.listDocumentsByApplication(applicationId, auth.userId),
+      ]);
+      const [sanitizedSubmissions, sanitizedDocuments] = await Promise.all([
+        Promise.all(submissions.map(filterSubmissionDocuments)),
+        filterRealDocuments(documents),
       ]);
       return {
         content: [{
           type: "text",
-          text: JSON.stringify({ application, submissions, events, documents }, null, 2),
+          text: JSON.stringify({ application, submissions: sanitizedSubmissions, events, documents: sanitizedDocuments }, null, 2),
         }],
       };
     },
@@ -630,7 +682,7 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
     async ({ jobUrl }) => {
       const canonicalJobUrl = canonicalizeJobUrl(jobUrl);
       if (!canonicalJobUrl) return { content: [{ type: "text", text: "Invalid URL" }], isError: true };
-      const application = await getDb().findApplicationByCanonicalJobUrl(auth.userId, canonicalJobUrl);
+      const application = await getDb().findApplicationByCanonicalJobUrl(auth.userId, canonicalJobUrl, MACHINE_DEMO_READ);
       return { content: [{ type: "text", text: JSON.stringify({ canonicalJobUrl, application }, null, 2) }] };
     },
   );
@@ -662,7 +714,7 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
           throw new Error("salary_range_invalid");
         }
         const db = getDb();
-        const existing = await db.findApplicationByCanonicalJobUrl(auth.userId, canonicalJobUrl);
+        const existing = await db.findApplicationByCanonicalJobUrl(auth.userId, canonicalJobUrl, MACHINE_DEMO_READ);
         const metadata = parseStructuredApplicationMetadata(args as unknown as Record<string, unknown>);
         const assertNoLifecycleUpdate = (application: { status: string; currentStage?: string | null }) => {
           if (args.status !== undefined && args.status !== application.status) {
@@ -736,7 +788,7 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
         } catch (error) {
           const code = error instanceof Error ? error.message : "";
           if (code !== "canonical_job_url_conflict") throw error;
-          const concurrent = await db.findApplicationByCanonicalJobUrl(auth.userId, canonicalJobUrl);
+          const concurrent = await db.findApplicationByCanonicalJobUrl(auth.userId, canonicalJobUrl, MACHINE_DEMO_READ);
           if (!concurrent) throw error;
           application = await updateExisting(concurrent);
           operation = "updated";
@@ -757,17 +809,28 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
       if (!canAccessSubmissions) return submissionScopeError();
       const db = getDb();
       const [applications, submissions, documents] = await Promise.all([
-        db.listApplications(auth.userId),
+        db.listApplications(auth.userId, MACHINE_DEMO_READ),
         db.listUserSubmissions(auth.userId),
         db.listDocuments(auth.userId),
       ]);
+      const realApplicationIds = new Set(applications.map((application) => application.id));
+      const visibleDocuments = (await Promise.all(
+        documents.map((document) => filterRealDocumentApplications(document, auth.userId)),
+      )).filter((document): document is NonNullable<typeof document> => document !== null);
       const findings = computeApplicationHealth({
         applications,
-        submissions,
-        documents: documents.map((document) => ({
-          id: document.id,
-          applicationIds: document.applications?.map((application) => application.id) ?? [],
-        })),
+        submissions: submissions.filter((submission) => realApplicationIds.has(submission.applicationId)),
+        documents: visibleDocuments
+          .filter((document) =>
+            !document.applications?.length
+            || document.applications.some((application) => realApplicationIds.has(application.id)),
+          )
+          .map((document) => ({
+            id: document.id,
+            applicationIds: document.applications
+              ?.map((application) => application.id)
+              .filter((applicationId) => realApplicationIds.has(applicationId)) ?? [],
+          })),
       });
       return {
         content: [{
@@ -815,6 +878,12 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
     },
     async ({ items }) => {
       try {
+        await Promise.all(
+          items
+            .map((item) => item.id)
+            .filter((id): id is string => Boolean(id))
+            .map((id) => requireRealApplication(id)),
+        );
         const sanitized = items.map((item) => ({
           id: item.id,
           company: item.company?.slice(0, 255),
@@ -861,6 +930,7 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
     async ({ ids }) => {
       if (!canAccessSubmissions) return submissionScopeError();
       try {
+        await Promise.all(ids.map((id) => requireRealApplication(id)));
         const result = await getDb().batchDeleteApplications(ids, auth.userId);
         return {
           content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
@@ -911,7 +981,7 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
           fields: args.fields,
           limit: args.limit,
           includeContacts: args.include_contacts,
-        });
+        }, MACHINE_DEMO_READ);
         return {
           content: [{ type: "text", text: JSON.stringify(apps, null, 2) }],
         };
@@ -938,8 +1008,8 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
       linkedIn: z.string().optional().describe("LinkedIn profile URL"),
     },
     async ({ applicationId, ...data }) => {
-      const owns = await getDb().verifyApplicationOwner(applicationId, auth.userId);
-      if (!owns) {
+      const application = await getRealApplication(applicationId);
+      if (!application) {
         return {
           content: [{ type: "text", text: "Application not found or access denied" }],
           isError: true,
@@ -972,6 +1042,7 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
     },
     async ({ contactId, applicationId, ...data }) => {
       try {
+        await requireRealApplication(applicationId);
         const contact = await getDb().updateContact(
           contactId,
           applicationId,
@@ -1008,6 +1079,7 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
     },
     async ({ contactId, applicationId }) => {
       try {
+        await requireRealApplication(applicationId);
         await getDb().deleteContact(contactId, applicationId, auth.userId);
         return { content: [{ type: "text", text: "Contact deleted" }] };
       } catch {
@@ -1035,12 +1107,42 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
       pageSize: z.number().int().min(1).max(200).optional(),
     },
     async (args) => {
-      const docs = await getDb().listDocumentsFiltered(auth.readScopeUserId, {
-        ...args,
-        excludeSubmissionArtifacts: !canAccessSubmissions,
-      });
+      const requestedPage = args.page ?? 1;
+      const requestedPageSize = args.pageSize ?? 50;
+      const logicalPageEnd = requestedPage * requestedPageSize;
+      const scanPageSize = 200;
+      const visibleDocs: Partial<DocumentRecord>[] = [];
+      let scanPage = 1;
+      while (visibleDocs.length < logicalPageEnd) {
+        const docs = await getDb().listDocumentsFiltered(auth.readScopeUserId, {
+          ...args,
+          page: scanPage,
+          pageSize: scanPageSize,
+          fields: undefined,
+          excludeSubmissionArtifacts: !canAccessSubmissions,
+        });
+        const visibleBatch = (await Promise.all(
+          docs.map((document) => filterRealDocumentApplications(document)),
+        )).filter((document): document is NonNullable<typeof document> => Boolean(document));
+        visibleDocs.push(...visibleBatch);
+        if (docs.length < scanPageSize) break;
+        scanPage += 1;
+      }
+      const logicalDocs = visibleDocs.slice(
+        (requestedPage - 1) * requestedPageSize,
+        logicalPageEnd,
+      );
+      const selectedDocs = args.fields?.length
+        ? logicalDocs.map((document) => {
+            const selected: Record<string, unknown> = { id: document.id };
+            for (const field of args.fields ?? []) {
+              if (field in document) selected[field] = document[field as keyof typeof document];
+            }
+            return selected;
+          })
+        : logicalDocs;
       return {
-        content: [{ type: "text", text: JSON.stringify(docs, null, 2) }],
+        content: [{ type: "text", text: JSON.stringify(selectedDocs, null, 2) }],
       };
     },
   );
@@ -1050,7 +1152,8 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
     "Get a single document by ID",
     { id: z.string().describe("Document ID") },
     async ({ id }) => {
-      const doc = await getDb().getDocument(id, auth.readScopeUserId);
+      const stored = await getDb().getDocument(id, auth.readScopeUserId);
+      const doc = stored ? await filterRealDocumentApplications(stored) : null;
       if (!doc) {
         return {
           content: [{ type: "text", text: "Document not found" }],
@@ -1075,7 +1178,23 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
       contentBase64: z.string().min(1).max(MAX_DOCUMENT_BASE64_SIZE).describe("Raw file bytes encoded as standard base64"),
       applicationIds: z.array(z.string()).optional().describe("Application IDs to link"),
     },
-    async (args) => uploadDocumentContent(args, auth.userId),
+    async (args) => {
+      try {
+        await Promise.all(
+          (args.applicationIds ?? []).map((applicationId) => requireRealApplication(applicationId)),
+        );
+        return await uploadDocumentContent(
+          args,
+          auth.userId,
+          (document) => filterRealDocumentApplications(document, auth.userId),
+        );
+      } catch {
+        return {
+          content: [{ type: "text", text: "Application not found or access denied" }],
+          isError: true,
+        };
+      }
+    },
   );
 
   server.tool(
@@ -1083,7 +1202,8 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
     "Download the binary content of a document. For files <=1MB the content is returned inline as base64. For larger files, a short-lived signed URL is returned instead when object storage is available (falls back to inline base64 otherwise).",
     { id: z.string().describe("Document ID") },
     async ({ id }) => {
-      const document = await getDb().getDocument(id, auth.readScopeUserId);
+      const stored = await getDb().getDocument(id, auth.readScopeUserId);
+      const document = stored ? await filterRealDocumentApplications(stored) : null;
       if (!document) {
         return { content: [{ type: "text", text: "Document not found" }], isError: true };
       }
@@ -1101,15 +1221,22 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
     },
     async ({ id, applicationIds }) => {
       try {
-        const existing = await getDb().getDocument(id, auth.userId);
-        if (!existing) throw new Error("not_found");
+        const existing = await requireExistingRealDocument(id);
+        await Promise.all(applicationIds.map((applicationId) => requireRealApplication(applicationId)));
         if (!canAccessSubmissions && requiresSubmissionScopeForDocumentMutation(existing)) {
           return submissionScopeError();
         }
-        const doc = await getDb().updateDocumentLinks(id, auth.userId, applicationIds);
+        const doc = await getDb().updateDocumentLinks(
+          id,
+          auth.userId,
+          applicationIds,
+          MACHINE_DOCUMENT_MUTATION,
+        );
         if (!canAccessSubmissions && isSubmissionDocument(doc)) return submissionScopeError();
+        const visible = await filterRealDocumentApplications(doc, auth.userId);
+        if (!visible) throw new Error("not_found");
         return {
-          content: [{ type: "text", text: JSON.stringify(doc, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(visible, null, 2) }],
         };
       } catch {
         return {
@@ -1135,25 +1262,31 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
     },
     async ({ id, generatedAt, submittedAt, ...metadata }) => {
       try {
-        const existing = await getDb().getDocument(id, auth.userId);
-        if (!existing) throw new Error("not_found");
+        const existing = await requireExistingRealDocument(id);
         if (
           !canAccessSubmissions
           && (
             requiresSubmissionScopeForDocumentMutation(existing, metadata.state)
           )
         ) return submissionScopeError();
-        const document = await getDb().updateDocumentMetadata(id, auth.userId, {
-          ...metadata,
-          ...(generatedAt !== undefined && {
-            generatedAt: generatedAt ? new Date(generatedAt) : null,
-          }),
-          ...(submittedAt !== undefined && {
-            submittedAt: submittedAt ? new Date(submittedAt) : null,
-          }),
-        });
+        const document = await getDb().updateDocumentMetadata(
+          id,
+          auth.userId,
+          {
+            ...metadata,
+            ...(generatedAt !== undefined && {
+              generatedAt: generatedAt ? new Date(generatedAt) : null,
+            }),
+            ...(submittedAt !== undefined && {
+              submittedAt: submittedAt ? new Date(submittedAt) : null,
+            }),
+          },
+          MACHINE_DOCUMENT_MUTATION,
+        );
         if (!canAccessSubmissions && isSubmissionDocument(document)) return submissionScopeError();
-        return { content: [{ type: "text", text: JSON.stringify(document, null, 2) }] };
+        const visible = await filterRealDocumentApplications(document, auth.userId);
+        if (!visible) throw new Error("not_found");
+        return { content: [{ type: "text", text: JSON.stringify(visible, null, 2) }] };
       } catch {
         return {
           content: [{ type: "text", text: "Document not found or access denied" }],
@@ -1169,7 +1302,13 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
     { id: z.string().describe("Document ID") },
     async ({ id }) => {
       try {
-        const result = await deleteDocumentWithContent(getDb(), id, auth.userId);
+        await requireExistingRealDocument(id);
+        const result = await deleteDocumentWithContent(
+          getDb(),
+          id,
+          auth.userId,
+          MACHINE_DOCUMENT_MUTATION,
+        );
         if (!result) {
           return {
             content: [{ type: "text", text: "Document not found or access denied" }],
@@ -1285,7 +1424,7 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
         const db = getDb();
 
         // Verify application ownership
-        const app = await db.getApplication(args.applicationId, auth.readScopeUserId);
+        const app = await db.getApplication(args.applicationId, auth.readScopeUserId, MACHINE_DEMO_READ);
         if (!app) {
           return {
             content: [{ type: "text", text: "Application not found or access denied" }],

--- a/app/api/share-links/__tests__/route.test.ts
+++ b/app/api/share-links/__tests__/route.test.ts
@@ -67,6 +67,24 @@ describe("POST /api/share-links", () => {
     expect(mocks.getApplication).toHaveBeenCalledWith("demo-app", "user-1", { demoVisibility: "exclude" });
     expect(mocks.createShareLink).not.toHaveBeenCalled();
   });
+
+  it("does not mint a public link for a detached document with demo provenance", async () => {
+    mocks.requireSessionAuth.mockResolvedValue(session);
+    mocks.getDocument.mockResolvedValue({
+      id: "demo-doc", userId: "user-1", demoProvenance: true,
+      applicationIds: [], applications: [],
+    });
+    const request = new NextRequest("https://example.test/api/share-links", {
+      method: "POST",
+      body: JSON.stringify({ targetType: "document", targetId: "demo-doc" }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(404);
+    expect(mocks.createShareLink).not.toHaveBeenCalled();
+  });
 });
 
 describe("share-link lifecycle", () => {

--- a/app/api/share-links/__tests__/route.test.ts
+++ b/app/api/share-links/__tests__/route.test.ts
@@ -5,6 +5,10 @@ const mocks = vi.hoisted(() => ({
   requireSessionAuth: vi.fn(),
   listShareLinks: vi.fn(),
   deleteShareLink: vi.fn(),
+  getDocument: vi.fn(),
+  getApplication: vi.fn(),
+  findShareLink: vi.fn(),
+  createShareLink: vi.fn(),
 }));
 
 vi.mock("@/lib/session", () => ({
@@ -14,6 +18,10 @@ vi.mock("@/lib/db", () => ({
   getDb: () => ({
     listShareLinks: mocks.listShareLinks,
     deleteShareLink: mocks.deleteShareLink,
+    getDocument: mocks.getDocument,
+    getApplication: mocks.getApplication,
+    findShareLink: mocks.findShareLink,
+    createShareLink: mocks.createShareLink,
   }),
 }));
 
@@ -36,6 +44,28 @@ describe("POST /api/share-links", () => {
 
     expect(response.status).toBe(401);
     expect(mocks.requireSessionAuth).toHaveBeenCalledWith({ allowDevBypass: false });
+  });
+
+  it("does not mint a public link for a demo-only document", async () => {
+    mocks.requireSessionAuth.mockResolvedValue(session);
+    mocks.getDocument.mockResolvedValue({
+      id: "demo-doc",
+      userId: "user-1",
+      applicationIds: ["demo-app"],
+      applications: [{ id: "demo-app" }],
+    });
+    mocks.getApplication.mockResolvedValue(null);
+    const request = new NextRequest("https://example.test/api/share-links", {
+      method: "POST",
+      body: JSON.stringify({ targetType: "document", targetId: "demo-doc" }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(404);
+    expect(mocks.getApplication).toHaveBeenCalledWith("demo-app", "user-1", { demoVisibility: "exclude" });
+    expect(mocks.createShareLink).not.toHaveBeenCalled();
   });
 });
 

--- a/app/api/share-links/route.ts
+++ b/app/api/share-links/route.ts
@@ -2,6 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireSessionAuth } from "@/lib/session";
 import { getDb } from "@/lib/db";
 import { generateShortCode } from "@/lib/token";
+import { sanitizeDocumentAssociations } from "@/lib/documents/provenance";
+
+const MACHINE_DEMO_READ = { demoVisibility: "exclude" } as const;
 
 export async function GET() {
   const session = await requireSessionAuth({ allowDevBypass: false });
@@ -53,7 +56,11 @@ export async function POST(request: NextRequest) {
   // For document links, verify the document exists and belongs to the user
   if (targetType === "document") {
     const doc = await db.getDocument(targetId, session.user.id);
-    if (!doc) {
+    const visible = doc && await sanitizeDocumentAssociations(
+      doc,
+      (applicationId) => db.getApplication(applicationId, session.user.id, MACHINE_DEMO_READ),
+    );
+    if (!visible) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     }
   }

--- a/app/applications/[id]/page.tsx
+++ b/app/applications/[id]/page.tsx
@@ -31,6 +31,9 @@ function serializeContact(record: ContactRecord): Contact {
 function serializeApplication(record: ApplicationRecord): Application {
   return {
     id: record.id,
+    isDemo: record.isDemo,
+    demoWorkspaceId: record.demoWorkspaceId,
+    demoKey: record.demoKey,
     company: record.company,
     role: record.role,
     status: normalizeStatus(record.status),

--- a/app/s/[code]/__tests__/route.test.ts
+++ b/app/s/[code]/__tests__/route.test.ts
@@ -144,4 +144,20 @@ describe("GET /s/[code]", () => {
     expect(mockFileExists).not.toHaveBeenCalled();
     expect(mockDownloadFile).not.toHaveBeenCalled();
   });
+
+  it("rejects a detached document with durable demo provenance after workspace removal", async () => {
+    mockGetShareLinkByCode.mockResolvedValue({
+      id: "1", code: "doc123", userId: "user-1", targetType: "document", targetId: "42", createdAt: new Date(),
+    });
+    mockGetDocument.mockResolvedValue({
+      id: "42", userId: "user-1", filename: "stored.pdf", originalName: "CV.pdf",
+      mimeType: "application/pdf", demoProvenance: true, applicationIds: [], applications: [],
+    });
+
+    const res = await GET(makeRequest("http://localhost/s/doc123"), makeParams("doc123"));
+
+    expect(res.status).toBe(404);
+    expect(mockFileExists).not.toHaveBeenCalled();
+    expect(mockDownloadFile).not.toHaveBeenCalled();
+  });
 });

--- a/app/s/[code]/__tests__/route.test.ts
+++ b/app/s/[code]/__tests__/route.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { NextRequest } from "next/server";
 
-const { mockGetShareLinkByCode, mockGetDocument, mockFileExists, mockDownloadFile } = vi.hoisted(() => ({
+const { mockGetShareLinkByCode, mockGetDocument, mockGetApplication, mockFileExists, mockDownloadFile } = vi.hoisted(() => ({
   mockGetShareLinkByCode: vi.fn(),
   mockGetDocument: vi.fn(),
+  mockGetApplication: vi.fn(),
   mockFileExists: vi.fn(),
   mockDownloadFile: vi.fn(),
 }));
@@ -12,6 +13,7 @@ vi.mock("@/lib/db", () => ({
   getDb: () => ({
     getShareLinkByCode: mockGetShareLinkByCode,
     getDocument: mockGetDocument,
+    getApplication: mockGetApplication,
   }),
 }));
 
@@ -38,6 +40,7 @@ describe("GET /s/[code]", () => {
     vi.resetAllMocks();
     process.env.BETTER_AUTH_URL = "https://nexus.example.com";
     process.env.PUBLIC_READ_TOKEN = "legacy-public-token";
+    mockGetApplication.mockResolvedValue({ id: "real-app" });
   });
 
   afterEach(() => {
@@ -123,5 +126,22 @@ describe("GET /s/[code]", () => {
 
     expect(mockDownloadFile).not.toHaveBeenCalled();
     expect(res.status).toBe(404);
+  });
+
+  it("rejects a public document link whose only parent is a demo", async () => {
+    mockGetShareLinkByCode.mockResolvedValue({
+      id: "1", code: "doc123", userId: "user-1", targetType: "document", targetId: "42", createdAt: new Date(),
+    });
+    mockGetDocument.mockResolvedValue({
+      id: "42", userId: "user-1", filename: "stored.pdf", originalName: "CV.pdf",
+      mimeType: "application/pdf", applicationIds: ["demo-app"], applications: [{ id: "demo-app" }],
+    });
+    mockGetApplication.mockResolvedValue(null);
+
+    const res = await GET(makeRequest("http://localhost/s/doc123"), makeParams("doc123"));
+
+    expect(res.status).toBe(404);
+    expect(mockFileExists).not.toHaveBeenCalled();
+    expect(mockDownloadFile).not.toHaveBeenCalled();
   });
 });

--- a/app/s/[code]/route.ts
+++ b/app/s/[code]/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import { downloadFile, fileExists } from "@/lib/storage";
+import { sanitizeDocumentAssociations } from "@/lib/documents/provenance";
+
+const MACHINE_DEMO_READ = { demoVisibility: "exclude" } as const;
 
 const NOT_FOUND = NextResponse.json({ error: "Not found" }, { status: 404 });
 
@@ -26,7 +29,11 @@ export async function GET(
 
   if (link.targetType === "document" && link.targetId) {
     const doc = await db.getDocument(link.targetId, link.userId);
-    if (!doc || doc.userId !== link.userId || !(await fileExists(doc.filename))) {
+    const visible = doc && doc.userId === link.userId && await sanitizeDocumentAssociations(
+      doc,
+      (applicationId) => db.getApplication(applicationId, link.userId, MACHINE_DEMO_READ),
+    );
+    if (!visible || !(await fileExists(doc.filename))) {
       return NOT_FOUND;
     }
 

--- a/app/share/__tests__/page.test.tsx
+++ b/app/share/__tests__/page.test.tsx
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getShareLinkByCode: vi.fn(),
+  listApplications: vi.fn(),
+  getUser: vi.fn(),
+  notFound: vi.fn(() => { throw new Error("not_found"); }),
+}));
+
+vi.mock("@/lib/db", () => ({ getDb: () => mocks }));
+vi.mock("next/navigation", () => ({ notFound: mocks.notFound }));
+vi.mock("@/components/share-portal", () => ({ SharePortal: () => null }));
+
+import SharePage from "../page";
+
+describe("public share demo boundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getShareLinkByCode.mockResolvedValue({
+      code: "public-code",
+      userId: "owner-1",
+      targetType: "share_page",
+    });
+    mocks.listApplications.mockResolvedValue([]);
+    mocks.getUser.mockResolvedValue({ id: "owner-1", name: "Owner" });
+  });
+
+  it("excludes demo applications before public disclosure and statistics", async () => {
+    await SharePage({ searchParams: Promise.resolve({ code: "public-code", lang: "en" }) });
+    expect(mocks.listApplications).toHaveBeenCalledWith("owner-1", { demoVisibility: "exclude" });
+  });
+});

--- a/app/share/page.tsx
+++ b/app/share/page.tsx
@@ -43,7 +43,7 @@ export default async function SharePage({ searchParams }: SharePageProps) {
   }
 
   const [allApplications, ownerUser] = await Promise.all([
-    db.listApplications(link.userId),
+    db.listApplications(link.userId, { demoVisibility: "exclude" }),
     db.getUser(link.userId),
   ]);
 

--- a/components/__tests__/dashboard-demo-workspace.test.tsx
+++ b/components/__tests__/dashboard-demo-workspace.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Application } from "@/types";
+import { Dashboard } from "../dashboard";
+
+vi.mock("next-intl", () => ({
+  useLocale: () => "en",
+  useTranslations: (namespace: string) => (key: string) => `${namespace}.${key}`,
+}));
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/",
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+vi.mock("@/lib/auth-client", () => ({ authClient: { signOut: vi.fn() } }));
+vi.mock("../ai-operator/ai-operator", () => ({ AiOperator: () => null }));
+
+function application(id: string, isDemo: boolean, status: Application["status"]): Application {
+  return {
+    id,
+    company: isDemo ? "Demo Company" : "Real Company",
+    role: "Engineer",
+    status,
+    appliedAt: null,
+    lastContact: null,
+    followUpAt: null,
+    notes: null,
+    jobDescription: null,
+    source: "linkedin",
+    remote: false,
+    salaryMin: null,
+    salaryMax: null,
+    rating: null,
+    jobUrl: null,
+    resumeId: null,
+    companySize: null,
+    salaryBandMentioned: false,
+    triageQuality: null,
+    triageReason: null,
+    incomingSource: null,
+    autoRejected: false,
+    autoRejectReason: null,
+    archivedAt: null,
+    createdAt: "2026-08-10T00:00:00.000Z",
+    updatedAt: "2026-08-10T00:00:00.000Z",
+    isDemo,
+  };
+}
+
+function renderDashboard(client = new QueryClient({ defaultOptions: { queries: { retry: false } } })) {
+  return render(
+    <QueryClientProvider client={client}>
+      <Dashboard
+        user={{ id: "user-1", email: "user@example.com", isAdmin: false }}
+        shareUrl="https://example.com/share"
+      />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  const values = new Map<string, string>([["onboarding-complete", "true"]]);
+  vi.stubGlobal("localStorage", {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value),
+    removeItem: (key: string) => values.delete(key),
+    clear: () => values.clear(),
+  });
+  vi.stubGlobal("matchMedia", vi.fn(() => ({
+    matches: true,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  })));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("Dashboard demo workspace ownership", () => {
+  it("creates a demo from the true-empty state and refreshes applications", async () => {
+    let applications: Application[] = [];
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === "POST") {
+        applications = [application("demo", true, "interview")];
+        return { ok: true, json: async () => ({ created: true }) } as Response;
+      }
+      return { ok: true, json: async () => applications } as Response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const user = userEvent.setup();
+    renderDashboard();
+
+    await user.click(await screen.findByRole("button", { name: "focus.create_demo" }));
+
+    await waitFor(() => expect(screen.getByText("dashboard.demo_banner_title")).toBeTruthy());
+    expect(fetchMock).toHaveBeenCalledWith("/api/demo-workspace", { method: "POST" });
+    expect(fetchMock.mock.calls.filter(([url]) => url === "/api/applications")).toHaveLength(2);
+  });
+
+  it("shows zero regular metrics for demo-only rows and removes demos after confirmation", async () => {
+    const demo = application("demo", true, "offer");
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === "DELETE") return { ok: true, json: async () => ({ deleted: 1 }) } as Response;
+      return { ok: true, json: async () => [demo] } as Response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("confirm", vi.fn(() => true));
+    const user = userEvent.setup();
+    renderDashboard();
+
+    const banner = await screen.findByRole("status", { name: "dashboard.demo_banner_title" });
+    const totalMetric = screen.getByText("stats.total").parentElement;
+    expect(totalMetric?.textContent).toContain("0");
+    expect(screen.getByText("Demo Company")).toBeTruthy();
+
+    await user.click(within(banner).getByRole("button", { name: "dashboard.remove_demo" }));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith("/api/demo-workspace", { method: "DELETE" }),
+    );
+    expect(confirm).toHaveBeenCalledWith("confirm.remove_demo");
+  });
+
+  it("does not allow ordinary deletion of a demo row or hide its workspace banner", async () => {
+    const demo = application("demo", true, "interview");
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => [demo],
+    }) as Response);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("confirm", vi.fn(() => true));
+    const user = userEvent.setup();
+    renderDashboard();
+
+    const banner = await screen.findByRole("status", { name: "dashboard.demo_banner_title" });
+    await user.click(screen.getByRole("button", {
+      name: "actions.opportunity_actions",
+    }));
+    await user.click(await screen.findByRole("menuitem", { name: "actions.delete" }));
+
+    expect(confirm).not.toHaveBeenCalledWith("confirm.delete");
+    expect(fetchMock).not.toHaveBeenCalledWith("/api/applications/demo", { method: "DELETE" });
+    expect(banner.isConnected).toBe(true);
+    expect(within(banner).getByRole("button", { name: "dashboard.remove_demo" })).toBeTruthy();
+  });
+
+  it("does not bulk-delete a selected demo row or hide its workspace banner", async () => {
+    const demo = application("demo", true, "interview");
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => [demo],
+    }) as Response);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("confirm", vi.fn(() => true));
+    const user = userEvent.setup();
+    renderDashboard();
+
+    const banner = await screen.findByRole("status", { name: "dashboard.demo_banner_title" });
+    await user.click(screen.getByRole("button", {
+      name: "actions.opportunity_actions",
+    }));
+    await user.click(await screen.findByRole("menuitem", { name: "focus.select_action" }));
+    await user.click(await screen.findByRole("button", { name: "bulk_actions.delete_selected" }));
+
+    expect(confirm).not.toHaveBeenCalledWith("confirm.bulk_delete_confirm");
+    expect(fetchMock).not.toHaveBeenCalledWith("/api/applications/demo", { method: "DELETE" });
+    expect(banner.isConnected).toBe(true);
+    expect(within(banner).getByRole("button", { name: "dashboard.remove_demo" })).toBeTruthy();
+  });
+});

--- a/components/__tests__/dashboard-demo-workspace.test.tsx
+++ b/components/__tests__/dashboard-demo-workspace.test.tsx
@@ -184,6 +184,45 @@ describe("Dashboard demo workspace ownership", () => {
     expect(within(banner).getByRole("button", { name: "dashboard.remove_demo" })).toBeTruthy();
   });
 
+  it("does not archive a demo row through its row action", async () => {
+    const demo = application("demo", true, "interview");
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => input === "/api/demo-workspace"
+      ? { ok: true, json: async () => ({ hasDemoWorkspace: true, canCreateDemoWorkspace: false }) } as Response
+      : { ok: true, json: async () => [demo] } as Response);
+    vi.stubGlobal("fetch", fetchMock);
+    const user = userEvent.setup();
+    renderDashboard();
+
+    await user.click(await screen.findByRole("button", { name: "actions.opportunity_actions" }));
+    await user.click(await screen.findByRole("menuitem", { name: "actions.archive" }));
+
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "/api/applications/demo",
+      expect.objectContaining({ method: "PATCH" }),
+    );
+  });
+
+  it("does not archive a selected demo row through the bulk action", async () => {
+    const demo = application("demo", true, "interview");
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => input === "/api/demo-workspace"
+      ? { ok: true, json: async () => ({ hasDemoWorkspace: true, canCreateDemoWorkspace: false }) } as Response
+      : { ok: true, json: async () => [demo] } as Response);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("confirm", vi.fn(() => true));
+    const user = userEvent.setup();
+    renderDashboard();
+
+    await user.click(await screen.findByRole("button", { name: "actions.opportunity_actions" }));
+    await user.click(await screen.findByRole("menuitem", { name: "focus.select_action" }));
+    await user.click(await screen.findByRole("button", { name: "bulk_actions.archive_selected" }));
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "/api/applications/demo",
+      expect.objectContaining({ method: "PATCH" }),
+    );
+  });
+
   it("does not offer demo creation when the owner has only archived real applications", async () => {
     const archived = {
       ...application("archived", false, "rejected"),

--- a/components/__tests__/dashboard-demo-workspace.test.tsx
+++ b/components/__tests__/dashboard-demo-workspace.test.tsx
@@ -184,6 +184,19 @@ describe("Dashboard demo workspace ownership", () => {
     expect(within(banner).getByRole("button", { name: "dashboard.remove_demo" })).toBeTruthy();
   });
 
+  it("disables real application creation while the demo workspace exists", async () => {
+    const demo = application("demo", true, "interview");
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => input === "/api/demo-workspace"
+      ? { ok: true, json: async () => ({ hasDemoWorkspace: true, canCreateDemoWorkspace: false }) } as Response
+      : { ok: true, json: async () => [demo] } as Response));
+
+    renderDashboard();
+
+    const createControls = await screen.findAllByRole("button", { name: "actions.new_application" });
+    expect(createControls).toHaveLength(2);
+    expect(createControls.every((control) => control.hasAttribute("disabled"))).toBe(true);
+  });
+
   it("does not archive a demo row through its row action", async () => {
     const demo = application("demo", true, "interview");
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => input === "/api/demo-workspace"

--- a/components/__tests__/dashboard-demo-workspace.test.tsx
+++ b/components/__tests__/dashboard-demo-workspace.test.tsx
@@ -50,11 +50,14 @@ function application(id: string, isDemo: boolean, status: Application["status"])
   };
 }
 
-function renderDashboard(client = new QueryClient({ defaultOptions: { queries: { retry: false } } })) {
+function renderDashboard(
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } }),
+  isAdmin = false,
+) {
   return render(
     <QueryClientProvider client={client}>
       <Dashboard
-        user={{ id: "user-1", email: "user@example.com", isAdmin: false }}
+        user={{ id: "user-1", email: "user@example.com", isAdmin }}
         shareUrl="https://example.com/share"
       />
     </QueryClientProvider>,
@@ -89,6 +92,13 @@ describe("Dashboard demo workspace ownership", () => {
         applications = [application("demo", true, "interview")];
         return { ok: true, json: async () => ({ created: true }) } as Response;
       }
+      if (_input === "/api/demo-workspace") {
+        const hasDemoWorkspace = applications.some((item) => item.isDemo);
+        return { ok: true, json: async () => ({
+          hasDemoWorkspace,
+          canCreateDemoWorkspace: applications.length === 0,
+        }) } as Response;
+      }
       return { ok: true, json: async () => applications } as Response;
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -106,6 +116,9 @@ describe("Dashboard demo workspace ownership", () => {
     const demo = application("demo", true, "offer");
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       if (init?.method === "DELETE") return { ok: true, json: async () => ({ deleted: 1 }) } as Response;
+      if (input === "/api/demo-workspace") {
+        return { ok: true, json: async () => ({ hasDemoWorkspace: true, canCreateDemoWorkspace: false }) } as Response;
+      }
       return { ok: true, json: async () => [demo] } as Response;
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -128,10 +141,9 @@ describe("Dashboard demo workspace ownership", () => {
 
   it("does not allow ordinary deletion of a demo row or hide its workspace banner", async () => {
     const demo = application("demo", true, "interview");
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      json: async () => [demo],
-    }) as Response);
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => input === "/api/demo-workspace"
+      ? { ok: true, json: async () => ({ hasDemoWorkspace: true, canCreateDemoWorkspace: false }) } as Response
+      : { ok: true, json: async () => [demo] } as Response);
     vi.stubGlobal("fetch", fetchMock);
     vi.stubGlobal("confirm", vi.fn(() => true));
     const user = userEvent.setup();
@@ -151,10 +163,9 @@ describe("Dashboard demo workspace ownership", () => {
 
   it("does not bulk-delete a selected demo row or hide its workspace banner", async () => {
     const demo = application("demo", true, "interview");
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      json: async () => [demo],
-    }) as Response);
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => input === "/api/demo-workspace"
+      ? { ok: true, json: async () => ({ hasDemoWorkspace: true, canCreateDemoWorkspace: false }) } as Response
+      : { ok: true, json: async () => [demo] } as Response);
     vi.stubGlobal("fetch", fetchMock);
     vi.stubGlobal("confirm", vi.fn(() => true));
     const user = userEvent.setup();
@@ -171,5 +182,59 @@ describe("Dashboard demo workspace ownership", () => {
     expect(fetchMock).not.toHaveBeenCalledWith("/api/applications/demo", { method: "DELETE" });
     expect(banner.isConnected).toBe(true);
     expect(within(banner).getByRole("button", { name: "dashboard.remove_demo" })).toBeTruthy();
+  });
+
+  it("does not offer demo creation when the owner has only archived real applications", async () => {
+    const archived = {
+      ...application("archived", false, "rejected"),
+      archivedAt: "2026-08-09T00:00:00.000Z",
+    };
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => input === "/api/demo-workspace"
+      ? { ok: true, json: async () => ({ hasDemoWorkspace: false, canCreateDemoWorkspace: false }) } as Response
+      : { ok: true, json: async () => [archived] } as Response));
+
+    renderDashboard();
+
+    await screen.findByText("focus.true_empty_title");
+    expect(screen.queryByRole("button", { name: "focus.create_demo" })).toBeNull();
+  });
+
+  it("does not show another tenant's demo-removal banner to an administrator", async () => {
+    const otherTenantDemo = application("other-demo", true, "interview");
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => input === "/api/demo-workspace"
+      ? { ok: true, json: async () => ({ hasDemoWorkspace: false, canCreateDemoWorkspace: true }) } as Response
+      : { ok: true, json: async () => [otherTenantDemo] } as Response));
+
+    renderDashboard(undefined, true);
+
+    await screen.findByText("Demo Company");
+    expect(screen.queryByRole("status", { name: "dashboard.demo_banner_title" })).toBeNull();
+  });
+
+  it("refreshes demo eligibility after deleting the final real application", async () => {
+    let applications = [application("real", false, "interview")];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (input === "/api/applications/real" && init?.method === "DELETE") {
+        applications = [];
+        return { ok: true } as Response;
+      }
+      if (input === "/api/demo-workspace") {
+        return { ok: true, json: async () => ({
+          hasDemoWorkspace: false,
+          canCreateDemoWorkspace: applications.length === 0,
+        }) } as Response;
+      }
+      return { ok: true, json: async () => applications } as Response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("confirm", vi.fn(() => true));
+    const user = userEvent.setup();
+    renderDashboard();
+
+    await user.click(await screen.findByRole("button", { name: "actions.opportunity_actions" }));
+    await user.click(await screen.findByRole("menuitem", { name: "actions.delete" }));
+
+    expect(await screen.findByRole("button", { name: "focus.create_demo" })).toBeTruthy();
+    expect(fetchMock.mock.calls.filter(([url]) => url === "/api/demo-workspace")).toHaveLength(2);
   });
 });

--- a/components/__tests__/focus-queue.test.tsx
+++ b/components/__tests__/focus-queue.test.tsx
@@ -102,6 +102,8 @@ describe("FocusQueue empty recovery", () => {
             onDelete={vi.fn()}
             onArchive={vi.fn()}
             onCreate={onCreate}
+            onCreateDemo={vi.fn()}
+            demoCreationPending={false}
             onClearFilters={vi.fn()}
             statusMutation={{ mutate: vi.fn() }}
           />
@@ -109,10 +111,45 @@ describe("FocusQueue empty recovery", () => {
       );
     });
 
-    const button = container.querySelector("button");
-    expect(button?.textContent).toBe("create");
-    await act(async () => button?.click());
+    const createButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "create",
+    );
+    expect(createButton).toBeTruthy();
+    await act(async () => createButton?.click());
     expect(onCreate).toHaveBeenCalledOnce();
     expect(container.textContent).not.toContain("groups.overdue");
+  });
+
+  it("offers demo creation alongside the regular true-empty action", async () => {
+    const onCreateDemo = vi.fn();
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={new QueryClient()}>
+          <FocusQueue
+            applications={[]}
+            isTrueEmpty
+            isFilteredEmpty={false}
+            selectedIds={new Set()}
+            onToggleSelect={vi.fn()}
+            onOpen={vi.fn()}
+            onEdit={vi.fn()}
+            onDelete={vi.fn()}
+            onArchive={vi.fn()}
+            onCreate={vi.fn()}
+            onCreateDemo={onCreateDemo}
+            demoCreationPending={false}
+            onClearFilters={vi.fn()}
+            statusMutation={{ mutate: vi.fn() }}
+          />
+        </QueryClientProvider>,
+      );
+    });
+
+    const demoButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "create_demo",
+    );
+    expect(demoButton).toBeTruthy();
+    await act(async () => demoButton?.click());
+    expect(onCreateDemo).toHaveBeenCalledOnce();
   });
 });

--- a/components/__tests__/onboarding-demo-workspace.test.tsx
+++ b/components/__tests__/onboarding-demo-workspace.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OnboardingWizard } from "../onboarding-wizard";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+function renderWizard(props: Partial<React.ComponentProps<typeof OnboardingWizard>> = {}) {
+  return render(
+    <QueryClientProvider client={new QueryClient()}>
+      <OnboardingWizard
+        onComplete={vi.fn()}
+        onCreateDemo={vi.fn().mockResolvedValue(undefined)}
+        {...props}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+async function reachFirstOpportunityStep() {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: "get_started" }));
+  await screen.findByRole("heading", { name: "profile_title" });
+  await user.type(screen.getByRole("textbox"), "Nexus");
+  await user.click(screen.getByRole("button", { name: "continue" }));
+  await screen.findByRole("heading", { name: "first_app_title" });
+  return user;
+}
+
+beforeEach(() => {
+  const values = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value),
+    removeItem: (key: string) => values.delete(key),
+    clear: () => values.clear(),
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("OnboardingWizard demo workspace", () => {
+  it("offers optional demo creation and completes onboarding after success", async () => {
+    const onCreateDemo = vi.fn().mockResolvedValue(undefined);
+    const onComplete = vi.fn();
+    renderWizard({ onCreateDemo, onComplete });
+    const user = await reachFirstOpportunityStep();
+
+    await user.click(screen.getByRole("button", { name: "create_demo" }));
+
+    await waitFor(() => expect(onCreateDemo).toHaveBeenCalledOnce());
+    expect(onComplete).toHaveBeenCalledOnce();
+    expect(localStorage.getItem("onboarding-complete")).toBe("true");
+  });
+});

--- a/components/ai-operator/__tests__/dashboard-ai-operator.test.tsx
+++ b/components/ai-operator/__tests__/dashboard-ai-operator.test.tsx
@@ -71,10 +71,12 @@ describe("Dashboard AI operator lifetime", () => {
   });
 
   it("preserves the operator instance when onboarding completes", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([]), {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    }));
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => new Response(
+      JSON.stringify(input === "/api/demo-workspace"
+        ? { hasDemoWorkspace: false, canCreateDemoWorkspace: true }
+        : []),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    ));
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const user = userEvent.setup();
     render(
@@ -94,8 +96,10 @@ describe("Dashboard AI operator lifetime", () => {
 
   it("hides the operator launcher when bulk selection is active", async () => {
     localStorage.setItem("onboarding-complete", "true");
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([opportunity]), {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) =>
+      new Response(JSON.stringify(input === "/api/demo-workspace"
+        ? { hasDemoWorkspace: false, canCreateDemoWorkspace: false }
+        : [opportunity]), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       }),

--- a/components/analytics-dashboard.tsx
+++ b/components/analytics-dashboard.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import { Application, ApplicationStatus, STATUS_COLORS, STATUS_ORDER, getSourceCategory } from "@/types";
 import { AppHeader } from "./app-header";
+import { realApplications } from "@/lib/demo-workspace/presentation";
 
 async function fetchApplications(): Promise<Application[]> {
   const res = await fetch("/api/applications");
@@ -57,7 +58,10 @@ export function AnalyticsDashboard({ user }: AnalyticsDashboardProps) {
     queryFn: fetchApplications,
   });
 
-  const activeApps = useMemo(() => applications.filter((a) => !a.archivedAt), [applications]);
+  const activeApps = useMemo(
+    () => realApplications(applications).filter((a) => !a.archivedAt),
+    [applications],
+  );
 
   // === Status Breakdown ===
   const { statusCounts, maxStatusCount } = useMemo(() => {

--- a/components/application-detail.tsx
+++ b/components/application-detail.tsx
@@ -23,6 +23,7 @@ import { ContactsSection } from "./application-form/contacts-section";
 import { DocumentsSection } from "./application-form/documents-section";
 import { ResumeSection } from "./application-form/resume-section";
 import { ApplicationTimeline } from "./application-timeline";
+import { DemoBadge } from "./demo-badge";
 
 interface ApplicationDetailProps {
   user: {
@@ -176,6 +177,7 @@ export function ApplicationDetail({ user, application }: ApplicationDetailProps)
                   {form.role || application.role}
                 </h1>
               </div>
+              {application.isDemo && <DemoBadge />}
               <span
                 className={`inline-flex shrink-0 items-center rounded-full px-2.5 py-1 text-xs font-semibold ${STATUS_COLORS[form.status]}`}
               >

--- a/components/application-table.tsx
+++ b/components/application-table.tsx
@@ -28,6 +28,7 @@ import { useLocale } from "next-intl";
 import { ActionMenu } from "./action-menu";
 import type { ApplicationStatusMutation } from "@/hooks/use-application-status-mutation";
 import { getSafeExternalUrl, openExternalUrl } from "@/lib/external-url";
+import { DemoBadge } from "./demo-badge";
 
 const columnHelper = createColumnHelper<Application>();
 
@@ -213,6 +214,7 @@ function MobileApplicationCard({
           <span className="truncate text-sm font-semibold text-slate-950 dark:text-white">
             {app.company || "—"}
           </span>
+          {app.isDemo && <DemoBadge />}
           <StatusBadge status={app.status} />
         </div>
         <p className="mt-0.5 truncate text-sm text-slate-600 dark:text-slate-300">
@@ -390,6 +392,7 @@ export function ApplicationTable({
             >
               {info.getValue() || "—"}
             </button>
+            {info.row.original.isDemo && <DemoBadge />}
             {info.row.original.jobUrl && (
               <JobLink
                 jobUrl={info.row.original.jobUrl}

--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -42,6 +42,7 @@ import { resolveOpportunityView } from "@/lib/applications/workspace-view";
 import { parseLocalCalendarDate } from "@/lib/applications/local-calendar";
 import { useApplicationStatusMutation } from "@/hooks/use-application-status-mutation";
 import { applicationsToCsv } from "@/lib/applications/csv-export";
+import { realApplications } from "@/lib/demo-workspace/presentation";
 
 interface DashboardProps {
   user: {
@@ -61,6 +62,16 @@ async function fetchApplications(): Promise<Application[]> {
   const res = await fetch("/api/applications");
   if (!res.ok) throw new Error("Failed to fetch applications");
   return res.json();
+}
+
+async function createDemoWorkspace(): Promise<void> {
+  const res = await fetch("/api/demo-workspace", { method: "POST" });
+  if (!res.ok) throw new Error("Failed to create demo workspace");
+}
+
+async function deleteDemoWorkspace(): Promise<void> {
+  const res = await fetch("/api/demo-workspace", { method: "DELETE" });
+  if (!res.ok) throw new Error("Failed to delete demo workspace");
 }
 
 async function deleteApplication(id: string): Promise<void> {
@@ -178,6 +189,31 @@ export function Dashboard({
     queryFn: fetchApplications,
   });
 
+  const refreshDemoQueries = useCallback(async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ["applications"] }),
+      queryClient.invalidateQueries({ queryKey: ["activity"] }),
+    ]);
+  }, [queryClient]);
+
+  const createDemoMutation = useMutation({
+    mutationFn: createDemoWorkspace,
+    onSuccess: refreshDemoQueries,
+  });
+
+  const deleteDemoMutation = useMutation({
+    mutationFn: deleteDemoWorkspace,
+    onSuccess: async () => {
+      const demoIds = new Set(
+        applications.filter((application) => application.isDemo).map(({ id }) => id),
+      );
+      setSelectedIds((previous) =>
+        new Set([...previous].filter((id) => !demoIds.has(id))),
+      );
+      await refreshDemoQueries();
+    },
+  });
+
   const deleteMutation = useMutation({
     mutationFn: deleteApplication,
     onSuccess: () => {
@@ -201,6 +237,7 @@ export function Dashboard({
   );
 
   function handleDelete(id: string) {
+    if (applications.find((application) => application.id === id)?.isDemo) return;
     if (confirm(tc("delete"))) {
       removeFromSelection(id);
       deleteMutation.mutate(id);
@@ -210,6 +247,12 @@ export function Dashboard({
   function handleNewApplication() {
     modalOpenerRef.current = document.activeElement as HTMLElement | null;
     setIsModalOpen(true);
+  }
+
+  function handleRemoveDemoWorkspace() {
+    if (confirm(tc("remove_demo"))) {
+      deleteDemoMutation.mutate();
+    }
   }
 
   function handleCloseModal() {
@@ -250,6 +293,10 @@ export function Dashboard({
   const archivedApplications = useMemo(
     () => applications.filter((application) => !!application.archivedAt),
     [applications],
+  );
+  const realActiveApplications = useMemo(
+    () => realApplications(activeApplications),
+    [activeApplications],
   );
   const visibleApplications = showArchived
     ? archivedApplications
@@ -313,7 +360,7 @@ export function Dashboard({
   function handleBulkArchive(days: number) {
     const cutoff = new Date();
     cutoff.setDate(cutoff.getDate() - days);
-    const old = activeApplications.filter((a) => {
+    const old = realActiveApplications.filter((a) => {
       const d = a.appliedAt ? new Date(a.appliedAt) : new Date(a.createdAt);
       return d < cutoff;
     });
@@ -326,7 +373,7 @@ export function Dashboard({
   }
 
   function handleBulkArchiveByRating(maxRating: number) {
-    const lowRated = activeApplications.filter(
+    const lowRated = realActiveApplications.filter(
       (a) =>
         a.rating !== null && a.rating !== undefined && a.rating <= maxRating,
     );
@@ -346,13 +393,13 @@ export function Dashboard({
   }
 
   const stats = {
-    total: activeApplications.length,
-    inbound: activeApplications.filter((a) => a.status === "inbound").length,
-    active: activeApplications.filter((a) =>
+    total: realActiveApplications.length,
+    inbound: realActiveApplications.filter((a) => a.status === "inbound").length,
+    active: realActiveApplications.filter((a) =>
       (["applied", "interview"] as ApplicationStatus[]).includes(a.status),
     ).length,
-    offers: activeApplications.filter((a) => a.status === "offer").length,
-    rejected: activeApplications.filter((a) => a.status === "rejected").length,
+    offers: realActiveApplications.filter((a) => a.status === "offer").length,
+    rejected: realActiveApplications.filter((a) => a.status === "rejected").length,
   };
 
   // Triage stats — single pass over activeApplications
@@ -360,14 +407,14 @@ export function Dashboard({
     const oneWeekAgo = new Date();
     oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
     const counts = { thisWeek: 0, 5: 0, 4: 0, 3: 0, 2: 0, 1: 0, unrated: 0 };
-    for (const a of activeApplications) {
+    for (const a of realActiveApplications) {
       if (new Date(a.createdAt) >= oneWeekAgo) counts.thisWeek++;
       const q = a.triageQuality;
       if (q != null && q >= 1 && q <= 5) counts[q as 1 | 2 | 3 | 4 | 5]++;
       else counts.unrated++;
     }
     return { ...counts, highPriority: counts[5] + counts[4] };
-  }, [activeApplications]);
+  }, [realActiveApplications]);
 
   function navigateToDataset(archived: boolean) {
     if (archived === showArchived) return;
@@ -396,7 +443,7 @@ export function Dashboard({
     for (const days of ARCHIVE_THRESHOLDS) {
       const cutoff = new Date();
       cutoff.setDate(cutoff.getDate() - days);
-      const count = activeApplications.filter((application) => {
+      const count = realActiveApplications.filter((application) => {
         const date = application.appliedAt
           ? new Date(application.appliedAt)
           : new Date(application.createdAt);
@@ -412,7 +459,7 @@ export function Dashboard({
       });
     }
     for (const stars of RATING_THRESHOLDS) {
-      const count = activeApplications.filter(
+      const count = realActiveApplications.filter(
         (application) =>
           application.rating != null && application.rating <= stars,
       ).length;
@@ -441,7 +488,7 @@ export function Dashboard({
     }
   });
 
-  const overdueFollowUps = activeApplications.filter((a) => {
+  const overdueFollowUps = realActiveApplications.filter((a) => {
     if (!a.followUpAt) return false;
     // Only show for active pipeline statuses
     if (a.status === "offer" || a.status === "rejected") return false;
@@ -568,7 +615,9 @@ export function Dashboard({
   }
 
   function handleBulkDeleteSelected() {
-    const ids = [...scopedSelectedIds];
+    const ids = [...scopedSelectedIds].filter(
+      (id) => !applications.find((application) => application.id === id)?.isDemo,
+    );
     if (ids.length === 0) return;
     if (confirm(tc("bulk_delete_confirm", { count: ids.length }))) {
       clearSelection();
@@ -772,6 +821,7 @@ export function Dashboard({
 
       {showOnboarding ? (
         <OnboardingWizard
+          onCreateDemo={() => createDemoMutation.mutateAsync()}
           onComplete={() => {
             setOnboardingComplete(true);
             queryClient.invalidateQueries({ queryKey: ["applications"] });
@@ -780,6 +830,31 @@ export function Dashboard({
       ) : (
         <>
       <main className="nexus-page-bottom-space mx-auto max-w-7xl px-4 py-5 sm:px-6 sm:py-8 lg:px-8">
+        {applications.some((application) => application.isDemo) && (
+          <section
+            role="status"
+            aria-label={t("demo_banner_title")}
+            className="mb-6 flex flex-wrap items-center gap-3 rounded-2xl border border-indigo-200 bg-indigo-50 p-4 text-sm text-indigo-900 dark:border-indigo-500/30 dark:bg-indigo-500/10 dark:text-indigo-200"
+          >
+            <div className="min-w-0 flex-1">
+              <h2 className="font-semibold">{t("demo_banner_title")}</h2>
+              <p className="mt-1 text-xs opacity-80">{t("demo_banner_description")}</p>
+            </div>
+            <button
+              type="button"
+              onClick={handleRemoveDemoWorkspace}
+              disabled={deleteDemoMutation.isPending}
+              className="nexus-button-ghost nexus-target disabled:cursor-wait disabled:opacity-60"
+            >
+              {deleteDemoMutation.isPending ? t("removing_demo") : t("remove_demo")}
+            </button>
+          </section>
+        )}
+        {deleteDemoMutation.isError && (
+          <p role="alert" className="mb-4 text-sm text-red-600 dark:text-red-300">
+            {t("demo_remove_error")}
+          </p>
+        )}
         {/* Overdue follow-up banners */}
         {overdueFollowUps.length > 0 && (
           <div className="mb-6 space-y-2">
@@ -918,6 +993,9 @@ export function Dashboard({
             onDelete={handleDelete}
             onArchive={handleArchive}
             onCreate={handleNewApplication}
+            onCreateDemo={() => createDemoMutation.mutate()}
+            demoCreationPending={createDemoMutation.isPending}
+            demoCreationError={createDemoMutation.isError ? t("demo_create_error") : undefined}
             onClearFilters={clearFilters}
             statusMutation={statusMutation}
           />

--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -289,6 +289,7 @@ export function Dashboard({
   }
 
   function handleArchive(id: string, archive: boolean) {
+    if (applications.some((application) => application.id === id && application.isDemo)) return;
     removeFromSelection(id);
     archiveMutation.mutate({ id, archive });
   }
@@ -624,7 +625,10 @@ export function Dashboard({
   }
 
   function handleBulkArchiveSelected() {
-    const ids = [...scopedSelectedIds];
+    const demoIds = new Set(
+      applications.filter((application) => application.isDemo).map((application) => application.id),
+    );
+    const ids = [...scopedSelectedIds].filter((id) => !demoIds.has(id));
     if (ids.length === 0) return;
     if (confirm(tc("bulk_archive_confirm", { count: ids.length }))) {
       bulkArchiveMutation.mutate(ids);

--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -64,6 +64,17 @@ async function fetchApplications(): Promise<Application[]> {
   return res.json();
 }
 
+interface DemoWorkspaceStatus {
+  hasDemoWorkspace: boolean;
+  canCreateDemoWorkspace: boolean;
+}
+
+async function fetchDemoWorkspaceStatus(): Promise<DemoWorkspaceStatus> {
+  const res = await fetch("/api/demo-workspace");
+  if (!res.ok) throw new Error("Failed to fetch demo workspace status");
+  return res.json();
+}
+
 async function createDemoWorkspace(): Promise<void> {
   const res = await fetch("/api/demo-workspace", { method: "POST" });
   if (!res.ok) throw new Error("Failed to create demo workspace");
@@ -188,11 +199,16 @@ export function Dashboard({
     queryKey: ["applications"],
     queryFn: fetchApplications,
   });
+  const { data: demoWorkspaceStatus } = useQuery({
+    queryKey: ["demo-workspace-status"],
+    queryFn: fetchDemoWorkspaceStatus,
+  });
 
   const refreshDemoQueries = useCallback(async () => {
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: ["applications"] }),
       queryClient.invalidateQueries({ queryKey: ["activity"] }),
+      queryClient.invalidateQueries({ queryKey: ["demo-workspace-status"] }),
     ]);
   }, [queryClient]);
 
@@ -218,6 +234,7 @@ export function Dashboard({
     mutationFn: deleteApplication,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["applications"] });
+      queryClient.invalidateQueries({ queryKey: ["demo-workspace-status"] });
     },
   });
 
@@ -595,6 +612,7 @@ export function Dashboard({
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["applications"] });
+      queryClient.invalidateQueries({ queryKey: ["demo-workspace-status"] });
       clearSelection();
     },
   });
@@ -806,7 +824,10 @@ export function Dashboard({
   }
 
   // Onboarding is only eligible after the initial request succeeds.
-  const showOnboarding = !onboardingComplete && applications.length === 0;
+  const showOnboarding =
+    !onboardingComplete &&
+    applications.length === 0 &&
+    demoWorkspaceStatus?.canCreateDemoWorkspace === true;
 
   return (
     <div className="nexus-shell">
@@ -830,7 +851,7 @@ export function Dashboard({
       ) : (
         <>
       <main className="nexus-page-bottom-space mx-auto max-w-7xl px-4 py-5 sm:px-6 sm:py-8 lg:px-8">
-        {applications.some((application) => application.isDemo) && (
+        {demoWorkspaceStatus?.hasDemoWorkspace === true && (
           <section
             role="status"
             aria-label={t("demo_banner_title")}
@@ -993,7 +1014,9 @@ export function Dashboard({
             onDelete={handleDelete}
             onArchive={handleArchive}
             onCreate={handleNewApplication}
-            onCreateDemo={() => createDemoMutation.mutate()}
+            onCreateDemo={demoWorkspaceStatus?.canCreateDemoWorkspace
+              ? () => createDemoMutation.mutate()
+              : undefined}
             demoCreationPending={createDemoMutation.isPending}
             demoCreationError={createDemoMutation.isError ? t("demo_create_error") : undefined}
             onClearFilters={clearFilters}

--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -261,10 +261,11 @@ export function Dashboard({
     }
   }
 
-  function handleNewApplication() {
+  const handleNewApplication = useCallback(() => {
+    if (demoWorkspaceStatus?.hasDemoWorkspace === true) return;
     modalOpenerRef.current = document.activeElement as HTMLElement | null;
     setIsModalOpen(true);
-  }
+  }, [demoWorkspaceStatus?.hasDemoWorkspace]);
 
   function handleRemoveDemoWorkspace() {
     if (confirm(tc("remove_demo"))) {
@@ -789,6 +790,7 @@ export function Dashboard({
     scopedSelectedIds,
     toggleSelect,
     handleEdit,
+    handleNewApplication,
   ]);
 
   if (isLoading) {
@@ -965,6 +967,7 @@ export function Dashboard({
               />
             }
             onCreate={handleNewApplication}
+            createDisabled={demoWorkspaceStatus?.hasDemoWorkspace === true}
             createLabel={ta("new_application")}
             focusLabel={tw("focus")}
             tableLabel={tn("table_view")}
@@ -1074,6 +1077,7 @@ export function Dashboard({
           <button
             type="button"
             onClick={handleNewApplication}
+            disabled={demoWorkspaceStatus?.hasDemoWorkspace === true}
             data-dashboard-create-control="mobile"
             className="nexus-fab nexus-fixed-bottom fixed right-4 z-40 lg:hidden"
           >

--- a/components/demo-badge.tsx
+++ b/components/demo-badge.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+export function DemoBadge() {
+  const t = useTranslations("demoWorkspace");
+  return (
+    <span className="inline-flex shrink-0 items-center rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-semibold text-amber-900 dark:bg-amber-500/20 dark:text-amber-200">
+      {t("badge")}
+    </span>
+  );
+}

--- a/components/focus-queue.tsx
+++ b/components/focus-queue.tsx
@@ -13,6 +13,7 @@ import type { ApplicationStatusMutation } from "@/hooks/use-application-status-m
 import { formatLocalCalendarDate } from "@/lib/applications/local-calendar";
 import { getSafeExternalUrl, openExternalUrl } from "@/lib/external-url";
 import { ActionMenu } from "./action-menu";
+import { DemoBadge } from "./demo-badge";
 
 interface FocusQueueProps {
   applications: Application[];
@@ -25,6 +26,9 @@ interface FocusQueueProps {
   onDelete: (id: string) => void;
   onArchive: (id: string, archive: boolean) => void;
   onCreate: () => void;
+  onCreateDemo?: () => void;
+  demoCreationPending?: boolean;
+  demoCreationError?: string;
   onClearFilters: () => void;
   statusMutation: ApplicationStatusMutation;
 }
@@ -40,6 +44,9 @@ export function FocusQueue({
   onDelete,
   onArchive,
   onCreate,
+  onCreateDemo,
+  demoCreationPending = false,
+  demoCreationError,
   onClearFilters,
   statusMutation,
 }: FocusQueueProps) {
@@ -61,6 +68,21 @@ export function FocusQueue({
         >
           {t("create")}
         </button>
+        {demoCreationError && (
+          <p role="alert" className="mt-3 text-sm text-red-600 dark:text-red-300">
+            {demoCreationError}
+          </p>
+        )}
+        {onCreateDemo && (
+          <button
+            type="button"
+            onClick={onCreateDemo}
+            disabled={demoCreationPending}
+            className="nexus-button-ghost nexus-target mt-3 disabled:cursor-wait disabled:opacity-60"
+          >
+            {demoCreationPending ? t("creating_demo") : t("create_demo")}
+          </button>
+        )}
       </div>
     );
   }
@@ -178,6 +200,7 @@ function FocusRow({
           <span className="truncate text-sm font-semibold text-slate-950 dark:text-white">
             {application.company}
           </span>
+          {application.isDemo && <DemoBadge />}
           <span
             className={`shrink-0 rounded-full px-2 py-0.5 text-[11px] font-semibold ${STATUS_COLORS[application.status]}`}
           >

--- a/components/kanban-view.tsx
+++ b/components/kanban-view.tsx
@@ -26,6 +26,7 @@ import {
   STATUS_COLORS,
   STATUS_ORDER,
 } from "@/types";
+import { DemoBadge } from "./demo-badge";
 
 type KanbanSortKey =
   | "rating_desc"
@@ -92,6 +93,7 @@ function KanbanCard({ app, onEdit, isDragging = false }: CardProps) {
             >
               {app.company}
             </span>
+            {app.isDemo && <DemoBadge />}
             {safeJobUrl && (
               <button
                 type="button"

--- a/components/onboarding-wizard.tsx
+++ b/components/onboarding-wizard.tsx
@@ -6,18 +6,20 @@ import { useQueryClient } from "@tanstack/react-query";
 
 interface OnboardingWizardProps {
   onComplete: () => void;
+  onCreateDemo: () => Promise<void>;
 }
 
 const STEPS = ["welcome", "profile", "first_app", "done"] as const;
 type Step = (typeof STEPS)[number];
 
-export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
+export function OnboardingWizard({ onComplete, onCreateDemo }: OnboardingWizardProps) {
   const t = useTranslations("onboarding");
   const [currentStep, setCurrentStep] = useState<Step>("welcome");
   const [appTitle, setAppTitle] = useState("");
   const [company, setCompany] = useState("");
   const [role, setRole] = useState("");
   const [error, setError] = useState("");
+  const [isCreatingDemo, setIsCreatingDemo] = useState(false);
   const queryClient = useQueryClient();
 
   const stepIndex = STEPS.indexOf(currentStep);
@@ -64,6 +66,20 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
       nextStep();
     } catch {
       setError(t("error_create"));
+    }
+  }
+
+  async function handleCreateDemo() {
+    setError("");
+    setIsCreatingDemo(true);
+    try {
+      await onCreateDemo();
+      localStorage.setItem("onboarding-complete", "true");
+      onComplete();
+    } catch {
+      setError(t("error_create_demo"));
+    } finally {
+      setIsCreatingDemo(false);
     }
   }
 
@@ -195,6 +211,14 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
                   {t("create_app")}
                 </button>
               </div>
+              <button
+                type="button"
+                onClick={handleCreateDemo}
+                disabled={isCreatingDemo}
+                className="w-full rounded-lg border border-blue-200 px-4 py-2.5 text-sm font-medium text-blue-700 transition-colors hover:bg-blue-50 disabled:cursor-wait disabled:opacity-60 dark:border-blue-800 dark:text-blue-300 dark:hover:bg-blue-950/30"
+              >
+                {isCreatingDemo ? t("creating_demo") : t("create_demo")}
+              </button>
             </div>
           )}
 

--- a/components/workspace-toolbar.tsx
+++ b/components/workspace-toolbar.tsx
@@ -9,6 +9,7 @@ interface WorkspaceToolbarProps {
   onViewModeChange: (viewMode: WorkspaceViewMode) => void;
   moreMenu: ReactNode;
   onCreate: () => void;
+  createDisabled?: boolean;
   createLabel: string;
   focusLabel: string;
   tableLabel: string;
@@ -25,6 +26,7 @@ export function WorkspaceToolbar({
   onViewModeChange,
   moreMenu,
   onCreate,
+  createDisabled = false,
   createLabel,
   focusLabel,
   tableLabel,
@@ -51,6 +53,7 @@ export function WorkspaceToolbar({
           <button
             type="button"
             onClick={onCreate}
+            disabled={createDisabled}
             data-dashboard-create-control="desktop"
             className="nexus-button-primary nexus-target hidden whitespace-nowrap lg:inline-flex"
           >

--- a/lib/agent/__tests__/proposal-executor.test.ts
+++ b/lib/agent/__tests__/proposal-executor.test.ts
@@ -13,6 +13,7 @@ import { canonicalizeMcpCall } from "../mcp-proposal";
 function application(overrides: Partial<ApplicationRecord> = {}): ApplicationRecord {
   return {
     id: "1", userId: "user-a", company: "Acme", role: "Engineer", status: "applied",
+    isDemo: false, demoWorkspaceId: null, demoKey: null,
     appliedAt: null, lastContact: null, followUpAt: null, notes: null,
     jobDescription: null, source: null, remote: true, salaryMin: null, salaryMax: null,
     rating: null, jobUrl: null, canonicalJobUrl: null, resumeId: null, companySize: null,
@@ -148,6 +149,21 @@ describe("proposal executor", () => {
     await expect(approveProposal({ repository, db, userId: "user-a", proposalId: "proposal-1" }))
       .rejects.toThrow("Proposal is stale");
     expect(repository.value.status).toBe("stale");
+    expect(db.updateApplication).not.toHaveBeenCalled();
+  });
+
+  it("rejects a hidden demo target before transitioning or mutating", async () => {
+    const repository = new MemoryExecutionRepository();
+    const db = {
+      getApplication: vi.fn().mockResolvedValue(null),
+      updateApplication: vi.fn(),
+    } as unknown as DatabaseAdapter;
+
+    await expect(approveProposal({ repository, db, userId: "user-a", proposalId: "proposal-1" }))
+      .rejects.toThrow("Proposal target not found");
+
+    expect(db.getApplication).toHaveBeenCalledWith("1", "user-a", { demoVisibility: "exclude" });
+    expect(repository.transitions).toEqual([]);
     expect(db.updateApplication).not.toHaveBeenCalled();
   });
 

--- a/lib/agent/__tests__/tools-and-proposals.test.ts
+++ b/lib/agent/__tests__/tools-and-proposals.test.ts
@@ -13,6 +13,9 @@ function application(overrides: Partial<ApplicationRecord> = {}): ApplicationRec
   return {
     id: "1",
     userId: "user-a",
+    isDemo: false,
+    demoWorkspaceId: null,
+    demoKey: null,
     company: "Acme",
     role: "Platform Engineer",
     status: "applied",
@@ -88,7 +91,7 @@ describe("tenant-scoped Nexus agent tools", () => {
 
     const summary = await getPipelineSummary(db, "user-a");
 
-    expect(db.listApplications).toHaveBeenCalledWith("user-a");
+    expect(db.listApplications).toHaveBeenCalledWith("user-a", { demoVisibility: "exclude" });
     expect(summary.total).toBe(2);
     expect(summary.byStatus).toMatchObject({ applied: 1, interview: 1 });
   });
@@ -103,7 +106,7 @@ describe("tenant-scoped Nexus agent tools", () => {
 
     const results = await searchApplicationsForAgent(db, "user-a", "platform");
 
-    expect(db.listApplications).toHaveBeenCalledWith("user-a");
+    expect(db.listApplications).toHaveBeenCalledWith("user-a", { demoVisibility: "exclude" });
     expect(results).toHaveLength(1);
     expect(results[0]).not.toHaveProperty("jobDescription");
   });
@@ -115,7 +118,7 @@ describe("tenant-scoped Nexus agent tools", () => {
       jobDescription: "d".repeat(5_000),
     })) } as unknown as DatabaseAdapter;
     const result = await getApplicationForAgent(db, "user-a", "1");
-    expect(db.getApplication).toHaveBeenCalledWith("1", "user-a");
+    expect(db.getApplication).toHaveBeenCalledWith("1", "user-a", { demoVisibility: "exclude" });
     expect(result).not.toHaveProperty("notes");
     expect(result).not.toHaveProperty("jobSummary");
     expect(result?.untrustedExternalContext).toMatchObject({
@@ -148,6 +151,7 @@ describe("application update proposals", () => {
     });
 
     expect(db.updateApplication).not.toHaveBeenCalled();
+    expect(db.getApplication).toHaveBeenCalledWith("1", "user-a", { demoVisibility: "exclude" });
     expect(proposal).toMatchObject({
       userId: "user-a",
       kind: "update_application",

--- a/lib/agent/__tests__/tools-and-proposals.test.ts
+++ b/lib/agent/__tests__/tools-and-proposals.test.ts
@@ -262,6 +262,89 @@ describe("application update proposals", () => {
     ).resolves.toEqual(existing);
   });
 
+  it("revalidates an existing proposal target against demo exclusion", async () => {
+    const db = { getApplication: vi.fn().mockResolvedValue(null) } as unknown as DatabaseAdapter;
+    const repository = new MemoryProposalRepository();
+    await repository.create({
+      userId: "user-a",
+      threadId: null,
+      runId: null,
+      toolInvocationId: null,
+      kind: "update_application",
+      targetType: "application",
+      targetId: "demo-1",
+      payload: { status: "interview" },
+      expectedDiff: [],
+      assumptions: null,
+      baseVersion: application().updatedAt,
+      idempotencyKey: "existing-key",
+      status: "pending",
+      expiresAt: new Date(Date.now() + 60_000),
+      executedAt: null,
+    });
+
+    await expect(proposeApplicationUpdate({
+      db,
+      repository,
+      userId: "user-a",
+      applicationId: "demo-1",
+      changes: { status: "interview" },
+      reason: "replay",
+      idempotencyKey: "existing-key",
+    })).rejects.toThrow("Application not found");
+    expect(db.getApplication).toHaveBeenCalledWith("demo-1", "user-a", {
+      demoVisibility: "exclude",
+    });
+  });
+
+  it("revalidates a concurrent idempotency winner target against demo exclusion", async () => {
+    const visible = application();
+    const db = {
+      getApplication: vi.fn()
+        .mockResolvedValueOnce(visible)
+        .mockResolvedValueOnce(null),
+    } as unknown as DatabaseAdapter;
+    const winner = new MemoryProposalRepository();
+    const existing = await winner.create({
+      userId: "user-a",
+      threadId: null,
+      runId: null,
+      toolInvocationId: null,
+      kind: "update_application",
+      targetType: "application",
+      targetId: "1",
+      payload: { status: "interview" },
+      expectedDiff: [],
+      assumptions: null,
+      baseVersion: visible.updatedAt,
+      idempotencyKey: "race-hidden-key",
+      status: "pending",
+      expiresAt: new Date(Date.now() + 60_000),
+      executedAt: null,
+    });
+    let lookups = 0;
+    const repository: ProposalRepository = {
+      create: vi.fn().mockRejectedValue(Object.assign(new Error("unique"), {
+        code: "P2002",
+        meta: { target: ["userId", "idempotencyKey"] },
+      })),
+      findByIdempotencyKey: vi.fn(async () => (++lookups === 1 ? null : existing)),
+    };
+
+    await expect(proposeApplicationUpdate({
+      db,
+      repository,
+      userId: "user-a",
+      applicationId: "1",
+      changes: { status: "interview" },
+      reason: "race",
+      idempotencyKey: "race-hidden-key",
+    })).rejects.toThrow("Application not found");
+    expect(db.getApplication).toHaveBeenNthCalledWith(2, "1", "user-a", {
+      demoVisibility: "exclude",
+    });
+  });
+
   it("rethrows unrelated unique-constraint conflicts", async () => {
     const db = { getApplication: vi.fn().mockResolvedValue(application()) } as unknown as DatabaseAdapter;
     const unrelated = Object.assign(new Error("tool invocation conflict"), {

--- a/lib/agent/proposal-executor.ts
+++ b/lib/agent/proposal-executor.ts
@@ -283,7 +283,9 @@ export async function approveProposal(input: {
     executionError("UNSUPPORTED", "Unsupported proposal kind");
   }
 
-  const current = await input.db.getApplication(proposal.targetId, input.userId);
+  const current = await input.db.getApplication(proposal.targetId, input.userId, {
+    demoVisibility: "exclude",
+  });
   if (!current) executionError("TARGET_NOT_FOUND", "Proposal target not found");
   if (
     proposal.baseVersion &&
@@ -324,7 +326,9 @@ export async function approveProposal(input: {
     throw error;
   }
 
-  const readBack = await input.db.getApplication(proposal.targetId, input.userId);
+  const readBack = await input.db.getApplication(proposal.targetId, input.userId, {
+    demoVisibility: "exclude",
+  });
     if (!readBack) throw new Error("Applied target could not be verified");
     const expected = Object.fromEntries(
       proposal.expectedDiff.map((diff) => [diff.field, diff.to]),

--- a/lib/agent/proposals.ts
+++ b/lib/agent/proposals.ts
@@ -144,6 +144,18 @@ function canonicalizeChanges(changes: ApplicationProposalChanges): ApplicationPr
   return canonical;
 }
 
+async function revalidateProposalTarget(
+  db: DatabaseAdapter,
+  userId: string,
+  proposal: ProposalRecord,
+): Promise<ProposalRecord> {
+  const application = await db.getApplication(proposal.targetId, userId, {
+    demoVisibility: "exclude",
+  });
+  if (!application) throw new Error("Application not found");
+  return proposal;
+}
+
 export async function proposeApplicationUpdate(input: {
   db: DatabaseAdapter;
   repository: ProposalRepository;
@@ -158,7 +170,7 @@ export async function proposeApplicationUpdate(input: {
 }) {
   const key = input.idempotencyKey ?? randomUUID();
   const existing = await input.repository.findByIdempotencyKey(input.userId, key);
-  if (existing) return existing;
+  if (existing) return revalidateProposalTarget(input.db, input.userId, existing);
 
   const application = await input.db.getApplication(input.applicationId, input.userId, {
     demoVisibility: "exclude",
@@ -206,6 +218,6 @@ export async function proposeApplicationUpdate(input: {
     if (String(details?.code ?? "") !== "P2002" || !idempotencyTarget) throw error;
     const winner = await input.repository.findByIdempotencyKey(input.userId, key);
     if (!winner) throw error;
-    return winner;
+    return revalidateProposalTarget(input.db, input.userId, winner);
   }
 }

--- a/lib/agent/proposals.ts
+++ b/lib/agent/proposals.ts
@@ -160,7 +160,9 @@ export async function proposeApplicationUpdate(input: {
   const existing = await input.repository.findByIdempotencyKey(input.userId, key);
   if (existing) return existing;
 
-  const application = await input.db.getApplication(input.applicationId, input.userId);
+  const application = await input.db.getApplication(input.applicationId, input.userId, {
+    demoVisibility: "exclude",
+  });
   if (!application) throw new Error("Application not found");
   const payload = canonicalizeChanges(input.changes);
   const expectedDiff: ProposalDiff[] = Object.entries(payload).map(([field, to]) => {

--- a/lib/agent/tools.ts
+++ b/lib/agent/tools.ts
@@ -1,7 +1,9 @@
 import type { DatabaseAdapter } from "@/lib/db/adapter";
 
+const AGENT_DEMO_READ = { demoVisibility: "exclude" } as const;
+
 export async function getPipelineSummary(db: DatabaseAdapter, userId: string) {
-  const applications = await db.listApplications(userId);
+  const applications = await db.listApplications(userId, AGENT_DEMO_READ);
   const byStatus: Record<string, number> = {};
   let overdueFollowUps = 0;
   const now = Date.now();
@@ -24,7 +26,7 @@ export async function searchApplicationsForAgent(
   query: string,
 ) {
   const normalized = query.trim().toLowerCase();
-  const applications = await db.listApplications(userId);
+  const applications = await db.listApplications(userId, AGENT_DEMO_READ);
   return applications
     .filter((application) => {
       if (!normalized) return true;
@@ -50,7 +52,7 @@ export async function getApplicationForAgent(
   userId: string,
   applicationId: string,
 ) {
-  const application = await db.getApplication(applicationId, userId);
+  const application = await db.getApplication(applicationId, userId, AGENT_DEMO_READ);
   if (!application) return null;
   return {
     id: application.id,

--- a/lib/db/__tests__/demo-schema.test.ts
+++ b/lib/db/__tests__/demo-schema.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const schema = readFileSync(new URL("../../../prisma/schema.prisma", import.meta.url), "utf8");
+
+describe("demo workspace persistence schema", () => {
+  it("defines tenant-safe workspaces and composite demo relations", () => {
+    expect(schema).toContain("model DemoWorkspace");
+    expect(schema).toMatch(/userId\s+String\s+@unique/);
+    expect(schema).toMatch(/isDemo\s+Boolean\s+@default\(false\)/);
+    expect(schema).toMatch(/demoWorkspaceId\s+Int\?/);
+    expect(schema).toMatch(/demoKey\s+String\?/);
+    expect(schema.match(/isDemo\s+Boolean\s+@default\(false\)/g)).toHaveLength(2);
+    expect(schema).toMatch(/@@unique\(\[id, userId\]\)/);
+    expect(schema.match(/fields: \[demoWorkspaceId, userId\], references: \[id, userId\]/g)).toHaveLength(2);
+  });
+
+  it("composite-constrains every event to its parent tenant and demo classification", () => {
+    expect(schema).toMatch(/application\s+Application\s+@relation\(fields: \[applicationId, userId, isDemo\], references: \[id, userId, isDemo\]/);
+    expect(schema).toMatch(/@@unique\(\[id, userId, isDemo\]\)/);
+  });
+});

--- a/lib/db/__tests__/firestore-adapter.test.ts
+++ b/lib/db/__tests__/firestore-adapter.test.ts
@@ -414,17 +414,22 @@ describe("FirestoreAdapter — demo workspace lifecycle", () => {
     const fixtures = createDemoFixtures(new Date("2026-08-10T12:00:00.000Z"));
     const created = await adapter.ensureDemoWorkspace("owner-1", fixtures);
     const application = created.applications[0];
-    const event = await adapter.createApplicationEvent(application.id, "owner-1", {
-      type: "note_added",
+    const eventInput = {
+      type: "note_added" as const,
       idempotencyKey: "demo-note-1",
       occurredAt: new Date("2026-08-10T12:01:00.000Z"),
       metadata: { note: "Demo interaction" },
-    });
+    };
+    const event = await adapter.createApplicationEvent(application.id, "owner-1", eventInput);
     expect(event).toMatchObject({
       isDemo: true,
       demoWorkspaceId: created.workspace.id,
       demoKey: expect.stringContaining(`${application.demoKey}:event:`),
     });
+    await expect(adapter.createApplicationEvent(application.id, "owner-1", eventInput))
+      .resolves.toEqual(event);
+    expect(Array.from(stores.applicationEvents.values()).map((row) => row.demoKey))
+      .toEqual(expect.arrayContaining(fixtures.events.map((fixture) => fixture.demoKey)));
     await expect(adapter.ensureDemoWorkspace("owner-1", fixtures)).resolves.toMatchObject({ replayed: true });
   });
 
@@ -457,6 +462,32 @@ describe("FirestoreAdapter — demo workspace lifecycle", () => {
     app.isDemo = false;
     await expect(adapter.deleteDemoWorkspace("owner-1")).rejects.toThrow("demo_marker_conflict");
     expect(stores.demoWorkspaces.size).toBe(1);
+  });
+
+  it("deletes events added after preparation while returning the stable preparation count", async () => {
+    const adapter = new FirestoreAdapter();
+    const fixtures = createDemoFixtures(new Date("2026-08-10T12:00:00.000Z"));
+    const created = await adapter.ensureDemoWorkspace("owner-1", fixtures);
+    const application = created.applications[0];
+
+    batchState.beforeCommit = () => {
+      stores.applicationEvents.set("concurrent-demo-event", {
+        userId: "owner-1",
+        applicationId: application.id,
+        type: "note_added",
+        occurredAt: mockTimestamp,
+        isDemo: true,
+        demoWorkspaceId: created.workspace.id,
+        demoKey: `${application.demoKey}:event:concurrent`,
+        createdAt: mockTimestamp,
+      });
+    };
+
+    await expect(adapter.deleteDemoWorkspace("owner-1")).resolves.toEqual({
+      deletedApplications: fixtures.applications.length,
+      deletedEvents: fixtures.events.length,
+    });
+    expect(stores.applicationEvents.has("concurrent-demo-event")).toBe(false);
   });
 
   it("keeps deletion metadata fail-closed across a middle-cascade failure and fully retries", async () => {
@@ -1158,6 +1189,20 @@ describe("FirestoreAdapter — document operations", () => {
         mimeType: "application/pdf",
         applicationIds: ["app-1"],
       })).rejects.toThrow("invalid_applications");
+      expect(stores.documents.size).toBe(0);
+    });
+
+    it("rejects demo parents inside the creation transaction when guarded", async () => {
+      seedApps([{ id: "demo-app", userId, company: "Demo", role: "Explorer" }]);
+      stores.applications.get("demo-app")!.isDemo = true;
+
+      await expect(adapter.createDocument(userId, {
+        filename: "doc.pdf",
+        originalName: "doc.pdf",
+        size: 512,
+        mimeType: "application/pdf",
+        applicationIds: ["demo-app"],
+      }, { requireNonDemoProvenance: true })).rejects.toThrow("invalid_applications");
       expect(stores.documents.size).toBe(0);
     });
 

--- a/lib/db/__tests__/firestore-adapter.test.ts
+++ b/lib/db/__tests__/firestore-adapter.test.ts
@@ -713,10 +713,10 @@ describe("FirestoreAdapter — retryable application deletion", () => {
     Object.values(stores).forEach((store) => store.clear());
   });
 
-  it("removes only the deleted application link without overwriting a concurrent document mutation", async () => {
+  it("marks durable demo provenance while detaching a demo application without overwriting a concurrent document mutation", async () => {
     const adapter = new FirestoreAdapter();
     stores.applications.set("app-1", {
-      userId: "user-1", company: "Acme", role: "Engineer", canonicalJobUrl: null,
+      userId: "user-1", company: "Acme", role: "Engineer", canonicalJobUrl: null, isDemo: true,
     });
     stores.documents.set("doc-1", {
       userId: "user-1",
@@ -743,6 +743,7 @@ describe("FirestoreAdapter — retryable application deletion", () => {
       applicationIds: ["app-2", "app-3"],
       submissionId: null,
       state: "superseded",
+      demoProvenance: true,
     });
   });
 
@@ -1206,6 +1207,19 @@ describe("FirestoreAdapter — document operations", () => {
       expect(stores.documents.size).toBe(0);
     });
 
+    it("persists demo provenance when an interactive upload links a demo parent", async () => {
+      seedApps([{ id: "demo-app", userId, company: "Demo", role: "Explorer" }]);
+      stores.applications.get("demo-app")!.isDemo = true;
+
+      const result = await adapter.createDocument(userId, {
+        filename: "doc.pdf", originalName: "doc.pdf", size: 512,
+        mimeType: "application/pdf", applicationIds: ["demo-app"],
+      });
+
+      expect(result.demoProvenance).toBe(true);
+      expect(stores.documents.get(result.id)!.demoProvenance).toBe(true);
+    });
+
     it("handles empty applicationIds without calling getAll", async () => {
       const result = await adapter.createDocument(userId, {
         filename: "empty.pdf",
@@ -1250,6 +1264,26 @@ describe("FirestoreAdapter — document operations", () => {
 
       expect(mockGetAll).toHaveBeenCalledTimes(1);
       expect(result.applications).toHaveLength(2);
+    });
+
+    it("keeps demo provenance sticky after relinking to a real parent", async () => {
+      seedDocs([{
+        id: "doc-1", userId, filename: "f.pdf", originalName: "f.pdf",
+        size: 100, mimeType: "application/pdf", applicationIds: [],
+      }]);
+      seedApps([
+        { id: "demo-app", userId, company: "Demo", role: "Explorer" },
+        { id: "real-app", userId, company: "Real", role: "Engineer" },
+      ]);
+      stores.applications.get("demo-app")!.isDemo = true;
+
+      await adapter.updateDocumentLinks("doc-1", userId, ["demo-app"]);
+      expect(stores.documents.get("doc-1")!.demoProvenance).toBe(true);
+      await adapter.updateDocumentLinks("doc-1", userId, ["real-app"]);
+      await expect(adapter.updateDocumentLinks("doc-1", userId, ["real-app"], { requireNonDemoProvenance: true }))
+        .resolves.toMatchObject({ demoProvenance: true });
+      await expect(adapter.updateDocumentMetadata("doc-1", userId, { version: 2 }, { requireNonDemoProvenance: true }))
+        .resolves.toMatchObject({ version: 2, demoProvenance: true });
     });
 
     it("rejects if document not owned by user", async () => {
@@ -1301,6 +1335,24 @@ describe("FirestoreAdapter — document operations", () => {
       expect(stores.documents.get("doc-1")!.version).not.toBe(2);
       expect(stores.documents.get("doc-1")!.applicationIds).toEqual(["demo-app"]);
       expect(stores.documents.has("doc-1")).toBe(true);
+    });
+
+    it("rejects guarded mutations for detached sticky demo provenance", async () => {
+      seedDocs([{
+        id: "doc-1", userId, filename: "f.pdf", originalName: "f.pdf",
+        size: 100, mimeType: "application/pdf", applicationIds: [],
+      }]);
+      stores.documents.get("doc-1")!.demoProvenance = true;
+
+      await expect(adapter.updateDocumentMetadata("doc-1", userId, { version: 2 }, guard))
+        .rejects.toThrow("not_found");
+      await expect(adapter.updateDocumentLinks("doc-1", userId, [], guard))
+        .rejects.toThrow("not_found");
+      await expect(adapter.deleteDocument("doc-1", userId, guard))
+        .rejects.toThrow("not_found");
+
+      expect(stores.documents.get("doc-1")!).toMatchObject({ demoProvenance: true });
+      expect(stores.documents.get("doc-1")!.version).toBeUndefined();
     });
 
     it("rejects guarded replacement links to demo applications", async () => {

--- a/lib/db/__tests__/firestore-adapter.test.ts
+++ b/lib/db/__tests__/firestore-adapter.test.ts
@@ -10,6 +10,8 @@ const { mockGetAll, stores, mockTimestamp, batchState, queryStats, applyUpdate }
     applicationSubmissions: new Map<string, Record<string, unknown>>(),
     applicationEvents: new Map<string, Record<string, unknown>>(),
     applicationCanonicalUrls: new Map<string, Record<string, unknown>>(),
+    demoWorkspaces: new Map<string, Record<string, unknown>>(),
+    ownerApplicationLifecycles: new Map<string, Record<string, unknown>>(),
     cvPatches: new Map<string, Record<string, unknown>>(),
   };
 
@@ -277,6 +279,7 @@ import {
   submissionInputRequestHash,
   submissionRequestHash,
 } from "../../applications/submission";
+import { createDemoFixtures } from "../../demo-workspace/fixtures";
 
 // ── Test seed helpers ───────────────────────────────────────────────────────
 
@@ -325,6 +328,182 @@ beforeEach(() => {
   queryStats.eventReadSizes = [];
 });
 
+describe("FirestoreAdapter — demo workspace lifecycle", () => {
+  beforeEach(() => {
+    stores.applications.clear();
+    stores.applicationEvents.clear();
+    stores.demoWorkspaces.clear();
+    stores.contacts.clear();
+    stores.documents.clear();
+    stores.applicationSubmissions.clear();
+    stores.applicationCanonicalUrls.clear();
+    stores.cvPatches.clear();
+    stores.ownerApplicationLifecycles.clear();
+  });
+
+  it("creates deterministic owner-scoped demos, replays, filters, and deletes safely", async () => {
+    const adapter = new FirestoreAdapter();
+    const fixtures = createDemoFixtures(new Date("2026-08-10T12:00:00.000Z"));
+
+    const created = await adapter.ensureDemoWorkspace("owner-1", fixtures);
+    expect(created.replayed).toBe(false);
+    expect(created.applications).toHaveLength(fixtures.applications.length);
+    expect(await adapter.listApplications("owner-1", { demoVisibility: "exclude" })).toEqual([]);
+    expect(await adapter.listApplications("owner-1", { demoVisibility: "only" })).toHaveLength(fixtures.applications.length);
+
+    const replay = await adapter.ensureDemoWorkspace("owner-1", fixtures);
+    expect(replay.replayed).toBe(true);
+    expect(stores.applications.size).toBe(fixtures.applications.length);
+
+    const demoApplication = replay.applications[0];
+    const canonicalJobUrl = "https://demo.invalid/job/1";
+    stores.applications.get(demoApplication.id)!.canonicalJobUrl = canonicalJobUrl;
+    stores.contacts.set("demo-contact", { userId: "owner-1", applicationId: demoApplication.id });
+    stores.applicationSubmissions.set("demo-submission", { userId: "owner-1", applicationId: demoApplication.id });
+    stores.documents.set("demo-document", {
+      userId: "owner-1", applicationIds: [demoApplication.id], submissionId: "demo-submission",
+      state: "submitted", filename: "demo.pdf", originalName: "demo.pdf", size: 1, mimeType: "application/pdf",
+    });
+    stores.cvPatches.set(demoApplication.id, { userId: "owner-1", applicationId: demoApplication.id });
+    stores.applicationCanonicalUrls.set(submissionRequestHash({ userId: "owner-1", canonicalJobUrl }), {
+      userId: "owner-1", canonicalJobUrl, applicationId: demoApplication.id,
+    });
+    await adapter.createApplicationEvent(demoApplication.id, "owner-1", {
+      type: "note_added", idempotencyKey: "delete-me", occurredAt: fixtures.createdAt, metadata: { note: "demo" },
+    });
+
+    stores.applications.set("foreign-real", { userId: "owner-2", company: "Real", role: "Role", isDemo: false, createdAt: mockTimestamp });
+    const removed = await adapter.deleteDemoWorkspace("owner-1");
+    expect(removed).toEqual({ deletedApplications: fixtures.applications.length, deletedEvents: fixtures.events.length + 1 });
+    expect(stores.contacts.has("demo-contact")).toBe(false);
+    expect(stores.applicationSubmissions.has("demo-submission")).toBe(false);
+    expect(stores.cvPatches.has(demoApplication.id)).toBe(false);
+    expect(stores.applicationCanonicalUrls.size).toBe(0);
+    expect(stores.documents.get("demo-document")).toMatchObject({ applicationIds: [], submissionId: null, state: "historical" });
+    expect(stores.applications.has("foreign-real")).toBe(true);
+    await expect(adapter.deleteDemoWorkspace("owner-1")).resolves.toEqual({ deletedApplications: 0, deletedEvents: 0 });
+  });
+
+  it("rejects first creation when legacy real applications exist", async () => {
+    const adapter = new FirestoreAdapter();
+    stores.applications.set("legacy-real", { userId: "owner-1", company: "Legacy", role: "Real", createdAt: mockTimestamp });
+    await expect(adapter.ensureDemoWorkspace("owner-1", createDemoFixtures())).rejects.toThrow("real_applications_exist");
+    expect(stores.demoWorkspaces.size).toBe(0);
+  });
+
+  it("reconciles a stale real lifecycle sentinel after the last real application is gone", async () => {
+    const adapter = new FirestoreAdapter();
+    const lifecycleId = submissionRequestHash({ kind: "application-owner", userId: "owner-1" });
+    stores.ownerApplicationLifecycles.set(lifecycleId, {
+      userId: "owner-1",
+      mode: "real",
+      updatedAt: mockTimestamp,
+    });
+    expect(stores.applications.size).toBe(0);
+
+    await expect(adapter.ensureDemoWorkspace("owner-1", createDemoFixtures()))
+      .resolves.toMatchObject({ replayed: false });
+    expect(stores.ownerApplicationLifecycles.get(lifecycleId)).toMatchObject({
+      userId: "owner-1",
+      mode: "demo",
+    });
+  });
+
+  it("propagates demo markers to ordinary events without breaking fixture replay", async () => {
+    const adapter = new FirestoreAdapter();
+    const fixtures = createDemoFixtures(new Date("2026-08-10T12:00:00.000Z"));
+    const created = await adapter.ensureDemoWorkspace("owner-1", fixtures);
+    const application = created.applications[0];
+    const event = await adapter.createApplicationEvent(application.id, "owner-1", {
+      type: "note_added",
+      idempotencyKey: "demo-note-1",
+      occurredAt: new Date("2026-08-10T12:01:00.000Z"),
+      metadata: { note: "Demo interaction" },
+    });
+    expect(event).toMatchObject({
+      isDemo: true,
+      demoWorkspaceId: created.workspace.id,
+      demoKey: expect.stringContaining(`${application.demoKey}:event:`),
+    });
+    await expect(adapter.ensureDemoWorkspace("owner-1", fixtures)).resolves.toMatchObject({ replayed: true });
+  });
+
+  it("requires ready exact owned fixture markers on replay", async () => {
+    const adapter = new FirestoreAdapter();
+    const fixtures = createDemoFixtures();
+    await adapter.ensureDemoWorkspace("owner-1", fixtures);
+    const workspace = Array.from(stores.demoWorkspaces.values())[0];
+    workspace.state = "deleting";
+    await expect(adapter.ensureDemoWorkspace("owner-1", fixtures)).rejects.toThrow("demo_workspace_unavailable");
+    workspace.state = "ready";
+    stores.applications.delete(Array.from(stores.applications.keys())[0]);
+    await expect(adapter.ensureDemoWorkspace("owner-1", fixtures)).rejects.toThrow("demo_workspace_incomplete");
+  });
+
+  it("serializes normal creation against an existing demo lifecycle", async () => {
+    const adapter = new FirestoreAdapter();
+    await adapter.ensureDemoWorkspace("owner-1", createDemoFixtures());
+    await expect(adapter.createApplication("owner-1", {
+      company: "Real", role: "Engineer", status: "inbound", appliedAt: null,
+      lastContact: null, followUpAt: null, notes: null, jobDescription: null,
+      source: null, remote: false, salaryMin: null, salaryMax: null, rating: null, jobUrl: null,
+    })).rejects.toThrow("demo_workspace_exists");
+  });
+
+  it("aborts deletion on inconsistent workspace markers", async () => {
+    const adapter = new FirestoreAdapter();
+    await adapter.ensureDemoWorkspace("owner-1", createDemoFixtures());
+    const app = Array.from(stores.applications.values())[0];
+    app.isDemo = false;
+    await expect(adapter.deleteDemoWorkspace("owner-1")).rejects.toThrow("demo_marker_conflict");
+    expect(stores.demoWorkspaces.size).toBe(1);
+  });
+
+  it("keeps deletion metadata fail-closed across a middle-cascade failure and fully retries", async () => {
+    const adapter = new FirestoreAdapter();
+    const fixtures = createDemoFixtures(new Date("2026-08-10T12:00:00.000Z"));
+    await adapter.ensureDemoWorkspace("owner-1", fixtures);
+    const applicationIds = [...stores.applications.keys()];
+    const workspaceId = [...stores.demoWorkspaces.keys()][0];
+    const lifecycleId = [...stores.ownerApplicationLifecycles.keys()][0];
+    batchState.failOnCommit = 2;
+
+    await expect(adapter.deleteDemoWorkspace("owner-1"))
+      .rejects.toThrow("injected_batch_failure");
+
+    expect(stores.demoWorkspaces.get(workspaceId)).toMatchObject({
+      state: "deleting",
+      deletionApplicationIds: applicationIds,
+      deletionApplicationCount: fixtures.applications.length,
+      deletionEventCount: fixtures.events.length,
+    });
+    expect(stores.ownerApplicationLifecycles.get(lifecycleId)).toMatchObject({
+      mode: "deleting",
+      workspaceId,
+    });
+    expect(stores.applications.size).toBeGreaterThan(0);
+    expect(stores.applications.size).toBeLessThan(fixtures.applications.length);
+
+    batchState.failOnCommit = null;
+    await expect(adapter.deleteDemoWorkspace("owner-1")).resolves.toEqual({
+      deletedApplications: fixtures.applications.length,
+      deletedEvents: fixtures.events.length,
+    });
+
+    expect(stores.demoWorkspaces.size).toBe(0);
+    expect(stores.ownerApplicationLifecycles.size).toBe(0);
+    expect(stores.applications.size).toBe(0);
+    expect(stores.applicationEvents.size).toBe(0);
+    expect(stores.contacts.size).toBe(0);
+    expect(stores.applicationSubmissions.size).toBe(0);
+    expect(stores.applicationCanonicalUrls.size).toBe(0);
+    expect(stores.cvPatches.size).toBe(0);
+    expect(Array.from(stores.documents.values()).every((document) =>
+      !applicationIds.some((id) => (document.applicationIds as string[] | undefined)?.includes(id))
+    )).toBe(true);
+  });
+});
+
 describe("FirestoreAdapter — application metadata", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -369,6 +548,43 @@ describe("FirestoreAdapter — application metadata", () => {
     expect(result.eligibleCountries).toEqual(["ES", "AT"]);
     expect(result.salaryCurrency).toBe("EUR");
     expect(result.requisitionId).toBe("REQ-1");
+  });
+
+  it("persists explicit real markers for direct and delegated batch creates", async () => {
+    const adapter = new FirestoreAdapter();
+    const input = {
+      company: "Acme",
+      role: "Engineer",
+      status: "inbound" as const,
+      appliedAt: null,
+      lastContact: null,
+      followUpAt: null,
+      notes: null,
+      jobDescription: null,
+      source: null,
+      remote: false,
+      salaryMin: null,
+      salaryMax: null,
+      rating: null,
+      jobUrl: null,
+    };
+
+    const direct = await adapter.createApplication("user-1", input);
+    const batch = await adapter.batchUpsertApplications("user-1", [{
+      company: "Beta",
+      role: "Platform Engineer",
+    }]);
+
+    expect(stores.applications.get(direct.id)).toMatchObject({
+      isDemo: false,
+      demoWorkspaceId: null,
+      demoKey: null,
+    });
+    expect(stores.applications.get(batch.results[0].id)).toMatchObject({
+      isDemo: false,
+      demoWorkspaceId: null,
+      demoKey: null,
+    });
   });
 
   it("atomically rejects duplicate canonical job URLs", async () => {
@@ -1015,6 +1231,67 @@ describe("FirestoreAdapter — document operations", () => {
     });
   });
 
+  describe("guarded document mutation provenance", () => {
+    const guard = { requireNonDemoProvenance: true } as const;
+
+    function seedDemoOnlyDocument() {
+      seedApps([{ id: "demo-app", userId, company: "Demo", role: "Explorer" }]);
+      stores.applications.get("demo-app")!.isDemo = true;
+      seedDocs([{
+        id: "doc-1", userId, filename: "f.pdf", originalName: "f.pdf",
+        size: 100, mimeType: "application/pdf", applicationIds: ["demo-app"],
+      }]);
+    }
+
+    it("rejects metadata, relink, and delete atomically for a demo-only document", async () => {
+      seedDemoOnlyDocument();
+
+      await expect(adapter.updateDocumentMetadata("doc-1", userId, { version: 2 }, guard))
+        .rejects.toThrow("not_found");
+      await expect(adapter.updateDocumentLinks("doc-1", userId, [], guard))
+        .rejects.toThrow("not_found");
+      await expect(adapter.deleteDocument("doc-1", userId, guard))
+        .rejects.toThrow("not_found");
+
+      expect(stores.documents.get("doc-1")!.version).not.toBe(2);
+      expect(stores.documents.get("doc-1")!.applicationIds).toEqual(["demo-app"]);
+      expect(stores.documents.has("doc-1")).toBe(true);
+    });
+
+    it("rejects guarded replacement links to demo applications", async () => {
+      seedApps([
+        { id: "real-app", userId, company: "Real", role: "Engineer" },
+        { id: "demo-app", userId, company: "Demo", role: "Explorer" },
+      ]);
+      stores.applications.get("demo-app")!.isDemo = true;
+      seedDocs([{
+        id: "doc-1", userId, filename: "f.pdf", originalName: "f.pdf",
+        size: 100, mimeType: "application/pdf", applicationIds: ["real-app"],
+      }]);
+
+      await expect(adapter.updateDocumentLinks("doc-1", userId, ["demo-app"], guard))
+        .rejects.toThrow("invalid_applications");
+      expect(stores.documents.get("doc-1")!.applicationIds).toEqual(["real-app"]);
+    });
+
+    it("allows guarded mutation for unlinked and legacy-real documents", async () => {
+      seedDocs([{
+        id: "unlinked", userId, filename: "u.pdf", originalName: "u.pdf",
+        size: 100, mimeType: "application/pdf", applicationIds: [],
+      }]);
+      await expect(adapter.updateDocumentMetadata("unlinked", userId, { version: 2 }, guard))
+        .resolves.toMatchObject({ version: 2 });
+
+      seedApps([{ id: "legacy-real", userId, company: "Real", role: "Engineer" }]);
+      seedDocs([{
+        id: "linked", userId, filename: "l.pdf", originalName: "l.pdf",
+        size: 100, mimeType: "application/pdf", applicationIds: ["legacy-real"],
+      }]);
+      await expect(adapter.updateDocumentMetadata("linked", userId, { version: 3 }, guard))
+        .resolves.toMatchObject({ version: 3 });
+    });
+  });
+
   describe("renameDocument", () => {
     it("renames and resolves app refs via batch", async () => {
       seedDocs([{
@@ -1346,6 +1623,141 @@ describe("FirestoreAdapter — first-class application events", () => {
     });
     expect(page.items.map((event) => event.id)).toEqual(["1"]);
     expect(page.nextCursor).toBeNull();
+  });
+
+  it("keeps fixture event keys visible when workspace markers agree with their parents", async () => {
+    const adapter = new FirestoreAdapter();
+    const fixtures = createDemoFixtures(new Date("2026-08-10T12:00:00.000Z"));
+    await adapter.ensureDemoWorkspace(userId, fixtures);
+
+    const page = await adapter.listApplicationEventsFiltered(userId, {
+      order: "newest",
+      limit: 20,
+    }, { demoVisibility: "only" });
+
+    expect(page.items).toHaveLength(fixtures.events.length);
+    expect(page.items.every((event) => event.application?.company.includes("Fictional Demo")))
+      .toBe(true);
+  });
+
+  it("validates parent visibility and marker agreement before filtered pagination", async () => {
+    const timestamp = { toDate: () => new Date("2026-07-24T09:00:00Z") };
+    stores.applications.set("demo-app", {
+      userId,
+      company: "Demo",
+      role: "Engineer",
+      isDemo: true,
+      demoWorkspaceId: "workspace-1",
+      demoKey: "demo-app",
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+    stores.applications.set("real-app", {
+      userId,
+      company: "Real",
+      role: "Engineer",
+      isDemo: false,
+      demoWorkspaceId: null,
+      demoKey: null,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+    for (let index = 99; index >= 40; index -= 1) {
+      const applicationId = index % 3 === 0 ? "missing-app" : index % 3 === 1 ? "demo-app" : "real-app";
+      const childClaimsDemo = applicationId === "real-app";
+      stores.applicationEvents.set(String(index).padStart(3, "0"), {
+        userId,
+        applicationId,
+        type: "stage_changed",
+        occurredAt: timestamp,
+        createdAt: timestamp,
+        isDemo: childClaimsDemo,
+        demoWorkspaceId: childClaimsDemo ? "mismatched-workspace" : null,
+        demoKey: childClaimsDemo ? `mismatch:event:${index}` : null,
+      });
+    }
+    stores.applicationEvents.set("002", {
+      userId,
+      applicationId: "real-app",
+      type: "stage_changed",
+      occurredAt: timestamp,
+      createdAt: timestamp,
+      isDemo: false,
+      demoWorkspaceId: null,
+      demoKey: null,
+    });
+    stores.applicationEvents.set("001", {
+      userId,
+      applicationId: "real-app",
+      type: "stage_changed",
+      occurredAt: timestamp,
+      createdAt: timestamp,
+      isDemo: false,
+      demoWorkspaceId: null,
+      demoKey: null,
+    });
+    const adapter = new FirestoreAdapter();
+
+    const first = await adapter.listApplicationEventsFiltered(userId, {
+      order: "newest",
+      limit: 1,
+    }, { demoVisibility: "exclude" });
+    expect(first.items.map((event) => event.id)).toEqual(["002"]);
+    expect(first.items[0].application?.company).toBe("Real");
+    expect(first.nextCursor).toBeTruthy();
+
+    const { decodeEventCursor } = await import("../../applications/events");
+    const second = await adapter.listApplicationEventsFiltered(userId, {
+      order: "newest",
+      limit: 1,
+      cursor: decodeEventCursor(first.nextCursor!),
+    }, { demoVisibility: "exclude" });
+    expect(second.items.map((event) => event.id)).toEqual(["001"]);
+    expect(second.nextCursor).toBeNull();
+    expect(queryStats.eventReadSizes.some((size) => size === 50)).toBe(true);
+  });
+
+  it("validates child marker agreement before applying an application timeline limit", async () => {
+    stores.applications.set("app-1", {
+      userId,
+      company: "Acme Demo",
+      role: "Engineer",
+      isDemo: true,
+      demoWorkspaceId: "workspace-1",
+      demoKey: "app-1",
+      createdAt: mockTimestamp,
+      updatedAt: mockTimestamp,
+    });
+    const timestamp = { toDate: () => new Date("2026-07-24T09:00:00Z") };
+    stores.applicationEvents.set("2", {
+      userId,
+      applicationId: "app-1",
+      type: "stage_changed",
+      occurredAt: timestamp,
+      createdAt: timestamp,
+      isDemo: false,
+      demoWorkspaceId: null,
+      demoKey: null,
+    });
+    stores.applicationEvents.set("1", {
+      userId,
+      applicationId: "app-1",
+      type: "stage_changed",
+      occurredAt: timestamp,
+      createdAt: timestamp,
+      isDemo: true,
+      demoWorkspaceId: "workspace-1",
+      demoKey: "app-1:event:1",
+    });
+
+    const events = await new FirestoreAdapter().listApplicationEvents(
+      "app-1",
+      userId,
+      1,
+      { demoVisibility: "include" },
+    );
+
+    expect(events.map((event) => event.id)).toEqual(["1"]);
   });
 
   it("applies legacy timeline limits before reading Firestore events", async () => {

--- a/lib/db/__tests__/prisma-application-events.test.ts
+++ b/lib/db/__tests__/prisma-application-events.test.ts
@@ -233,6 +233,43 @@ describe("PrismaAdapter — atomic application events", () => {
     expect(fake.events()).toHaveLength(1);
   });
 
+  it("accepts persisted fixture demo keys when replaying an event", async () => {
+    fake.setApplication({ isDemo: true, demoWorkspaceId: 9, demoKey: "fixture-app" });
+    const requestHash = submissionRequestHash({
+      applicationId: "1",
+      type: command.type,
+      occurredAt: command.occurredAt,
+      source: command.source,
+      actor: command.actor,
+      metadata: command.metadata,
+      contactId: command.contactId,
+      outcome: command.outcome,
+      expectedUpdatedAt: command.expectedUpdatedAt,
+    });
+    fake.seedEvent({
+      id: 99,
+      userId: "owner-1",
+      applicationId: 1,
+      type: command.type,
+      idempotencyKey: command.idempotencyKey,
+      requestHash,
+      occurredAt: command.occurredAt,
+      createdAt: command.occurredAt,
+      source: command.source,
+      actor: command.actor,
+      contactId: null,
+      outcome: null,
+      metadata: command.metadata,
+      isDemo: true,
+      demoWorkspaceId: 9,
+      demoKey: "fixture-stage-changed",
+    });
+
+    await expect(new PrismaAdapter().recordApplicationEvent("1", "owner-1", command))
+      .resolves.toMatchObject({ replayed: true });
+    expect(fake.events()).toHaveLength(1);
+  });
+
   it("fails closed when an inconsistent replay appears inside the transaction", async () => {
     const requestHash = submissionRequestHash({
       applicationId: "1",

--- a/lib/db/__tests__/prisma-application-events.test.ts
+++ b/lib/db/__tests__/prisma-application-events.test.ts
@@ -6,6 +6,7 @@ const fake = vi.hoisted(() => {
   let application: Row;
   let events: Row[];
   let failCreate = false;
+  let replayAfterInitialLookup: Row | null = null;
 
   const reset = () => {
     application = {
@@ -28,12 +29,16 @@ const fake = vi.hoisted(() => {
       canonicalJobUrl: null,
       currentStage: "screen",
       eventVersion: 0,
+      isDemo: false,
+      demoWorkspaceId: null,
+      demoKey: null,
       createdAt: new Date("2026-07-01T00:00:00Z"),
       updatedAt: new Date("2026-07-24T08:00:00Z"),
       contacts: [],
     };
     events = [];
     failCreate = false;
+    replayAfterInitialLookup = null;
   };
   reset();
 
@@ -71,10 +76,23 @@ const fake = vi.hoisted(() => {
       };
       return { ...application, contacts: [] };
     }),
+    create: vi.fn(async ({ data }: { data: Row }) => ({
+      ...application,
+      ...data,
+      id: Number(application.id) + 1,
+      contacts: [],
+    })),
+    count: vi.fn(async () => 1),
   };
   const eventApi = {
     findUnique: vi.fn(async ({ where }: { where: { userId_idempotencyKey: { userId: string; idempotencyKey: string } } }) => {
       const key = where.userId_idempotencyKey;
+      if (replayAfterInitialLookup) {
+        const row = replayAfterInitialLookup;
+        replayAfterInitialLookup = null;
+        events.push(row);
+        return null;
+      }
       return events.find((event) => event.userId === key.userId && event.idempotencyKey === key.idempotencyKey) ?? null;
     }),
     create: vi.fn(async ({ data }: { data: Row }) => {
@@ -83,16 +101,21 @@ const fake = vi.hoisted(() => {
       events.push(row);
       return row;
     }),
+    findMany: vi.fn(async () => events),
   };
   const contactApi = { count: vi.fn(async () => 1) };
   const documentApi = { count: vi.fn(async () => 1) };
   const submissionApi = { count: vi.fn(async () => 1) };
+  const demoWorkspaceApi = { count: vi.fn(async () => 0) };
+  const ownerLock = vi.fn(async () => [{ id: "owner-1" }]);
   Object.assign(prisma, {
     application: applicationApi,
     applicationEvent: eventApi,
     contact: contactApi,
     document: documentApi,
     applicationSubmission: submissionApi,
+    demoWorkspace: demoWorkspaceApi,
+    $queryRaw: ownerLock,
     $transaction: vi.fn(async (callback: (transaction: unknown) => Promise<unknown>) => {
       const applicationBefore = structuredClone(application);
       const eventsBefore = structuredClone(events);
@@ -117,6 +140,9 @@ const fake = vi.hoisted(() => {
     submissionCount: submissionApi.count,
     setApplication: (update: Row) => { application = { ...application, ...update }; },
     setFailCreate: (value: boolean) => { failCreate = value; },
+    setReplayAfterInitialLookup: (row: Row) => { replayAfterInitialLookup = row; },
+    demoWorkspaceCount: demoWorkspaceApi.count,
+    ownerLock,
   };
 });
 
@@ -150,6 +176,23 @@ describe("PrismaAdapter — atomic application events", () => {
     expect(result.event.metadata).not.toHaveProperty("requestHash");
     expect(fake.events()).toHaveLength(1);
     expect(fake.events()[0].requestHash).toEqual(expect.any(String));
+  });
+
+  it("propagates demo ownership markers to ordinary event writes", async () => {
+    fake.setApplication({ isDemo: true, demoWorkspaceId: 9, demoKey: "fixture-app" });
+    await new PrismaAdapter().recordApplicationEvent("1", "owner-1", command);
+    expect(fake.events()[0]).toMatchObject({
+      isDemo: true,
+      demoWorkspaceId: 9,
+      demoKey: expect.stringMatching(/^fixture-app:event:/),
+    });
+  });
+
+  it("fails closed when a parent has inconsistent demo markers", async () => {
+    fake.setApplication({ isDemo: false, demoWorkspaceId: 9, demoKey: "fixture-app" });
+    await expect(new PrismaAdapter().recordApplicationEvent("1", "owner-1", command))
+      .rejects.toThrow("demo_marker_conflict");
+    expect(fake.events()).toHaveLength(0);
   });
 
   it("replays a pre-migration legacy idempotency hash", async () => {
@@ -188,6 +231,41 @@ describe("PrismaAdapter — atomic application events", () => {
     const replay = await adapter.recordApplicationEvent("1", "owner-1", command);
     expect(replay.replayed).toBe(true);
     expect(fake.events()).toHaveLength(1);
+  });
+
+  it("fails closed when an inconsistent replay appears inside the transaction", async () => {
+    const requestHash = submissionRequestHash({
+      applicationId: "1",
+      type: command.type,
+      occurredAt: command.occurredAt,
+      source: command.source,
+      actor: command.actor,
+      metadata: command.metadata,
+      contactId: command.contactId,
+      outcome: command.outcome,
+      expectedUpdatedAt: command.expectedUpdatedAt,
+    });
+    fake.setReplayAfterInitialLookup({
+      id: 99,
+      userId: "owner-1",
+      applicationId: 1,
+      type: command.type,
+      idempotencyKey: command.idempotencyKey,
+      requestHash,
+      occurredAt: command.occurredAt,
+      createdAt: command.occurredAt,
+      source: command.source,
+      actor: command.actor,
+      contactId: null,
+      outcome: null,
+      metadata: command.metadata,
+      isDemo: true,
+      demoWorkspaceId: 9,
+      demoKey: "foreign:event:replay",
+    });
+
+    await expect(new PrismaAdapter().recordApplicationEvent("1", "owner-1", command))
+      .rejects.toThrow("demo_marker_conflict");
   });
 
   it("rejects a changed payload for the same idempotency key", async () => {
@@ -279,6 +357,53 @@ describe("PrismaAdapter — atomic application events", () => {
       results: [{ error: "lifecycle_event_required" }],
     });
     expect((fake.prisma.application as { update: ReturnType<typeof vi.fn> }).update).not.toHaveBeenCalled();
+  });
+
+  it("serializes every batch create against the demo lifecycle while preserving partial success", async () => {
+    fake.demoWorkspaceCount
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(1);
+
+    const result = await new PrismaAdapter().batchUpsertApplications("owner-1", [
+      { company: "First", role: "Engineer" },
+      { company: "Second", role: "Designer" },
+    ]);
+
+    expect(result).toMatchObject({
+      succeeded: 1,
+      failed: 1,
+      results: [
+        { index: 0, operation: "created" },
+        { index: 1, operation: "created", error: "demo_workspace_exists" },
+      ],
+    });
+    expect(fake.ownerLock).toHaveBeenCalledTimes(2);
+    expect((fake.prisma as { $transaction: ReturnType<typeof vi.fn> }).$transaction).toHaveBeenCalledTimes(2);
+    expect((fake.prisma.application as { create: ReturnType<typeof vi.fn> }).create).toHaveBeenCalledTimes(1);
+  });
+
+  it("requires a visible matching parent on event reads", async () => {
+    const adapter = new PrismaAdapter();
+    await adapter.listApplicationEventsFiltered("owner-1", { limit: 10, order: "newest" }, { demoVisibility: "exclude" });
+    expect((fake.prisma.applicationEvent as { findMany: ReturnType<typeof vi.fn> }).findMany)
+      .toHaveBeenLastCalledWith(expect.objectContaining({
+        where: expect.objectContaining({
+          userId: "owner-1",
+          isDemo: false,
+          application: { userId: "owner-1", isDemo: false },
+        }),
+      }));
+
+    await adapter.listApplicationEvents("1", "owner-1", 10, { demoVisibility: "only" });
+    expect((fake.prisma.applicationEvent as { findMany: ReturnType<typeof vi.fn> }).findMany)
+      .toHaveBeenLastCalledWith(expect.objectContaining({
+        where: expect.objectContaining({
+          applicationId: 1,
+          userId: "owner-1",
+          isDemo: true,
+          application: { userId: "owner-1", isDemo: true },
+        }),
+      }));
   });
 
   it("rolls back projection changes when event creation fails", async () => {

--- a/lib/db/__tests__/prisma-demo-workspace.test.ts
+++ b/lib/db/__tests__/prisma-demo-workspace.test.ts
@@ -48,6 +48,14 @@ describe("PrismaAdapter — demo workspace deletion", () => {
     expect(fake.transaction.document.updateMany).toHaveBeenCalledWith({
       where: {
         userId: "owner-1",
+        applications: { some: { userId: "owner-1", demoWorkspaceId: 7, isDemo: true } },
+      },
+      data: { demoProvenance: true },
+    });
+
+    expect(fake.transaction.document.updateMany).toHaveBeenCalledWith({
+      where: {
+        userId: "owner-1",
         submission: {
           application: {
             userId: "owner-1",
@@ -56,8 +64,8 @@ describe("PrismaAdapter — demo workspace deletion", () => {
           },
         },
       },
-      data: { state: "historical" },
+      data: { state: "historical", demoProvenance: true },
     });
-    expect(fake.calls).toEqual(["document.updateMany", "workspace.delete"]);
+    expect(fake.calls).toEqual(["document.updateMany", "document.updateMany", "workspace.delete"]);
   });
 });

--- a/lib/db/__tests__/prisma-demo-workspace.test.ts
+++ b/lib/db/__tests__/prisma-demo-workspace.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fake = vi.hoisted(() => {
+  const calls: string[] = [];
+  const transaction = {
+    $queryRaw: vi.fn(async () => [{ id: "owner-1" }]),
+    demoWorkspace: {
+      findUnique: vi.fn(async () => ({ id: 7, userId: "owner-1" })),
+      delete: vi.fn(async () => { calls.push("workspace.delete"); }),
+    },
+    application: {
+      count: vi.fn(async () => 2),
+    },
+    applicationEvent: {
+      count: vi.fn(async () => 3),
+    },
+    document: {
+      updateMany: vi.fn(async () => {
+        calls.push("document.updateMany");
+        return { count: 1 };
+      }),
+    },
+  };
+  const prisma = {
+    $transaction: vi.fn(async (callback: (tx: typeof transaction) => Promise<unknown>) => callback(transaction)),
+  };
+  return { calls, transaction, prisma };
+});
+
+vi.mock("@/lib/prisma", () => ({ prisma: fake.prisma }));
+
+import { PrismaAdapter } from "../prisma-adapter";
+
+describe("PrismaAdapter — demo workspace deletion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fake.calls.length = 0;
+  });
+
+  it("marks submission-linked documents historical before cascading the workspace", async () => {
+    const adapter = new PrismaAdapter();
+
+    await expect(adapter.deleteDemoWorkspace("owner-1")).resolves.toEqual({
+      deletedApplications: 2,
+      deletedEvents: 3,
+    });
+
+    expect(fake.transaction.document.updateMany).toHaveBeenCalledWith({
+      where: {
+        userId: "owner-1",
+        submission: {
+          application: {
+            userId: "owner-1",
+            demoWorkspaceId: 7,
+            isDemo: true,
+          },
+        },
+      },
+      data: { state: "historical" },
+    });
+    expect(fake.calls).toEqual(["document.updateMany", "workspace.delete"]);
+  });
+});

--- a/lib/db/__tests__/prisma-document-mutations.test.ts
+++ b/lib/db/__tests__/prisma-document-mutations.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fake = vi.hoisted(() => {
+  const realApp = { id: 1, userId: "owner-1", company: "Real", role: "Engineer", isDemo: false };
+  const demoApp = { id: 2, userId: "owner-1", company: "Demo", role: "Explorer", isDemo: true };
+  let applications = [demoApp];
+  let document: Record<string, unknown> | null;
+
+  const reset = () => {
+    applications = [demoApp];
+    document = {
+      id: 1,
+      userId: "owner-1",
+      filename: "stored.pdf",
+      originalName: "resume.pdf",
+      mimeType: "application/pdf",
+      size: 100,
+      documentType: "resume",
+      state: "current",
+      version: 1,
+      contentHash: null,
+      source: null,
+      generatedAt: null,
+      submittedAt: null,
+      submissionId: null,
+      uploadedAt: new Date("2026-08-10T00:00:00Z"),
+    };
+  };
+  reset();
+
+  const documentApi = {
+    findFirstOrThrow: vi.fn(async () => {
+      if (!document) throw new Error("not_found");
+      return { ...document, applications };
+    }),
+    update: vi.fn(async ({ data }: { data: Record<string, unknown> }) => {
+      if (!document) throw new Error("not_found");
+      document = { ...document, ...data };
+      return { ...document, applications };
+    }),
+    delete: vi.fn(async () => {
+      if (!document) throw new Error("not_found");
+      const deleted = document;
+      document = null;
+      return deleted;
+    }),
+  };
+  const applicationApi = {
+    findMany: vi.fn(async ({ where }: { where: { id: { in: number[] }; userId: string; isDemo?: boolean } }) =>
+      [realApp, demoApp].filter((app) =>
+        where.id.in.includes(app.id)
+        && app.userId === where.userId
+        && (where.isDemo === undefined || app.isDemo === where.isDemo),
+      ).map(({ id }) => ({ id })),
+    ),
+  };
+  const transaction = {
+    $queryRaw: vi.fn(async () => document ? [{ submissionId: null, state: document.state }] : []),
+    document: documentApi,
+    application: applicationApi,
+    shareLink: { deleteMany: vi.fn(async () => ({ count: 0 })) },
+  };
+  const prisma = {
+    $transaction: vi.fn(async (callback: (tx: typeof transaction) => Promise<unknown>) => callback(transaction)),
+  };
+
+  return {
+    prisma,
+    transaction,
+    documentApi,
+    applicationApi,
+    reset,
+    useReal: () => { applications = [realApp]; },
+    useMixed: () => { applications = [realApp, demoApp]; },
+    currentDocument: () => document,
+  };
+});
+
+vi.mock("@/lib/prisma", () => ({ prisma: fake.prisma }));
+
+import { PrismaAdapter } from "../prisma-adapter";
+
+const adapter = new PrismaAdapter();
+const guard = { requireNonDemoProvenance: true } as const;
+
+describe("Prisma guarded document mutations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fake.reset();
+  });
+
+  it("rejects metadata, relink, and delete for demo-only current provenance", async () => {
+    await expect(adapter.updateDocumentMetadata("1", "owner-1", { version: 2 }, guard))
+      .rejects.toThrow("not_found");
+    await expect(adapter.updateDocumentLinks("1", "owner-1", [], guard))
+      .rejects.toThrow("not_found");
+    await expect(adapter.deleteDocument("1", "owner-1", guard))
+      .rejects.toThrow("not_found");
+
+    expect(fake.currentDocument()).toMatchObject({ version: 1 });
+    expect(fake.documentApi.update).not.toHaveBeenCalled();
+    expect(fake.documentApi.delete).not.toHaveBeenCalled();
+  });
+
+  it("rejects a demo replacement even when current provenance is real", async () => {
+    fake.useReal();
+
+    await expect(adapter.updateDocumentLinks("1", "owner-1", ["2"], guard))
+      .rejects.toThrow("invalid_applications");
+    expect(fake.documentApi.update).not.toHaveBeenCalled();
+  });
+
+  it("allows guarded mutations for real or mixed current provenance", async () => {
+    fake.useReal();
+    await expect(adapter.updateDocumentMetadata("1", "owner-1", { version: 2 }, guard))
+      .resolves.toMatchObject({ version: 2 });
+
+    fake.useMixed();
+    await expect(adapter.updateDocumentLinks("1", "owner-1", ["1"], guard))
+      .resolves.toMatchObject({ id: "1" });
+  });
+});

--- a/lib/db/__tests__/prisma-document-mutations.test.ts
+++ b/lib/db/__tests__/prisma-document-mutations.test.ts
@@ -44,6 +44,25 @@ const fake = vi.hoisted(() => {
       document = null;
       return deleted;
     }),
+    create: vi.fn(async ({ data }: { data: Record<string, unknown> }) => ({
+      id: 3,
+      userId: "owner-1",
+      filename: "new.pdf",
+      originalName: "new.pdf",
+      mimeType: "application/pdf",
+      size: 100,
+      documentType: "other",
+      state: "current",
+      version: 1,
+      contentHash: null,
+      source: "upload",
+      generatedAt: null,
+      submittedAt: null,
+      submissionId: null,
+      uploadedAt: new Date("2026-08-10T00:00:00Z"),
+      ...data,
+      applications: [],
+    })),
   };
   const applicationApi = {
     findMany: vi.fn(async ({ where }: { where: { id: { in: number[] }; userId: string; isDemo?: boolean } }) =>
@@ -108,6 +127,17 @@ describe("Prisma guarded document mutations", () => {
     await expect(adapter.updateDocumentLinks("1", "owner-1", ["2"], guard))
       .rejects.toThrow("invalid_applications");
     expect(fake.documentApi.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects a demo parent inside guarded document creation", async () => {
+    await expect(adapter.createDocument("owner-1", {
+      filename: "new.pdf",
+      originalName: "new.pdf",
+      mimeType: "application/pdf",
+      size: 100,
+      applicationIds: ["2"],
+    }, guard)).rejects.toThrow("invalid_applications");
+    expect(fake.documentApi.create).not.toHaveBeenCalled();
   });
 
   it("allows guarded mutations for real or mixed current provenance", async () => {

--- a/lib/db/__tests__/prisma-document-mutations.test.ts
+++ b/lib/db/__tests__/prisma-document-mutations.test.ts
@@ -23,6 +23,7 @@ const fake = vi.hoisted(() => {
       generatedAt: null,
       submittedAt: null,
       submissionId: null,
+      demoProvenance: false,
       uploadedAt: new Date("2026-08-10T00:00:00Z"),
     };
   };
@@ -59,6 +60,7 @@ const fake = vi.hoisted(() => {
       generatedAt: null,
       submittedAt: null,
       submissionId: null,
+      demoProvenance: false,
       uploadedAt: new Date("2026-08-10T00:00:00Z"),
       ...data,
       applications: [],
@@ -70,7 +72,7 @@ const fake = vi.hoisted(() => {
         where.id.in.includes(app.id)
         && app.userId === where.userId
         && (where.isDemo === undefined || app.isDemo === where.isDemo),
-      ).map(({ id }) => ({ id })),
+      ).map(({ id, isDemo }) => ({ id, isDemo })),
     ),
   };
   const transaction = {
@@ -91,6 +93,10 @@ const fake = vi.hoisted(() => {
     reset,
     useReal: () => { applications = [realApp]; },
     useMixed: () => { applications = [realApp, demoApp]; },
+    useDetachedDemo: () => {
+      applications = [];
+      if (document) document.demoProvenance = true;
+    },
     currentDocument: () => document,
   };
 });
@@ -108,6 +114,46 @@ describe("Prisma guarded document mutations", () => {
     fake.reset();
   });
 
+  it("serializes document association writes with demo workspace deletion", async () => {
+    fake.useReal();
+
+    await adapter.createDocument("owner-1", {
+      filename: "new.pdf",
+      originalName: "new.pdf",
+      mimeType: "application/pdf",
+      size: 100,
+      applicationIds: ["1"],
+    });
+    const createQueries = (fake.transaction.$queryRaw.mock.calls as unknown[][])
+      .map((call) => String(call[0]));
+    expect(createQueries.some((query) => query.includes('FROM "User"'))).toBe(true);
+
+    fake.transaction.$queryRaw.mockClear();
+    await adapter.updateDocumentLinks("1", "owner-1", ["1"]);
+    const relinkQueries = (fake.transaction.$queryRaw.mock.calls as unknown[][])
+      .map((call) => String(call[0]));
+    expect(relinkQueries.some((query) => query.includes('FROM "User"'))).toBe(true);
+    expect(relinkQueries.some((query) => query.includes('FROM "Document"'))).toBe(true);
+  });
+
+  it("persists sticky demo provenance on creation and relinking", async () => {
+    await adapter.createDocument("owner-1", {
+      filename: "new.pdf", originalName: "new.pdf", mimeType: "application/pdf",
+      size: 100, applicationIds: ["2"],
+    });
+    expect(fake.documentApi.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ demoProvenance: true }),
+    }));
+
+    await adapter.updateDocumentLinks("1", "owner-1", ["2"]);
+    expect(fake.currentDocument()).toMatchObject({ demoProvenance: true });
+    fake.useReal();
+    await expect(adapter.updateDocumentLinks("1", "owner-1", ["1"], guard))
+      .resolves.toMatchObject({ demoProvenance: true });
+    await expect(adapter.updateDocumentMetadata("1", "owner-1", { version: 2 }, guard))
+      .resolves.toMatchObject({ version: 2, demoProvenance: true });
+  });
+
   it("rejects metadata, relink, and delete for demo-only current provenance", async () => {
     await expect(adapter.updateDocumentMetadata("1", "owner-1", { version: 2 }, guard))
       .rejects.toThrow("not_found");
@@ -117,6 +163,21 @@ describe("Prisma guarded document mutations", () => {
       .rejects.toThrow("not_found");
 
     expect(fake.currentDocument()).toMatchObject({ version: 1 });
+    expect(fake.documentApi.update).not.toHaveBeenCalled();
+    expect(fake.documentApi.delete).not.toHaveBeenCalled();
+  });
+
+  it("rejects guarded mutations for detached sticky demo provenance", async () => {
+    fake.useDetachedDemo();
+
+    await expect(adapter.updateDocumentMetadata("1", "owner-1", { version: 2 }, guard))
+      .rejects.toThrow("not_found");
+    await expect(adapter.updateDocumentLinks("1", "owner-1", ["1"], guard))
+      .rejects.toThrow("not_found");
+    await expect(adapter.deleteDocument("1", "owner-1", guard))
+      .rejects.toThrow("not_found");
+
+    expect(fake.currentDocument()).toMatchObject({ version: 1, demoProvenance: true });
     expect(fake.documentApi.update).not.toHaveBeenCalled();
     expect(fake.documentApi.delete).not.toHaveBeenCalled();
   });

--- a/lib/db/adapter.ts
+++ b/lib/db/adapter.ts
@@ -90,7 +90,7 @@ export interface DatabaseAdapter {
   /** List documents linked to a specific application. */
   listDocumentsByApplication(applicationId: string, userId: string): Promise<DocumentRecord[]>;
   getDocument(id: string, userId: string | null): Promise<DocumentRecord | null>;
-  createDocument(userId: string, data: CreateDocumentInput): Promise<DocumentRecord>;
+  createDocument(userId: string, data: CreateDocumentInput, options?: DocumentMutationOptions): Promise<DocumentRecord>;
   updateDocumentMetadata(id: string, userId: string, data: UpdateDocumentMetadataInput, options?: DocumentMutationOptions): Promise<DocumentRecord>;
   /** Replace the set of linked application IDs on a document. */
   updateDocumentLinks(id: string, userId: string, applicationIds: string[], options?: DocumentMutationOptions): Promise<DocumentRecord>;

--- a/lib/db/adapter.ts
+++ b/lib/db/adapter.ts
@@ -34,20 +34,25 @@ import type {
   ApplicationEventPage,
   ListDocumentsFilter,
   UpdateDocumentMetadataInput,
+  DocumentMutationOptions,
+  DemoReadOptions,
+  EnsureDemoWorkspaceResult,
+  DeleteDemoWorkspaceResult,
 } from "./types";
+import type { DemoFixtures } from "@/lib/demo-workspace/fixtures";
 
 export interface DatabaseAdapter {
   // ── Applications ─────────────────────────────────────────────────────────
   /** List applications, optionally scoped to userId (null = admin/all). */
-  listApplications(userId: string | null): Promise<ApplicationRecord[]>;
+  listApplications(userId: string | null, options?: DemoReadOptions): Promise<ApplicationRecord[]>;
   /** List applications with offset-based pagination. */
-  listApplicationsPaginated(userId: string | null, params: PaginationParams): Promise<PaginatedResult<ApplicationRecord>>;
-  getApplication(id: string, userId: string | null): Promise<ApplicationRecord | null>;
+  listApplicationsPaginated(userId: string | null, params: PaginationParams, options?: DemoReadOptions): Promise<PaginatedResult<ApplicationRecord>>;
+  getApplication(id: string, userId: string | null, options?: DemoReadOptions): Promise<ApplicationRecord | null>;
   createApplication(userId: string, data: CreateApplicationInput): Promise<ApplicationRecord>;
   updateApplication(id: string, userId: string, data: UpdateApplicationInput): Promise<ApplicationRecord>;
   deleteApplication(id: string, userId: string): Promise<void>;
   /** Find an exact canonical URL match owned by the user. */
-  findApplicationByCanonicalJobUrl(userId: string, canonicalJobUrl: string): Promise<ApplicationRecord | null>;
+  findApplicationByCanonicalJobUrl(userId: string, canonicalJobUrl: string, options?: DemoReadOptions): Promise<ApplicationRecord | null>;
   /** Append notes without a caller-side read/replace race and record an event. */
   appendApplicationNote(id: string, userId: string, note: string, event: CreateApplicationEventInput): Promise<{ application: ApplicationRecord; event: ApplicationEventRecord }>;
 
@@ -58,11 +63,15 @@ export interface DatabaseAdapter {
   getApplicationSubmission(id: string, userId: string): Promise<ApplicationSubmissionRecord | null>;
   createApplicationEvent(applicationId: string, userId: string, input: CreateApplicationEventInput): Promise<ApplicationEventRecord>;
   recordApplicationEvent(applicationId: string, userId: string, input: RecordApplicationEventInput): Promise<RecordApplicationEventResult>;
-  listApplicationEvents(applicationId: string, userId: string, limit?: number): Promise<ApplicationEventRecord[]>;
-  listApplicationEventsFiltered(userId: string, filter: ListApplicationEventsFilter): Promise<ApplicationEventPage>;
+  listApplicationEvents(applicationId: string, userId: string, limit?: number, options?: DemoReadOptions): Promise<ApplicationEventRecord[]>;
+  listApplicationEventsFiltered(userId: string, filter: ListApplicationEventsFilter, options?: DemoReadOptions): Promise<ApplicationEventPage>;
 
   /** List applications with optional filters and field selection. */
-  listApplicationsFiltered(userId: string | null, filter: ListApplicationsFilter): Promise<Partial<ApplicationRecord>[]>;
+  listApplicationsFiltered(userId: string | null, filter: ListApplicationsFilter, options?: DemoReadOptions): Promise<Partial<ApplicationRecord>[]>;
+
+  // ── Demo workspace lifecycle ─────────────────────────────────────────────
+  ensureDemoWorkspace(userId: string, fixtures: DemoFixtures): Promise<EnsureDemoWorkspaceResult>;
+  deleteDemoWorkspace(userId: string): Promise<DeleteDemoWorkspaceResult>;
   /** Batch create/update applications. Items with id → update, without → create. */
   batchUpsertApplications(userId: string, items: BatchUpsertItem[]): Promise<BatchUpsertResult>;
   /** Batch delete applications by IDs. */
@@ -82,13 +91,13 @@ export interface DatabaseAdapter {
   listDocumentsByApplication(applicationId: string, userId: string): Promise<DocumentRecord[]>;
   getDocument(id: string, userId: string | null): Promise<DocumentRecord | null>;
   createDocument(userId: string, data: CreateDocumentInput): Promise<DocumentRecord>;
-  updateDocumentMetadata(id: string, userId: string, data: UpdateDocumentMetadataInput): Promise<DocumentRecord>;
+  updateDocumentMetadata(id: string, userId: string, data: UpdateDocumentMetadataInput, options?: DocumentMutationOptions): Promise<DocumentRecord>;
   /** Replace the set of linked application IDs on a document. */
-  updateDocumentLinks(id: string, userId: string, applicationIds: string[]): Promise<DocumentRecord>;
+  updateDocumentLinks(id: string, userId: string, applicationIds: string[], options?: DocumentMutationOptions): Promise<DocumentRecord>;
   /** Rename the user-facing original name of a document. */
   renameDocument(id: string, userId: string, newName: string): Promise<DocumentRecord | null>;
   /** Delete document record. Returns the record (for filename cleanup) or null. */
-  deleteDocument(id: string, userId: string): Promise<DocumentRecord | null>;
+  deleteDocument(id: string, userId: string, options?: DocumentMutationOptions): Promise<DocumentRecord | null>;
 
   // ── Users ────────────────────────────────────────────────────────────────
   getUser(id: string): Promise<UserRecord | null>;

--- a/lib/db/firestore-adapter.ts
+++ b/lib/db/firestore-adapter.ts
@@ -498,6 +498,9 @@ export class FirestoreAdapter implements DatabaseAdapter {
       const applicationCount = workspaceData.state === "deleting"
         ? workspaceData.deletionApplicationCount
         : currentApplicationIds.length;
+      // Persist the preparation-time count so retries return one stable best-effort
+      // value. Events racing preparation are still cleaned up below, but are not
+      // retroactively included in the public deletion count.
       const eventCount = workspaceData.state === "deleting"
         ? workspaceData.deletionEventCount
         : events.docs.length;
@@ -534,6 +537,23 @@ export class FirestoreAdapter implements DatabaseAdapter {
     // CV patches, canonical indexes and every application event are handled consistently.
     for (const application of prepared.applications) {
       await this.deleteApplicationCascade(application.id, userId);
+    }
+
+    // An event can commit after a cascade has read its event snapshot but before the
+    // application is removed. No new event can pass the parent transaction once all
+    // applications are gone, so sweep those late arrivals without changing the stable
+    // preparation-time count returned to callers.
+    const lateEvents = await this.events.where("demoWorkspaceId", "==", workspaceId).get();
+    for (const document of lateEvents.docs) {
+      const data = document.data();
+      if (data.userId !== userId || data.isDemo !== true || data.demoWorkspaceId !== workspaceId) {
+        throw new Error("demo_marker_conflict");
+      }
+    }
+    for (let offset = 0; offset < lateEvents.docs.length; offset += 450) {
+      const batch = this.db.batch();
+      for (const document of lateEvents.docs.slice(offset, offset + 450)) batch.delete(document.ref);
+      await batch.commit();
     }
 
     const remnants: FirebaseFirestore.QuerySnapshot[] = await Promise.all([
@@ -1932,7 +1952,7 @@ export class FirestoreAdapter implements DatabaseAdapter {
     return (await this.getDocument(id, userId))!;
   }
 
-  async createDocument(userId: string, data: CreateDocumentInput): Promise<DocumentRecord> {
+  async createDocument(userId: string, data: CreateDocumentInput, options?: DocumentMutationOptions): Promise<DocumentRecord> {
     const { applicationIds, submissionId, ...rest } = data;
     if (submissionId || rest.state === "submitted") throw new Error("submitted_state_reserved");
     const uniqueApplicationIds = Array.from(new Set(applicationIds));
@@ -1952,6 +1972,7 @@ export class FirestoreAdapter implements DatabaseAdapter {
         !snapshot.exists
         || snapshot.data()!.userId !== userId
         || snapshot.data()!.deletionState === "in_progress"
+        || (options?.requireNonDemoProvenance && snapshot.data()!.isDemo === true)
       )) {
         throw new Error("invalid_applications");
       }

--- a/lib/db/firestore-adapter.ts
+++ b/lib/db/firestore-adapter.ts
@@ -53,7 +53,12 @@ import type {
   ApplicationEventPage,
   ListDocumentsFilter,
   UpdateDocumentMetadataInput,
+  DocumentMutationOptions,
+  DemoReadOptions,
+  EnsureDemoWorkspaceResult,
+  DeleteDemoWorkspaceResult,
 } from "./types";
+import type { DemoFixtures } from "@/lib/demo-workspace/fixtures";
 
 // ── Firestore init ──────────────────────────────────────────────────────────
 
@@ -123,6 +128,9 @@ function mapApp(id: string, data: FirebaseFirestore.DocumentData): ApplicationRe
     jobLiveness: data.jobLiveness ?? null,
     jobSummary: data.jobSummary ?? null,
     currentStage: data.currentStage ?? null,
+    isDemo: data.isDemo === true,
+    demoWorkspaceId: data.demoWorkspaceId ?? null,
+    demoKey: data.demoKey ?? null,
     createdAt: toDate(data.createdAt) ?? new Date(),
     updatedAt: toDate(data.updatedAt) ?? new Date(),
     contacts: data._contacts,
@@ -159,6 +167,7 @@ function mapDoc(id: string, data: FirebaseFirestore.DocumentData): DocumentRecor
     submittedAt: toDate(data.submittedAt),
     submissionId: data.submissionId ?? null,
     uploadedAt: toDate(data.uploadedAt) ?? new Date(),
+    applicationIds: Array.isArray(data.applicationIds) ? data.applicationIds : [],
     applications: data._applications,
   };
 }
@@ -214,6 +223,9 @@ function mapEvent(id: string, data: FirebaseFirestore.DocumentData): Application
     outcome: data.outcome ?? null,
     metadata: publicEventMetadata(data.metadata),
     createdAt: toDate(data.createdAt) ?? new Date(),
+    isDemo: data.isDemo === true,
+    demoWorkspaceId: data.demoWorkspaceId ?? null,
+    demoKey: data.demoKey ?? null,
     application: data._application,
   };
 }
@@ -242,6 +254,61 @@ function structuredMetadataForFirestore(data: Record<string, unknown>): Record<s
   return result;
 }
 
+function isDemoVisible(data: FirebaseFirestore.DocumentData, options?: DemoReadOptions): boolean {
+  const isDemo = data.isDemo === true;
+  if (options?.demoVisibility === "exclude") return !isDemo;
+  if (options?.demoVisibility === "only") return isDemo;
+  return true;
+}
+
+function firestoreEventDemoData(
+  application: FirebaseFirestore.DocumentData,
+  stableKey: string,
+): { isDemo: boolean; demoWorkspaceId: string | null; demoKey: string | null } {
+  const complete = application.isDemo === true
+    && typeof application.demoWorkspaceId === "string"
+    && typeof application.demoKey === "string";
+  const empty = application.isDemo !== true
+    && application.demoWorkspaceId == null
+    && application.demoKey == null;
+  if (!complete && !empty) throw new Error("demo_marker_conflict");
+  return complete
+    ? {
+        isDemo: true,
+        demoWorkspaceId: application.demoWorkspaceId,
+        demoKey: `${application.demoKey}:event:${stableKey}`,
+      }
+    : { isDemo: false, demoWorkspaceId: null, demoKey: null };
+}
+
+function assertFirestoreEventMatchesParent(
+  event: FirebaseFirestore.DocumentData,
+  application: FirebaseFirestore.DocumentData,
+): void {
+  const expected = firestoreEventDemoData(application, "replay");
+  if (
+    (event.isDemo === true) !== expected.isDemo
+    || (event.demoWorkspaceId ?? null) !== expected.demoWorkspaceId
+    || (expected.isDemo && (typeof event.demoKey !== "string" || event.demoKey.length === 0))
+    || (!expected.isDemo && event.demoKey != null)
+  ) throw new Error("demo_marker_conflict");
+}
+
+function isFirestoreEventVisibleWithParent(
+  event: FirebaseFirestore.DocumentData,
+  application: FirebaseFirestore.DocumentData | undefined,
+  userId: string,
+  options?: DemoReadOptions,
+): boolean {
+  if (!application || application.userId !== userId || !isDemoVisible(application, options)) return false;
+  try {
+    assertFirestoreEventMatchesParent(event, application);
+    return isDemoVisible(event, options);
+  } catch {
+    return false;
+  }
+}
+
 // ── Implementation ──────────────────────────────────────────────────────────
 
 export class FirestoreAdapter implements DatabaseAdapter {
@@ -251,19 +318,272 @@ export class FirestoreAdapter implements DatabaseAdapter {
   private get docs() { return this.db.collection("documents"); }
   private get submissions() { return this.db.collection("applicationSubmissions"); }
   private get events() { return this.db.collection("applicationEvents"); }
+  private get demoWorkspaces() { return this.db.collection("demoWorkspaces"); }
+  private get ownerLifecycles() { return this.db.collection("ownerApplicationLifecycles"); }
   private get canonicalUrls() { return this.db.collection("applicationCanonicalUrls"); }
 
   private canonicalUrlRef(userId: string, canonicalJobUrl: string) {
     return this.canonicalUrls.doc(submissionRequestHash({ userId, canonicalJobUrl }));
   }
 
+  private ownerLifecycleRef(userId: string) {
+    return this.ownerLifecycles.doc(submissionRequestHash({ kind: "application-owner", userId }));
+  }
+
+  async ensureDemoWorkspace(
+    userId: string,
+    fixtures: DemoFixtures,
+  ): Promise<EnsureDemoWorkspaceResult> {
+    const workspaceId = submissionRequestHash({ kind: "demo-workspace", userId });
+    const workspaceRef = this.demoWorkspaces.doc(workspaceId);
+    const lifecycleRef = this.ownerLifecycleRef(userId);
+    let replayed = false;
+    await this.db.runTransaction(async (transaction) => {
+      const [existing, lifecycle] = await Promise.all([
+        transaction.get(workspaceRef),
+        transaction.get(lifecycleRef),
+      ]);
+      if (lifecycle.exists && lifecycle.data()!.userId !== userId) throw new Error("demo_marker_conflict");
+      if (existing.exists) {
+        const data = existing.data()!;
+        if (data.userId !== userId) throw new Error("not_found");
+        if (data.seedVersion !== fixtures.seedVersion) throw new Error("demo_version_conflict");
+        if (data.state !== "ready") throw new Error("demo_workspace_unavailable");
+        const [applications, events] = await Promise.all([
+          transaction.get(this.apps.where("demoWorkspaceId", "==", workspaceId)),
+          transaction.get(this.events.where("demoWorkspaceId", "==", workspaceId)),
+        ]);
+        const applicationKeys = applications.docs.map((document) => {
+          const row = document.data();
+          if (row.userId !== userId || row.isDemo !== true || row.demoWorkspaceId !== workspaceId) {
+            throw new Error("demo_marker_conflict");
+          }
+          return row.demoKey;
+        }).sort();
+        const eventKeys = events.docs.map((document) => {
+          const row = document.data();
+          if (row.userId !== userId || row.isDemo !== true || row.demoWorkspaceId !== workspaceId) {
+            throw new Error("demo_marker_conflict");
+          }
+          return row.demoKey;
+        }).sort();
+        if (
+          JSON.stringify(applicationKeys) !== JSON.stringify(fixtures.applications.map((fixture) => fixture.demoKey).sort())
+          || !fixtures.events.every((fixture) => eventKeys.includes(fixture.demoKey))
+        ) throw new Error("demo_workspace_incomplete");
+        transaction.set(lifecycleRef, { userId, mode: "demo", workspaceId, updatedAt: Timestamp.now() });
+        replayed = true;
+        return;
+      }
+      const realApplications = await transaction.get(
+        this.apps.where("userId", "==", userId).where("isDemo", "==", false),
+      );
+      const legacyApplications = await transaction.get(this.apps.where("userId", "==", userId));
+      if (
+        !realApplications.empty ||
+        legacyApplications.docs.some((document) => document.data().isDemo !== true)
+      ) {
+        throw new Error("real_applications_exist");
+      }
+
+      const createdAt = toTimestamp(fixtures.createdAt);
+      transaction.create(workspaceRef, {
+        userId,
+        seedVersion: fixtures.seedVersion,
+        state: "ready",
+        createdAt,
+        updatedAt: createdAt,
+      });
+      transaction.set(lifecycleRef, { userId, mode: "demo", workspaceId, updatedAt: createdAt });
+      const appIds = new Map<string, string>();
+      for (const fixture of fixtures.applications) {
+        const id = submissionRequestHash({ workspaceId, demoKey: fixture.demoKey });
+        appIds.set(fixture.demoKey, id);
+        transaction.create(this.apps.doc(id), {
+          userId,
+          company: fixture.company,
+          role: fixture.role,
+          status: fixture.status,
+          appliedAt: toTimestamp(fixture.appliedAt),
+          lastContact: toTimestamp(fixture.lastContact),
+          followUpAt: toTimestamp(fixture.followUpAt),
+          notes: fixture.notes,
+          jobDescription: null,
+          source: fixture.source,
+          remote: fixture.remote,
+          salaryMin: fixture.salaryMin,
+          salaryMax: fixture.salaryMax,
+          rating: fixture.rating,
+          jobUrl: null,
+          isDemo: true,
+          demoWorkspaceId: workspaceId,
+          demoKey: fixture.demoKey,
+          createdAt,
+          updatedAt: createdAt,
+        });
+      }
+      for (const fixture of fixtures.events) {
+        const applicationId = appIds.get(fixture.applicationDemoKey);
+        if (!applicationId) throw new Error("demo_fixture_invalid");
+        const id = submissionRequestHash({ workspaceId, demoEventKey: fixture.demoKey });
+        transaction.create(this.events.doc(id), {
+          userId,
+          applicationId,
+          type: fixture.type,
+          idempotencyKey: null,
+          occurredAt: toTimestamp(fixture.occurredAt),
+          source: fixture.source,
+          actor: fixture.actor,
+          metadata: fixture.metadata,
+          isDemo: true,
+          demoWorkspaceId: workspaceId,
+          demoKey: fixture.demoKey,
+          createdAt,
+        });
+      }
+    });
+
+    const workspace = await workspaceRef.get();
+    if (!workspace.exists) throw new Error("demo_workspace_incomplete");
+    const data = workspace.data()!;
+    const applications = await this.listApplications(userId, { demoVisibility: "only" });
+    return {
+      workspace: {
+        id: workspaceId,
+        userId,
+        seedVersion: data.seedVersion,
+        state: data.state,
+        createdAt: toDate(data.createdAt) ?? fixtures.createdAt,
+        updatedAt: toDate(data.updatedAt) ?? fixtures.createdAt,
+      },
+      applications,
+      replayed,
+    };
+  }
+
+  async deleteDemoWorkspace(userId: string): Promise<DeleteDemoWorkspaceResult> {
+    const workspaceId = submissionRequestHash({ kind: "demo-workspace", userId });
+    const workspaceRef = this.demoWorkspaces.doc(workspaceId);
+    const lifecycleRef = this.ownerLifecycleRef(userId);
+    const prepared = await this.db.runTransaction(async (transaction) => {
+      const [workspace, lifecycle, applications, events] = await Promise.all([
+        transaction.get(workspaceRef),
+        transaction.get(lifecycleRef),
+        transaction.get(this.apps.where("demoWorkspaceId", "==", workspaceId)),
+        transaction.get(this.events.where("demoWorkspaceId", "==", workspaceId)),
+      ]);
+      if (!workspace.exists) return null;
+      const workspaceData = workspace.data()!;
+      if (workspaceData.userId !== userId) throw new Error("not_found");
+      if (workspaceData.state === "creating") throw new Error("demo_workspace_unavailable");
+      if (lifecycle.exists && (lifecycle.data()!.userId !== userId || lifecycle.data()!.workspaceId !== workspaceId)) {
+        throw new Error("demo_marker_conflict");
+      }
+      for (const document of applications.docs) {
+        const data = document.data();
+        if (data.userId !== userId || data.isDemo !== true || data.demoWorkspaceId !== workspaceId || typeof data.demoKey !== "string") {
+          throw new Error("demo_marker_conflict");
+        }
+      }
+      for (const document of events.docs) {
+        const data = document.data();
+        if (data.userId !== userId || data.isDemo !== true || data.demoWorkspaceId !== workspaceId || typeof data.demoKey !== "string") {
+          throw new Error("demo_marker_conflict");
+        }
+      }
+      const currentApplicationIds = applications.docs.map((document) => document.id);
+      const applicationIds = workspaceData.state === "deleting"
+        ? workspaceData.deletionApplicationIds
+        : currentApplicationIds;
+      const applicationCount = workspaceData.state === "deleting"
+        ? workspaceData.deletionApplicationCount
+        : currentApplicationIds.length;
+      const eventCount = workspaceData.state === "deleting"
+        ? workspaceData.deletionEventCount
+        : events.docs.length;
+      if (
+        !Array.isArray(applicationIds)
+        || applicationIds.some((id) => typeof id !== "string")
+        || typeof applicationCount !== "number"
+        || applicationCount !== applicationIds.length
+        || typeof eventCount !== "number"
+        || currentApplicationIds.some((id) => !applicationIds.includes(id))
+      ) throw new Error("demo_deletion_incomplete");
+      const deletionMetadata = {
+        deletionApplicationIds: applicationIds,
+        deletionApplicationCount: applicationCount,
+        deletionEventCount: eventCount,
+      };
+      transaction.update(workspaceRef, {
+        state: "deleting",
+        ...deletionMetadata,
+        updatedAt: FieldValue.serverTimestamp(),
+      });
+      transaction.set(lifecycleRef, {
+        userId,
+        mode: "deleting",
+        workspaceId,
+        ...deletionMetadata,
+        updatedAt: FieldValue.serverTimestamp(),
+      });
+      return { applications: applications.docs, applicationIds, applicationCount, eventCount };
+    });
+    if (!prepared) return { deletedApplications: 0, deletedEvents: 0 };
+
+    // Reuse the retryable application cascade so contacts, submissions, document links,
+    // CV patches, canonical indexes and every application event are handled consistently.
+    for (const application of prepared.applications) {
+      await this.deleteApplicationCascade(application.id, userId);
+    }
+
+    const remnants: FirebaseFirestore.QuerySnapshot[] = await Promise.all([
+      this.apps.where("demoWorkspaceId", "==", workspaceId).get(),
+      this.events.where("demoWorkspaceId", "==", workspaceId).get(),
+      ...prepared.applicationIds.flatMap((applicationId) => [
+        this.contacts.where("applicationId", "==", applicationId).get(),
+        this.submissions.where("applicationId", "==", applicationId).get(),
+        this.events.where("applicationId", "==", applicationId).get(),
+        this.docs.where("applicationIds", "array-contains", applicationId).get(),
+        this.canonicalUrls.where("applicationId", "==", applicationId).get(),
+      ]),
+    ]);
+    const patchRemnants = await Promise.all(
+      prepared.applicationIds.map((applicationId) => this.db.collection("cvPatches").doc(applicationId).get()),
+    );
+    if (remnants.some((snapshot) => !snapshot.empty) || patchRemnants.some((snapshot) => snapshot.exists)) {
+      throw new Error("demo_deletion_incomplete");
+    }
+    await this.db.runTransaction(async (transaction) => {
+      const [workspace, lifecycle] = await Promise.all([
+        transaction.get(workspaceRef),
+        transaction.get(lifecycleRef),
+      ]);
+      if (!workspace.exists) return;
+      if (
+        workspace.data()!.userId !== userId
+        || workspace.data()!.state !== "deleting"
+        || !lifecycle.exists
+        || lifecycle.data()!.userId !== userId
+        || lifecycle.data()!.mode !== "deleting"
+        || JSON.stringify(workspace.data()!.deletionApplicationIds) !== JSON.stringify(prepared.applicationIds)
+        || workspace.data()!.deletionApplicationCount !== prepared.applicationCount
+        || workspace.data()!.deletionEventCount !== prepared.eventCount
+      ) throw new Error("demo_deletion_incomplete");
+      transaction.delete(workspaceRef);
+      transaction.delete(lifecycleRef);
+    });
+    return { deletedApplications: prepared.applicationCount, deletedEvents: prepared.eventCount };
+  }
+
   // ── Applications ────────────────────────────────────────────────────────
 
-  async listApplications(userId: string | null): Promise<ApplicationRecord[]> {
+  async listApplications(userId: string | null, options?: DemoReadOptions): Promise<ApplicationRecord[]> {
     let q: FirebaseFirestore.Query = this.apps.orderBy("createdAt", "desc");
     if (userId !== null) q = q.where("userId", "==", userId);
     const snap = await q.get();
-    const applications = snap.docs.map((d) => mapApp(d.id, d.data()));
+    const applications = snap.docs
+      .filter((document) => isDemoVisible(document.data(), options))
+      .map((document) => mapApp(document.id, document.data()));
 
     // Batch-load contacts for all applications
     const appIds = applications.map((a) => a.id);
@@ -278,7 +598,8 @@ export class FirestoreAdapter implements DatabaseAdapter {
 
   async listApplicationsPaginated(
     userId: string | null,
-    params: PaginationParams
+    params: PaginationParams,
+    options?: DemoReadOptions,
   ): Promise<PaginatedResult<ApplicationRecord>> {
     const page = Math.max(1, params.page ?? 1);
     const pageSize = Math.max(1, Math.min(100, params.pageSize ?? 10));
@@ -288,11 +609,12 @@ export class FirestoreAdapter implements DatabaseAdapter {
     if (userId !== null) q = q.where("userId", "==", userId);
 
     const snap = await q.get();
-    const total = snap.docs.length;
+    const visibleDocs = snap.docs.filter((document) => isDemoVisible(document.data(), options));
+    const total = visibleDocs.length;
     const totalPages = Math.ceil(total / pageSize);
 
     const start = (page - 1) * pageSize;
-    const pageDocs = snap.docs.slice(start, start + pageSize);
+    const pageDocs = visibleDocs.slice(start, start + pageSize);
     const applications = pageDocs.map((d) => mapApp(d.id, d.data()));
 
     // Batch-load contacts for the page
@@ -307,11 +629,12 @@ export class FirestoreAdapter implements DatabaseAdapter {
     return { data: applications, total, page, pageSize, totalPages };
   }
 
-  async getApplication(id: string, userId: string | null): Promise<ApplicationRecord | null> {
+  async getApplication(id: string, userId: string | null, options?: DemoReadOptions): Promise<ApplicationRecord | null> {
     const doc = await this.apps.doc(id).get();
     if (!doc.exists) return null;
     const data = doc.data()!;
     if (userId !== null && data.userId !== userId) return null;
+    if (!isDemoVisible(data, options)) return null;
 
     const app = mapApp(id, data);
     // Load contacts
@@ -348,11 +671,24 @@ export class FirestoreAdapter implements DatabaseAdapter {
       incomingSource: data.incomingSource ?? null,
       autoRejected: data.autoRejected ?? false,
       autoRejectReason: data.autoRejectReason ?? null,
+      isDemo: false,
+      demoWorkspaceId: null,
+      demoKey: null,
       ...structuredMetadataForFirestore(data as unknown as Record<string, unknown>),
       createdAt: now,
       updatedAt: now,
     };
     await this.db.runTransaction(async (transaction) => {
+      const lifecycleRef = this.ownerLifecycleRef(userId);
+      const workspaceRef = this.demoWorkspaces.doc(submissionRequestHash({ kind: "demo-workspace", userId }));
+      const [lifecycle, workspace] = await Promise.all([
+        transaction.get(lifecycleRef),
+        transaction.get(workspaceRef),
+      ]);
+      if (lifecycle.exists && lifecycle.data()!.userId !== userId) throw new Error("demo_marker_conflict");
+      if (workspace.exists || (lifecycle.exists && lifecycle.data()!.mode !== "real")) {
+        throw new Error("demo_workspace_exists");
+      }
       if (data.canonicalJobUrl) {
         const indexReference = this.canonicalUrlRef(userId, data.canonicalJobUrl);
         const duplicate = await transaction.get(indexReference);
@@ -364,6 +700,7 @@ export class FirestoreAdapter implements DatabaseAdapter {
           createdAt: now,
         });
       }
+      transaction.set(lifecycleRef, { userId, mode: "real", updatedAt: now });
       transaction.create(reference, payload);
     });
     const app = mapApp(reference.id, payload);
@@ -538,14 +875,14 @@ export class FirestoreAdapter implements DatabaseAdapter {
   async findApplicationByCanonicalJobUrl(
     userId: string,
     canonicalJobUrl: string,
+    options?: DemoReadOptions,
   ): Promise<ApplicationRecord | null> {
     const snapshot = await this.apps
       .where("userId", "==", userId)
       .where("canonicalJobUrl", "==", canonicalJobUrl)
-      .limit(1)
       .get();
-    if (snapshot.empty) return null;
-    const document = snapshot.docs[0];
+    const document = snapshot.docs.find((candidate) => isDemoVisible(candidate.data(), options));
+    if (!document) return null;
     return mapApp(document.id, document.data());
   }
 
@@ -571,6 +908,7 @@ export class FirestoreAdapter implements DatabaseAdapter {
       if (appSnapshot.data()!.deletionState === "in_progress") throw new Error("application_deleting");
       if (eventSnapshot.exists) {
         if (eventSnapshot.data()!.requestHash !== requestHash) throw new Error("idempotency_conflict");
+        assertFirestoreEventMatchesParent(eventSnapshot.data()!, appSnapshot.data()!);
         return { appData: appSnapshot.data()!, eventData: eventSnapshot.data()! };
       }
       if (eventInput.expectedUpdatedAt) {
@@ -594,6 +932,7 @@ export class FirestoreAdapter implements DatabaseAdapter {
         actor: eventInput.actor ?? null,
         metadata: eventInput.metadata ?? {},
         createdAt: now,
+        ...firestoreEventDemoData(appSnapshot.data()!, requestHash),
       };
       transaction.update(appRef, { notes, updatedAt: now });
       transaction.create(eventRef, eventData);
@@ -652,6 +991,7 @@ export class FirestoreAdapter implements DatabaseAdapter {
       const appSnapshot = await transaction.get(appRef);
       if (!appSnapshot.exists || appSnapshot.data()!.userId !== userId) throw new Error("not_found");
       const appData = appSnapshot.data()!;
+      firestoreEventDemoData(appData, normalizedRequestHash);
       if (appData.deletionState === "in_progress") throw new Error("application_deleting");
       if (input.expectedUpdatedAt) {
         const updatedAt = toDate(appData.updatedAt);
@@ -749,6 +1089,7 @@ export class FirestoreAdapter implements DatabaseAdapter {
           policy,
         },
         createdAt: now,
+        ...firestoreEventDemoData(appData, normalizedRequestHash),
       };
       transaction.create(submissionRef, submissionData);
       transaction.create(this.events.doc(eventId), eventData);
@@ -804,6 +1145,7 @@ export class FirestoreAdapter implements DatabaseAdapter {
       this.events.doc(eventId).get(),
     ]);
     if (!application || !submission) throw new Error("verification_failed");
+    if (event.exists) assertFirestoreEventMatchesParent(event.data()!, application);
     const documents = await Promise.all(
       submission.documentIds.map(async (documentId) => {
         const document = await this.getDocument(documentId, userId);
@@ -911,6 +1253,7 @@ export class FirestoreAdapter implements DatabaseAdapter {
         if (!input.idempotencyKey || existing.data()!.userId !== userId || existing.data()!.requestHash !== requestHash) {
           throw new Error("idempotency_conflict");
         }
+        assertFirestoreEventMatchesParent(existing.data()!, application.data()!);
         return existing.data()!;
       }
       const data = {
@@ -924,6 +1267,7 @@ export class FirestoreAdapter implements DatabaseAdapter {
         actor: input.actor ?? null,
         metadata: input.metadata ?? {},
         createdAt: Timestamp.now(),
+        ...firestoreEventDemoData(application.data()!, requestHash),
       };
       transaction.create(eventRef, data);
       return data;
@@ -977,6 +1321,7 @@ export class FirestoreAdapter implements DatabaseAdapter {
           || typeof persistedRequestHash !== "string"
           || !acceptedRequestHashes.has(persistedRequestHash)
         ) throw new Error("idempotency_conflict");
+        assertFirestoreEventMatchesParent(existingData, applicationData);
         return { replayed: true, eventData: existingData };
       }
       const metadataInput = input.metadata ?? {};
@@ -1041,6 +1386,7 @@ export class FirestoreAdapter implements DatabaseAdapter {
         outcome: input.outcome ?? null,
         metadata,
         createdAt: Timestamp.now(),
+        ...firestoreEventDemoData(applicationData, requestHash),
       };
       transaction.create(eventRef, eventData);
       return { replayed: false, eventData };
@@ -1060,6 +1406,7 @@ export class FirestoreAdapter implements DatabaseAdapter {
   async listApplicationEventsFiltered(
     userId: string,
     filter: ListApplicationEventsFilter,
+    options?: DemoReadOptions,
   ): Promise<ApplicationEventPage> {
     const direction = filter.order === "oldest" ? "asc" : "desc";
     let query: FirebaseFirestore.Query = this.events.where("userId", "==", userId);
@@ -1107,21 +1454,30 @@ export class FirestoreAdapter implements DatabaseAdapter {
         document,
         event: mapEvent(document.id, document.data()),
       }));
-      const appMap = await this.loadVerifiedAppRefs([
+      const parentMap = await this.loadVerifiedEventParents([
         ...new Set(scannedEvents.map(({ event }) => event.applicationId)),
       ], userId);
-      for (const { event } of scannedEvents) event.application = appMap.get(event.applicationId);
-      matchingEvents.push(...scannedEvents.filter(({ event }) =>
-        (!filter.applicationId || event.applicationId === filter.applicationId)
-        && (!filter.company || event.application?.company.toLocaleLowerCase().includes(filter.company.toLocaleLowerCase()))
-        && (!filter.types?.length || filter.types.includes(event.type))
-        && (!filter.occurredAfter || event.occurredAt >= filter.occurredAfter)
-        && (!filter.occurredBefore || event.occurredAt <= filter.occurredBefore)
-        && (!filter.source || event.source === filter.source)
-        && (!filter.actor || event.actor === filter.actor)
-        && (!filter.contactId || event.contactId === filter.contactId)
-        && (!filter.outcome || event.outcome === filter.outcome)
-      ));
+      for (const candidate of scannedEvents) {
+        const parent = parentMap.get(candidate.event.applicationId);
+        if (!isFirestoreEventVisibleWithParent(
+          candidate.document.data(),
+          parent?.data,
+          userId,
+          options,
+        )) continue;
+        candidate.event.application = parent?.summary;
+        if (
+          (!filter.applicationId || candidate.event.applicationId === filter.applicationId)
+          && (!filter.company || candidate.event.application?.company.toLocaleLowerCase().includes(filter.company.toLocaleLowerCase()))
+          && (!filter.types?.length || filter.types.includes(candidate.event.type))
+          && (!filter.occurredAfter || candidate.event.occurredAt >= filter.occurredAfter)
+          && (!filter.occurredBefore || candidate.event.occurredAt <= filter.occurredBefore)
+          && (!filter.source || candidate.event.source === filter.source)
+          && (!filter.actor || candidate.event.actor === filter.actor)
+          && (!filter.contactId || candidate.event.contactId === filter.contactId)
+          && (!filter.outcome || candidate.event.outcome === filter.outcome)
+        ) matchingEvents.push(candidate);
+      }
       if (matchingEvents.length > filter.limit || snapshot.docs.length < scanLimit) break;
       const lastDocument = snapshot.docs.at(-1)!;
       const lastEvent = mapEvent(lastDocument.id, lastDocument.data());
@@ -1154,23 +1510,43 @@ export class FirestoreAdapter implements DatabaseAdapter {
     applicationId: string,
     userId: string,
     limit = 100,
+    options?: DemoReadOptions,
   ): Promise<ApplicationEventRecord[]> {
-    const application = await this.getApplication(applicationId, userId);
-    if (!application) throw new Error("not_found");
+    const application = await this.apps.doc(applicationId).get();
+    if (
+      !application.exists
+      || application.data()!.userId !== userId
+      || !isDemoVisible(application.data()!, options)
+    ) throw new Error("not_found");
+    const applicationData = application.data()!;
     const queryLimit = Math.max(1, Math.min(500, limit));
-    const snapshot = await this.events
+    let query = this.events
       .where("applicationId", "==", applicationId)
       .where("userId", "==", userId)
       .orderBy("occurredAt", "desc")
-      .orderBy(FieldPath.documentId(), "desc")
-      .limit(queryLimit)
-      .get();
-    return snapshot.docs.map((document) => mapEvent(document.id, document.data()));
+      .orderBy(FieldPath.documentId(), "desc");
+    const visibleEvents: ApplicationEventRecord[] = [];
+    while (visibleEvents.length < queryLimit) {
+      const remaining = queryLimit - visibleEvents.length;
+      const snapshot = await query.limit(remaining).get();
+      if (!snapshot.docs.length) break;
+      for (const document of snapshot.docs) {
+        if (isFirestoreEventVisibleWithParent(document.data(), applicationData, userId, options)) {
+          visibleEvents.push(mapEvent(document.id, document.data()));
+        }
+      }
+      if (snapshot.docs.length < remaining) break;
+      const lastDocument = snapshot.docs.at(-1)!;
+      const lastEvent = mapEvent(lastDocument.id, lastDocument.data());
+      query = query.startAfter(Timestamp.fromDate(lastEvent.occurredAt), lastEvent.id);
+    }
+    return visibleEvents;
   }
 
   async listApplicationsFiltered(
     userId: string | null,
-    filter: ListApplicationsFilter
+    filter: ListApplicationsFilter,
+    options?: DemoReadOptions,
   ): Promise<Partial<ApplicationRecord>[]> {
     // Firestore has limited query capabilities, so we fetch and filter in memory
     let q: FirebaseFirestore.Query = this.apps.orderBy("createdAt", "desc");
@@ -1183,7 +1559,9 @@ export class FirestoreAdapter implements DatabaseAdapter {
     }
 
     const snap = await q.get();
-    let apps = snap.docs.map((d) => mapApp(d.id, d.data()));
+    let apps = snap.docs
+      .filter((document) => isDemoVisible(document.data(), options))
+      .map((document) => mapApp(document.id, document.data()));
 
     // In-memory filters for capabilities Firestore doesn't support natively
     if (filter.status && filter.status.length > 1) {
@@ -1508,6 +1886,7 @@ export class FirestoreAdapter implements DatabaseAdapter {
     id: string,
     userId: string,
     data: UpdateDocumentMetadataInput,
+    options?: DocumentMutationOptions,
   ): Promise<DocumentRecord> {
     const reference = this.docs.doc(id);
     const update: Record<string, unknown> = {};
@@ -1521,6 +1900,20 @@ export class FirestoreAdapter implements DatabaseAdapter {
     await this.db.runTransaction(async (transaction) => {
       const existing = await transaction.get(reference);
       if (!existing.exists || existing.data()!.userId !== userId) throw new Error("not_found");
+      const currentApplicationIds = Array.isArray(existing.data()!.applicationIds)
+        ? Array.from(new Set(existing.data()!.applicationIds as string[]))
+        : [];
+      if (options?.requireNonDemoProvenance && currentApplicationIds.length > 0) {
+        const applications = await Promise.all(
+          currentApplicationIds.map((applicationId) => transaction.get(this.apps.doc(applicationId))),
+        );
+        if (!applications.some((application) =>
+          application.exists
+          && application.data()!.userId === userId
+          && application.data()!.isDemo !== true
+          && application.data()!.deletionState !== "in_progress"
+        )) throw new Error("not_found");
+      }
       const submissionId = existing.data()!.submissionId;
       const keys = Object.keys(data);
       const stateOnly = keys.every((key) => key === "state");
@@ -1574,13 +1967,27 @@ export class FirestoreAdapter implements DatabaseAdapter {
     return record;
   }
 
-  async updateDocumentLinks(id: string, userId: string, applicationIds: string[]): Promise<DocumentRecord> {
+  async updateDocumentLinks(id: string, userId: string, applicationIds: string[], options?: DocumentMutationOptions): Promise<DocumentRecord> {
     const reference = this.docs.doc(id);
     const uniqueApplicationIds = Array.from(new Set(applicationIds));
     const applicationReferences = uniqueApplicationIds.map((applicationId) => this.apps.doc(applicationId));
     await this.db.runTransaction(async (transaction) => {
       const existing = await transaction.get(reference);
       if (!existing.exists || existing.data()!.userId !== userId) throw new Error("not_found");
+      const currentApplicationIds = Array.isArray(existing.data()!.applicationIds)
+        ? Array.from(new Set(existing.data()!.applicationIds as string[]))
+        : [];
+      if (options?.requireNonDemoProvenance && currentApplicationIds.length > 0) {
+        const currentApplications = await Promise.all(
+          currentApplicationIds.map((applicationId) => transaction.get(this.apps.doc(applicationId))),
+        );
+        if (!currentApplications.some((application) =>
+          application.exists
+          && application.data()!.userId === userId
+          && application.data()!.isDemo !== true
+          && application.data()!.deletionState !== "in_progress"
+        )) throw new Error("not_found");
+      }
       if (
         existing.data()!.submissionId
         || existing.data()!.state === "submitted"
@@ -1593,6 +2000,7 @@ export class FirestoreAdapter implements DatabaseAdapter {
         !snapshot.exists
         || snapshot.data()!.userId !== userId
         || snapshot.data()!.deletionState === "in_progress"
+        || (options?.requireNonDemoProvenance && snapshot.data()!.isDemo === true)
       )) {
         throw new Error("invalid_applications");
       }
@@ -1617,11 +2025,25 @@ export class FirestoreAdapter implements DatabaseAdapter {
     return changed ? this.getDocument(id, userId) : null;
   }
 
-  async deleteDocument(id: string, userId: string): Promise<DocumentRecord | null> {
+  async deleteDocument(id: string, userId: string, options?: DocumentMutationOptions): Promise<DocumentRecord | null> {
     const reference = this.docs.doc(id);
     const document = await this.db.runTransaction(async (transaction) => {
       const existing = await transaction.get(reference);
       if (!existing.exists || existing.data()!.userId !== userId) return null;
+      const currentApplicationIds = Array.isArray(existing.data()!.applicationIds)
+        ? Array.from(new Set(existing.data()!.applicationIds as string[]))
+        : [];
+      if (options?.requireNonDemoProvenance && currentApplicationIds.length > 0) {
+        const applications = await Promise.all(
+          currentApplicationIds.map((applicationId) => transaction.get(this.apps.doc(applicationId))),
+        );
+        if (!applications.some((application) =>
+          application.exists
+          && application.data()!.userId === userId
+          && application.data()!.isDemo !== true
+          && application.data()!.deletionState !== "in_progress"
+        )) throw new Error("not_found");
+      }
       if (
         existing.data()!.submissionId
         || existing.data()!.state === "submitted"
@@ -1807,6 +2229,33 @@ export class FirestoreAdapter implements DatabaseAdapter {
             map.set(snap.id, { id: snap.id, company: d.company, role: d.role });
           }
         }
+      }
+    }
+    return map;
+  }
+
+  private async loadVerifiedEventParents(
+    ids: string[],
+    userId: string,
+  ): Promise<Map<string, {
+    data: FirebaseFirestore.DocumentData;
+    summary: { id: string; company: string; role: string };
+  }>> {
+    const map = new Map<string, {
+      data: FirebaseFirestore.DocumentData;
+      summary: { id: string; company: string; role: string };
+    }>();
+    for (let i = 0; i < ids.length; i += 30) {
+      const refs = ids.slice(i, i + 30).map((id) => this.apps.doc(id));
+      const snapshots = await this.db.getAll(...refs);
+      for (const snapshot of snapshots) {
+        if (!snapshot.exists) continue;
+        const data = snapshot.data()!;
+        if (data.userId !== userId) continue;
+        map.set(snapshot.id, {
+          data,
+          summary: { id: snapshot.id, company: data.company, role: data.role },
+        });
       }
     }
     return map;

--- a/lib/db/firestore-adapter.ts
+++ b/lib/db/firestore-adapter.ts
@@ -167,6 +167,7 @@ function mapDoc(id: string, data: FirebaseFirestore.DocumentData): DocumentRecor
     submittedAt: toDate(data.submittedAt),
     submissionId: data.submissionId ?? null,
     uploadedAt: toDate(data.uploadedAt) ?? new Date(),
+    demoProvenance: data.demoProvenance === true,
     applicationIds: Array.isArray(data.applicationIds) ? data.applicationIds : [],
     applications: data._applications,
   };
@@ -804,13 +805,14 @@ export class FirestoreAdapter implements DatabaseAdapter {
 
   private async deleteApplicationCascade(id: string, userId: string): Promise<void> {
     const ref = this.apps.doc(id);
-    await this.db.runTransaction(async (transaction) => {
+    const deletingDemo = await this.db.runTransaction(async (transaction) => {
       const existing = await transaction.get(ref);
       if (!existing.exists || existing.data()!.userId !== userId) throw new Error("not_found");
       transaction.update(ref, {
         deletionState: "in_progress",
         deletionStartedAt: FieldValue.serverTimestamp(),
       });
+      return existing.data()!.isDemo === true;
     });
 
     const [contactSnap, submissionSnap, eventSnap, linkedDocumentSnap] = await Promise.all([
@@ -844,6 +846,7 @@ export class FirestoreAdapter implements DatabaseAdapter {
         ref: document.ref,
         data: {
           applicationIds: FieldValue.arrayRemove(id),
+          ...(deletingDemo && { demoProvenance: true }),
           ...(belongsToDeletedSubmission && {
             submissionId: null,
             state: "historical",
@@ -1923,16 +1926,19 @@ export class FirestoreAdapter implements DatabaseAdapter {
       const currentApplicationIds = Array.isArray(existing.data()!.applicationIds)
         ? Array.from(new Set(existing.data()!.applicationIds as string[]))
         : [];
-      if (options?.requireNonDemoProvenance && currentApplicationIds.length > 0) {
+      if (options?.requireNonDemoProvenance) {
         const applications = await Promise.all(
           currentApplicationIds.map((applicationId) => transaction.get(this.apps.doc(applicationId))),
         );
-        if (!applications.some((application) =>
+        const hasConfirmedRealParent = applications.some((application) =>
           application.exists
           && application.data()!.userId === userId
           && application.data()!.isDemo !== true
           && application.data()!.deletionState !== "in_progress"
-        )) throw new Error("not_found");
+        );
+        if ((existing.data()!.demoProvenance === true || currentApplicationIds.length > 0) && !hasConfirmedRealParent) {
+          throw new Error("not_found");
+        }
       }
       const submissionId = existing.data()!.submissionId;
       const keys = Object.keys(data);
@@ -1964,7 +1970,7 @@ export class FirestoreAdapter implements DatabaseAdapter {
       applicationIds: uniqueApplicationIds,
       uploadedAt: Timestamp.now(),
     };
-    const applicationData = await this.db.runTransaction(async (transaction) => {
+    const creation = await this.db.runTransaction(async (transaction) => {
       const applicationSnapshots = await Promise.all(
         applicationReferences.map((applicationReference) => transaction.get(applicationReference)),
       );
@@ -1976,15 +1982,19 @@ export class FirestoreAdapter implements DatabaseAdapter {
       )) {
         throw new Error("invalid_applications");
       }
-      transaction.create(reference, payload);
-      return applicationSnapshots.map((snapshot) => ({
-        id: snapshot.id,
-        company: String(snapshot.data()!.company),
-        role: String(snapshot.data()!.role),
-      }));
+      const demoProvenance = applicationSnapshots.some((snapshot) => snapshot.data()!.isDemo === true);
+      transaction.create(reference, { ...payload, demoProvenance });
+      return {
+        demoProvenance,
+        applications: applicationSnapshots.map((snapshot) => ({
+          id: snapshot.id,
+          company: String(snapshot.data()!.company),
+          role: String(snapshot.data()!.role),
+        })),
+      };
     });
-    const record = mapDoc(reference.id, payload);
-    record.applications = applicationData;
+    const record = mapDoc(reference.id, { ...payload, demoProvenance: creation.demoProvenance });
+    record.applications = creation.applications;
     return record;
   }
 
@@ -1998,16 +2008,19 @@ export class FirestoreAdapter implements DatabaseAdapter {
       const currentApplicationIds = Array.isArray(existing.data()!.applicationIds)
         ? Array.from(new Set(existing.data()!.applicationIds as string[]))
         : [];
-      if (options?.requireNonDemoProvenance && currentApplicationIds.length > 0) {
+      if (options?.requireNonDemoProvenance) {
         const currentApplications = await Promise.all(
           currentApplicationIds.map((applicationId) => transaction.get(this.apps.doc(applicationId))),
         );
-        if (!currentApplications.some((application) =>
+        const hasConfirmedRealParent = currentApplications.some((application) =>
           application.exists
           && application.data()!.userId === userId
           && application.data()!.isDemo !== true
           && application.data()!.deletionState !== "in_progress"
-        )) throw new Error("not_found");
+        );
+        if ((existing.data()!.demoProvenance === true || currentApplicationIds.length > 0) && !hasConfirmedRealParent) {
+          throw new Error("not_found");
+        }
       }
       if (
         existing.data()!.submissionId
@@ -2025,7 +2038,11 @@ export class FirestoreAdapter implements DatabaseAdapter {
       )) {
         throw new Error("invalid_applications");
       }
-      transaction.update(reference, { applicationIds: uniqueApplicationIds });
+      transaction.update(reference, {
+        applicationIds: uniqueApplicationIds,
+        demoProvenance: existing.data()!.demoProvenance === true
+          || applicationSnapshots.some((snapshot) => snapshot.data()!.isDemo === true),
+      });
     });
     return (await this.getDocument(id, userId))!;
   }
@@ -2054,16 +2071,19 @@ export class FirestoreAdapter implements DatabaseAdapter {
       const currentApplicationIds = Array.isArray(existing.data()!.applicationIds)
         ? Array.from(new Set(existing.data()!.applicationIds as string[]))
         : [];
-      if (options?.requireNonDemoProvenance && currentApplicationIds.length > 0) {
+      if (options?.requireNonDemoProvenance) {
         const applications = await Promise.all(
           currentApplicationIds.map((applicationId) => transaction.get(this.apps.doc(applicationId))),
         );
-        if (!applications.some((application) =>
+        const hasConfirmedRealParent = applications.some((application) =>
           application.exists
           && application.data()!.userId === userId
           && application.data()!.isDemo !== true
           && application.data()!.deletionState !== "in_progress"
-        )) throw new Error("not_found");
+        );
+        if ((existing.data()!.demoProvenance === true || currentApplicationIds.length > 0) && !hasConfirmedRealParent) {
+          throw new Error("not_found");
+        }
       }
       if (
         existing.data()!.submissionId

--- a/lib/db/prisma-adapter.ts
+++ b/lib/db/prisma-adapter.ts
@@ -438,11 +438,20 @@ export class PrismaAdapter implements DatabaseAdapter {
       await tx.document.updateMany({
         where: {
           userId,
+          applications: {
+            some: { userId, demoWorkspaceId: workspace.id, isDemo: true },
+          },
+        },
+        data: { demoProvenance: true },
+      });
+      await tx.document.updateMany({
+        where: {
+          userId,
           submission: {
             application: { userId, demoWorkspaceId: workspace.id, isDemo: true },
           },
         },
-        data: { state: "historical" },
+        data: { state: "historical", demoProvenance: true },
       });
       await tx.demoWorkspace.delete({ where: { id: workspace.id, userId } });
       return { deletedApplications, deletedEvents };
@@ -1729,7 +1738,7 @@ export class PrismaAdapter implements DatabaseAdapter {
       });
       if (
         options?.requireNonDemoProvenance
-        && existing.applications.length > 0
+        && (existing.demoProvenance || existing.applications.length > 0)
         && !existing.applications.some((application) => application.userId === userId && !application.isDemo)
       ) throw new Error("not_found");
       const keys = Object.keys(data);
@@ -1756,6 +1765,10 @@ export class PrismaAdapter implements DatabaseAdapter {
     if (submissionId || rest.state === "submitted") throw new Error("submitted_state_reserved");
     const requestedApplicationIds = Array.from(new Set(applicationIds.map(nid)));
     const row = await prisma.$transaction(async (tx) => {
+      const owner = await tx.$queryRaw<Array<{ id: string }>>`
+        SELECT "id" FROM "User" WHERE "id" = ${userId} FOR UPDATE
+      `;
+      if (!owner.length) throw new Error("user_not_found");
       const owned = requestedApplicationIds.length
         ? await tx.application.findMany({
             where: {
@@ -1763,7 +1776,7 @@ export class PrismaAdapter implements DatabaseAdapter {
               userId,
               ...(options?.requireNonDemoProvenance ? { isDemo: false } : {}),
             },
-            select: { id: true },
+            select: { id: true, isDemo: true },
           })
         : [];
       if (owned.length !== requestedApplicationIds.length) throw new Error("invalid_applications");
@@ -1772,6 +1785,7 @@ export class PrismaAdapter implements DatabaseAdapter {
           userId,
           ...rest,
           submissionId: null,
+          demoProvenance: owned.some((application) => application.isDemo),
           applications: requestedApplicationIds.length
             ? { connect: requestedApplicationIds.map((id) => ({ id })) }
             : undefined,
@@ -1786,6 +1800,10 @@ export class PrismaAdapter implements DatabaseAdapter {
     const documentId = nid(id);
     const requestedApplicationIds = Array.from(new Set(applicationIds)).map(nid);
     return prisma.$transaction(async (tx) => {
+      const owner = await tx.$queryRaw<Array<{ id: string }>>`
+        SELECT "id" FROM "User" WHERE "id" = ${userId} FOR UPDATE
+      `;
+      if (!owner.length) throw new Error("user_not_found");
       const locked = await tx.$queryRaw<Array<{ submissionId: number | null; state: string }>>`
         SELECT "submissionId", "state"
         FROM "Document"
@@ -1799,7 +1817,7 @@ export class PrismaAdapter implements DatabaseAdapter {
       });
       if (
         options?.requireNonDemoProvenance
-        && existing.applications.length > 0
+        && (existing.demoProvenance || existing.applications.length > 0)
         && !existing.applications.some((application) => application.userId === userId && !application.isDemo)
       ) throw new Error("not_found");
       if (locked[0].submissionId !== null || locked[0].state === "submitted" || locked[0].state === "historical") {
@@ -1811,12 +1829,15 @@ export class PrismaAdapter implements DatabaseAdapter {
           userId,
           ...(options?.requireNonDemoProvenance ? { isDemo: false } : {}),
         },
-        select: { id: true },
+        select: { id: true, isDemo: true },
       });
       if (owned.length !== requestedApplicationIds.length) throw new Error("invalid_applications");
       const row = await tx.document.update({
         where: { id: documentId, userId },
-        data: { applications: { set: owned.map((application) => ({ id: application.id })) } },
+        data: {
+          demoProvenance: existing.demoProvenance || owned.some((application) => application.isDemo),
+          applications: { set: owned.map((application) => ({ id: application.id })) },
+        },
         include: { applications: { select: { id: true, company: true, role: true } } },
       });
       return mapDoc(row);
@@ -1854,7 +1875,7 @@ export class PrismaAdapter implements DatabaseAdapter {
       });
       if (
         options?.requireNonDemoProvenance
-        && provenance.applications.length > 0
+        && (provenance.demoProvenance || provenance.applications.length > 0)
         && !provenance.applications.some((application) => application.userId === userId && !application.isDemo)
       ) throw new Error("not_found");
       if (locked[0].submissionId !== null || locked[0].state === "submitted" || locked[0].state === "historical") {

--- a/lib/db/prisma-adapter.ts
+++ b/lib/db/prisma-adapter.ts
@@ -53,7 +53,12 @@ import type {
   ApplicationEventPage,
   ListDocumentsFilter,
   UpdateDocumentMetadataInput,
+  DocumentMutationOptions,
+  DemoReadOptions,
+  EnsureDemoWorkspaceResult,
+  DeleteDemoWorkspaceResult,
 } from "./types";
+import type { DemoFixtures } from "@/lib/demo-workspace/fixtures";
 
 // ── Helpers: convert Prisma int IDs ↔ string IDs ────────────────────────────
 
@@ -81,6 +86,7 @@ function mapApp(a: AppRow): ApplicationRecord {
   return {
     ...a,
     id: sid(a.id),
+    demoWorkspaceId: a.demoWorkspaceId === null ? null : sid(a.demoWorkspaceId),
     status: normalizeStatus(a.status),
     eligibleCountries: Array.isArray(a.eligibleCountries) ? (a.eligibleCountries as string[]) : [],
     primaryLocations: Array.isArray(a.primaryLocations) ? (a.primaryLocations as string[]) : [],
@@ -97,6 +103,7 @@ function mapDoc(d: DocumentWithApplications): DocumentRecord {
     ...d,
     id: sid(d.id),
     submissionId: d.submissionId ? sid(d.submissionId) : null,
+    applicationIds: d.applications?.map((application) => sid(application.id)),
     applications: d.applications?.map((a) => ({ id: sid(a.id), company: a.company, role: a.role })),
   };
 }
@@ -132,6 +139,9 @@ function publicEventMetadata(value: unknown): Record<string, unknown> | null {
 function mapEvent(row: EventWithApplication): ApplicationEventRecord {
   return {
     id: sid(row.id),
+    isDemo: row.isDemo,
+    demoWorkspaceId: row.demoWorkspaceId === null ? null : sid(row.demoWorkspaceId),
+    demoKey: row.demoKey,
     userId: row.userId,
     applicationId: sid(row.applicationId),
     type: row.type,
@@ -151,6 +161,35 @@ function mapEvent(row: EventWithApplication): ApplicationEventRecord {
 
 function submissionEventKey(idempotencyKey: string): string {
   return `submission:${idempotencyKey}`;
+}
+
+function eventDemoData(
+  application: { isDemo: boolean; demoWorkspaceId: number | null; demoKey: string | null },
+  stableKey: string,
+): { isDemo: boolean; demoWorkspaceId: number | null; demoKey: string | null } {
+  const complete = application.isDemo && application.demoWorkspaceId !== null && application.demoKey !== null;
+  const empty = !application.isDemo && application.demoWorkspaceId === null && application.demoKey === null;
+  if (!complete && !empty) throw new Error("demo_marker_conflict");
+  return complete
+    ? {
+        isDemo: true,
+        demoWorkspaceId: application.demoWorkspaceId,
+        demoKey: `${application.demoKey}:event:${stableKey}`,
+      }
+    : { isDemo: false, demoWorkspaceId: null, demoKey: null };
+}
+
+function assertEventMatchesParent(
+  event: { isDemo: boolean; demoWorkspaceId: number | null; demoKey: string | null },
+  application: { isDemo: boolean; demoWorkspaceId: number | null; demoKey: string | null },
+): void {
+  const expected = eventDemoData(application, "replay");
+  if (
+    (event.isDemo ?? false) !== expected.isDemo
+    || (event.demoWorkspaceId ?? null) !== expected.demoWorkspaceId
+    || (expected.isDemo && !event.demoKey?.startsWith(`${application.demoKey}:event:`))
+    || (!expected.isDemo && event.demoKey != null)
+  ) throw new Error("demo_marker_conflict");
 }
 
 async function loadSubmissionReplay(
@@ -183,6 +222,7 @@ async function loadSubmissionReplay(
     }),
   ]);
   if (!application) throw new Error("not_found");
+  if (event) assertEventMatchesParent(event, application);
   const mappedSubmission = mapSubmission(submission);
   return {
     replayed: true,
@@ -215,7 +255,13 @@ function mapCvProfile(row: CvProfileRow): CvProfileRecord {
 }
 
 function userWhere(userId: string | null): { userId: string } | object {
-  return userId ? { userId } : {};
+  return userId !== null ? { userId } : {};
+}
+
+function demoWhere(options?: DemoReadOptions): { isDemo?: boolean } {
+  if (options?.demoVisibility === "exclude") return { isDemo: false };
+  if (options?.demoVisibility === "only") return { isDemo: true };
+  return {};
 }
 
 function pickFields(apps: ApplicationRecord[], fields?: string[]): Partial<ApplicationRecord>[] {
@@ -269,11 +315,134 @@ function structuredApplicationData(data: Record<string, unknown>): Record<string
 // ── Implementation ──────────────────────────────────────────────────────────
 
 export class PrismaAdapter implements DatabaseAdapter {
+  async ensureDemoWorkspace(
+    userId: string,
+    fixtures: DemoFixtures,
+  ): Promise<EnsureDemoWorkspaceResult> {
+    return prisma.$transaction(async (tx) => {
+      const owner = await tx.$queryRaw<Array<{ id: string }>>`
+        SELECT "id" FROM "User" WHERE "id" = ${userId} FOR UPDATE
+      `;
+      if (!owner.length) throw new Error("user_not_found");
+
+      const existing = await tx.demoWorkspace.findUnique({ where: { userId } });
+      if (existing) {
+        if (existing.seedVersion !== fixtures.seedVersion) throw new Error("demo_version_conflict");
+        if (existing.state !== "ready") throw new Error("demo_workspace_unavailable");
+        const applications = await tx.application.findMany({
+          where: { userId, demoWorkspaceId: existing.id, isDemo: true },
+          include: { contacts: true },
+          orderBy: { demoKey: "asc" },
+        });
+        const events = await tx.applicationEvent.findMany({
+          where: { userId, demoWorkspaceId: existing.id, isDemo: true },
+          select: { demoKey: true },
+        });
+        const actualApplicationKeys = applications.map((row) => row.demoKey).sort();
+        const expectedApplicationKeys = fixtures.applications.map((fixture) => fixture.demoKey).sort();
+        const actualEventKeys = events.map((row) => row.demoKey).sort();
+        const expectedEventKeys = fixtures.events.map((fixture) => fixture.demoKey).sort();
+        if (
+          JSON.stringify(actualApplicationKeys) !== JSON.stringify(expectedApplicationKeys)
+          || !expectedEventKeys.every((key) => actualEventKeys.includes(key))
+        ) throw new Error("demo_workspace_incomplete");
+        return {
+          workspace: { ...existing, id: sid(existing.id), state: existing.state as "creating" | "ready" | "deleting" },
+          applications: applications.map(mapApp),
+          replayed: true,
+        };
+      }
+
+      const realCount = await tx.application.count({ where: { userId, isDemo: false } });
+      if (realCount > 0) throw new Error("real_applications_exist");
+
+      const workspace = await tx.demoWorkspace.create({
+        data: { userId, seedVersion: fixtures.seedVersion, state: "creating", createdAt: fixtures.createdAt },
+      });
+      const applicationsByKey = new Map<string, number>();
+      for (const fixture of fixtures.applications) {
+        const row = await tx.application.create({
+          data: {
+            userId,
+            company: fixture.company,
+            role: fixture.role,
+            status: fixture.status,
+            appliedAt: fixture.appliedAt,
+            lastContact: fixture.lastContact,
+            followUpAt: fixture.followUpAt,
+            notes: fixture.notes,
+            jobDescription: null,
+            source: fixture.source,
+            remote: fixture.remote,
+            salaryMin: fixture.salaryMin,
+            salaryMax: fixture.salaryMax,
+            rating: fixture.rating,
+            jobUrl: null,
+            isDemo: true,
+            demoWorkspaceId: workspace.id,
+            demoKey: fixture.demoKey,
+            createdAt: fixtures.createdAt,
+          },
+        });
+        applicationsByKey.set(fixture.demoKey, row.id);
+      }
+      for (const fixture of fixtures.events) {
+        const applicationId = applicationsByKey.get(fixture.applicationDemoKey);
+        if (!applicationId) throw new Error("demo_fixture_invalid");
+        await tx.applicationEvent.create({
+          data: {
+            userId,
+            applicationId,
+            type: fixture.type,
+            occurredAt: fixture.occurredAt,
+            source: fixture.source,
+            actor: fixture.actor,
+            metadata: fixture.metadata as Prisma.InputJsonValue,
+            isDemo: true,
+            demoWorkspaceId: workspace.id,
+            demoKey: fixture.demoKey,
+          },
+        });
+      }
+      const ready = await tx.demoWorkspace.update({
+        where: { id: workspace.id },
+        data: { state: "ready" },
+      });
+      const applications = await tx.application.findMany({
+        where: { userId, demoWorkspaceId: workspace.id, isDemo: true },
+        include: { contacts: true },
+        orderBy: { demoKey: "asc" },
+      });
+      return {
+        workspace: { ...ready, id: sid(ready.id), state: "ready" as const },
+        applications: applications.map(mapApp),
+        replayed: false,
+      };
+    });
+  }
+
+  async deleteDemoWorkspace(userId: string): Promise<DeleteDemoWorkspaceResult> {
+    return prisma.$transaction(async (tx) => {
+      const owner = await tx.$queryRaw<Array<{ id: string }>>`
+        SELECT "id" FROM "User" WHERE "id" = ${userId} FOR UPDATE
+      `;
+      if (!owner.length) throw new Error("user_not_found");
+      const workspace = await tx.demoWorkspace.findUnique({ where: { userId } });
+      if (!workspace) return { deletedApplications: 0, deletedEvents: 0 };
+      const [deletedApplications, deletedEvents] = await Promise.all([
+        tx.application.count({ where: { userId, demoWorkspaceId: workspace.id, isDemo: true } }),
+        tx.applicationEvent.count({ where: { userId, demoWorkspaceId: workspace.id, isDemo: true } }),
+      ]);
+      await tx.demoWorkspace.delete({ where: { id: workspace.id, userId } });
+      return { deletedApplications, deletedEvents };
+    });
+  }
+
   // Applications
 
-  async listApplications(userId: string | null): Promise<ApplicationRecord[]> {
+  async listApplications(userId: string | null, options?: DemoReadOptions): Promise<ApplicationRecord[]> {
     const rows = await prisma.application.findMany({
-      where: { ...userWhere(userId) },
+      where: { ...userWhere(userId), ...demoWhere(options) },
       orderBy: { createdAt: "desc" },
       include: { contacts: true },
     });
@@ -282,11 +451,12 @@ export class PrismaAdapter implements DatabaseAdapter {
 
   async listApplicationsPaginated(
     userId: string | null,
-    params: PaginationParams
+    params: PaginationParams,
+    options?: DemoReadOptions,
   ): Promise<PaginatedResult<ApplicationRecord>> {
     const page = Math.max(1, params.page ?? 1);
     const pageSize = Math.max(1, Math.min(100, params.pageSize ?? 10));
-    const where = { ...userWhere(userId) };
+    const where = { ...userWhere(userId), ...demoWhere(options) };
 
     const [total, rows] = await Promise.all([
       prisma.application.count({ where }),
@@ -308,9 +478,9 @@ export class PrismaAdapter implements DatabaseAdapter {
     };
   }
 
-  async getApplication(id: string, userId: string | null): Promise<ApplicationRecord | null> {
+  async getApplication(id: string, userId: string | null, options?: DemoReadOptions): Promise<ApplicationRecord | null> {
     const row = await prisma.application.findFirst({
-      where: { id: nid(id), ...userWhere(userId) },
+      where: { id: nid(id), ...userWhere(userId), ...demoWhere(options) },
       include: { contacts: true },
     });
     return row ? mapApp(row) : null;
@@ -319,14 +489,21 @@ export class PrismaAdapter implements DatabaseAdapter {
   async createApplication(userId: string, data: CreateApplicationInput): Promise<ApplicationRecord> {
     validateApplicationSummary(data.notes);
     try {
-      const row = await prisma.application.create({
-        data: {
-          userId,
-          ...data,
-          status: normalizeStatus(data.status),
-          appliedAt: resolveAppliedAtForCreate(data.status, data.appliedAt),
-        },
-        include: { contacts: true },
+      const row = await prisma.$transaction(async (tx) => {
+        const owner = await tx.$queryRaw<Array<{ id: string }>>`
+          SELECT "id" FROM "User" WHERE "id" = ${userId} FOR UPDATE
+        `;
+        if (!owner.length) throw new Error("user_not_found");
+        if (await tx.demoWorkspace.count({ where: { userId } })) throw new Error("demo_workspace_exists");
+        return tx.application.create({
+          data: {
+            userId,
+            ...data,
+            status: normalizeStatus(data.status),
+            appliedAt: resolveAppliedAtForCreate(data.status, data.appliedAt),
+          },
+          include: { contacts: true },
+        });
       });
       return mapApp(row);
     } catch (error) {
@@ -429,9 +606,10 @@ export class PrismaAdapter implements DatabaseAdapter {
   async findApplicationByCanonicalJobUrl(
     userId: string,
     canonicalJobUrl: string,
+    options?: DemoReadOptions,
   ): Promise<ApplicationRecord | null> {
     const row = await prisma.application.findFirst({
-      where: { userId, canonicalJobUrl },
+      where: { userId, canonicalJobUrl, ...demoWhere(options) },
       include: { contacts: true },
     });
     return row ? mapApp(row) : null;
@@ -459,6 +637,7 @@ export class PrismaAdapter implements DatabaseAdapter {
         include: { contacts: true },
       });
       if (!application) throw new Error("not_found");
+      assertEventMatchesParent(event, application);
       return { application: mapApp(application), event: mapEvent(event) };
     };
     const existingReplay = await loadReplay();
@@ -483,6 +662,7 @@ export class PrismaAdapter implements DatabaseAdapter {
           if (replay) {
             const legacyHash = ((replay.metadata ?? {}) as Record<string, unknown>).requestHash;
             if ((replay.requestHash ?? legacyHash) !== requestHash) throw new Error("idempotency_conflict");
+            assertEventMatchesParent(replay, existing);
             return { application: mapApp(existing), event: mapEvent(replay) };
           }
         }
@@ -547,6 +727,7 @@ export class PrismaAdapter implements DatabaseAdapter {
             source: eventInput.source ?? null,
             actor: eventInput.actor ?? null,
             metadata: (eventInput.metadata ?? {}) as Prisma.InputJsonValue,
+            ...eventDemoData(application, requestHash),
           },
         });
         return { application: mapApp(application), event: mapEvent(event) };
@@ -633,6 +814,7 @@ export class PrismaAdapter implements DatabaseAdapter {
             },
           }),
         ]);
+        if (event) assertEventMatchesParent(event, application);
         return {
           replayed: true,
           dryRun: false,
@@ -825,6 +1007,7 @@ export class PrismaAdapter implements DatabaseAdapter {
             answerCount: input.answers.length,
             policy,
           } as unknown as Prisma.InputJsonValue,
+          ...eventDemoData(updatedApplication, requestHash),
         },
       });
       const stored = await tx.applicationSubmission.findUniqueOrThrow({
@@ -904,8 +1087,6 @@ export class PrismaAdapter implements DatabaseAdapter {
     userId: string,
     input: CreateApplicationEventInput,
   ): Promise<ApplicationEventRecord> {
-    const owns = await prisma.application.count({ where: { id: nid(applicationId), userId } });
-    if (!owns) throw new Error("not_found");
     const requestHash = submissionRequestHash({
       applicationId,
       type: input.type,
@@ -920,6 +1101,9 @@ export class PrismaAdapter implements DatabaseAdapter {
         },
       });
       if (!replay) return null;
+      const application = await prisma.application.findFirst({ where: { id: nid(applicationId), userId } });
+      if (!application) throw new Error("not_found");
+      assertEventMatchesParent(replay, application);
       const legacyHash = ((replay.metadata ?? {}) as Record<string, unknown>).requestHash;
       if ((replay.requestHash ?? legacyHash) !== requestHash) throw new Error("idempotency_conflict");
       return mapEvent(replay);
@@ -928,6 +1112,9 @@ export class PrismaAdapter implements DatabaseAdapter {
     if (replay) return replay;
     try {
       const row = await prisma.$transaction(async (tx) => {
+        const application = await tx.application.findFirst({ where: { id: nid(applicationId), userId } });
+        if (!application) throw new Error("not_found");
+        eventDemoData(application, requestHash);
         const bumped = await tx.application.updateMany({
           where: { id: nid(applicationId), userId },
           data: { eventVersion: { increment: 1 } },
@@ -944,6 +1131,7 @@ export class PrismaAdapter implements DatabaseAdapter {
             source: input.source ?? null,
             actor: input.actor ?? null,
             metadata: (input.metadata ?? {}) as Prisma.InputJsonValue,
+            ...eventDemoData(application, requestHash),
           },
         });
       });
@@ -1001,6 +1189,7 @@ export class PrismaAdapter implements DatabaseAdapter {
         include: { contacts: true },
       });
       if (!application) throw new Error("not_found");
+      assertEventMatchesParent(event, application);
       return { event: mapEvent(event), application: mapApp(application), replayed: true };
     };
 
@@ -1014,6 +1203,7 @@ export class PrismaAdapter implements DatabaseAdapter {
           include: { contacts: true },
         });
         if (!application) throw new Error("not_found");
+        eventDemoData(application, requestHash);
         if (input.expectedUpdatedAt && application.updatedAt.getTime() !== input.expectedUpdatedAt.getTime()) {
           throw new Error("conflict");
         }
@@ -1030,6 +1220,7 @@ export class PrismaAdapter implements DatabaseAdapter {
             if (typeof persistedRequestHash !== "string" || !acceptedRequestHashes.has(persistedRequestHash)) {
               throw new Error("idempotency_conflict");
             }
+            assertEventMatchesParent(existing, application);
             return { event: mapEvent(existing), application: mapApp(application), replayed: true };
           }
         }
@@ -1102,6 +1293,7 @@ export class PrismaAdapter implements DatabaseAdapter {
             contactId: input.contactId ?? null,
             outcome: input.outcome ?? null,
             metadata: metadata as Prisma.InputJsonValue,
+            ...eventDemoData(updatedApplication, requestHash),
           },
         });
         return {
@@ -1130,12 +1322,19 @@ export class PrismaAdapter implements DatabaseAdapter {
   async listApplicationEventsFiltered(
     userId: string,
     filter: ListApplicationEventsFilter,
+    options?: DemoReadOptions,
   ): Promise<ApplicationEventPage> {
     const direction = filter.order === "oldest" ? "asc" : "desc";
+    const applicationWhere: Prisma.ApplicationWhereInput = {
+      userId,
+      ...demoWhere(options),
+      ...(filter.company ? { company: { contains: filter.company, mode: "insensitive" } } : {}),
+    };
     const where: Prisma.ApplicationEventWhereInput = {
       userId,
+      ...demoWhere(options),
+      application: applicationWhere,
       ...(filter.applicationId ? { applicationId: nid(filter.applicationId) } : {}),
-      ...(filter.company ? { application: { company: { contains: filter.company, mode: "insensitive" } } } : {}),
       ...(filter.types?.length ? { type: { in: filter.types } } : {}),
       ...(filter.source ? { source: filter.source } : {}),
       ...(filter.actor ? { actor: filter.actor } : {}),
@@ -1176,11 +1375,19 @@ export class PrismaAdapter implements DatabaseAdapter {
     applicationId: string,
     userId: string,
     limit = 100,
+    options?: DemoReadOptions,
   ): Promise<ApplicationEventRecord[]> {
-    const owns = await prisma.application.count({ where: { id: nid(applicationId), userId } });
+    const owns = await prisma.application.count({
+      where: { id: nid(applicationId), userId, ...demoWhere(options) },
+    });
     if (!owns) throw new Error("not_found");
     const rows = await prisma.applicationEvent.findMany({
-      where: { applicationId: nid(applicationId), userId },
+      where: {
+        applicationId: nid(applicationId),
+        userId,
+        ...demoWhere(options),
+        application: { userId, ...demoWhere(options) },
+      },
       orderBy: [{ occurredAt: "desc" }, { id: "desc" }],
       take: Math.max(1, Math.min(500, limit)),
     });
@@ -1189,9 +1396,10 @@ export class PrismaAdapter implements DatabaseAdapter {
 
   async listApplicationsFiltered(
     userId: string | null,
-    filter: ListApplicationsFilter
+    filter: ListApplicationsFilter,
+    options?: DemoReadOptions,
   ): Promise<Partial<ApplicationRecord>[]> {
-    const where: Prisma.ApplicationWhereInput = { ...userWhere(userId) };
+    const where: Prisma.ApplicationWhereInput = { ...userWhere(userId), ...demoWhere(options) };
 
     if (filter.status?.length) {
       where.status = { in: filter.status };
@@ -1313,35 +1521,44 @@ export class PrismaAdapter implements DatabaseAdapter {
             failed++;
             continue;
           }
-          const row = await prisma.application.create({
-            data: {
-              userId,
-              company: item.company,
-              role: item.role,
-              status: normalizeStatus(item.status || "inbound"),
-              appliedAt: resolveAppliedAtForCreate(item.status || "inbound", item.appliedAt),
-              lastContact: item.lastContact ?? null,
-              followUpAt: item.followUpAt ?? null,
-              notes: validateApplicationSummary(item.notes),
-              jobDescription: item.jobDescription ?? null,
-              source: item.source ?? null,
-              remote: item.remote ?? false,
-              salaryMin: item.salaryMin ?? null,
-              salaryMax: item.salaryMax ?? null,
-              rating: item.rating ?? null,
-              jobUrl: item.jobUrl ?? null,
-              resumeId: item.resumeId ?? null,
-              ...structuredApplicationData(item as unknown as Record<string, unknown>),
-              ...sanitizeTriageFields({
-                companySize: item.companySize ?? null,
-                salaryBandMentioned: item.salaryBandMentioned ?? false,
-                triageQuality: item.triageQuality ?? null,
-                triageReason: item.triageReason ?? null,
-                incomingSource: item.incomingSource ?? null,
-                autoRejected: item.autoRejected ?? false,
-                autoRejectReason: item.autoRejectReason ?? null,
-              }),
-            },
+          const company = item.company;
+          const role = item.role;
+          const row = await prisma.$transaction(async (tx) => {
+            const owner = await tx.$queryRaw<Array<{ id: string }>>`
+              SELECT "id" FROM "User" WHERE "id" = ${userId} FOR UPDATE
+            `;
+            if (!owner.length) throw new Error("user_not_found");
+            if (await tx.demoWorkspace.count({ where: { userId } })) throw new Error("demo_workspace_exists");
+            return tx.application.create({
+              data: {
+                userId,
+                company,
+                role,
+                status: normalizeStatus(item.status || "inbound"),
+                appliedAt: resolveAppliedAtForCreate(item.status || "inbound", item.appliedAt),
+                lastContact: item.lastContact ?? null,
+                followUpAt: item.followUpAt ?? null,
+                notes: validateApplicationSummary(item.notes),
+                jobDescription: item.jobDescription ?? null,
+                source: item.source ?? null,
+                remote: item.remote ?? false,
+                salaryMin: item.salaryMin ?? null,
+                salaryMax: item.salaryMax ?? null,
+                rating: item.rating ?? null,
+                jobUrl: item.jobUrl ?? null,
+                resumeId: item.resumeId ?? null,
+                ...structuredApplicationData(item as unknown as Record<string, unknown>),
+                ...sanitizeTriageFields({
+                  companySize: item.companySize ?? null,
+                  salaryBandMentioned: item.salaryBandMentioned ?? false,
+                  triageQuality: item.triageQuality ?? null,
+                  triageReason: item.triageReason ?? null,
+                  incomingSource: item.incomingSource ?? null,
+                  autoRejected: item.autoRejected ?? false,
+                  autoRejectReason: item.autoRejectReason ?? null,
+                }),
+              },
+            });
           });
           results.push({ index: i, id: sid(row.id), operation: "created" });
           succeeded++;
@@ -1484,33 +1701,43 @@ export class PrismaAdapter implements DatabaseAdapter {
     id: string,
     userId: string,
     data: UpdateDocumentMetadataInput,
+    options?: DocumentMutationOptions,
   ): Promise<DocumentRecord> {
     const documentId = nid(id);
-    const existing = await prisma.document.findFirst({ where: { id: documentId, userId } });
-    if (!existing) throw new Error("not_found");
-    const keys = Object.keys(data);
-    const stateOnly = keys.every((key) => key === "state");
-    const immutable = existing.submissionId !== null || existing.state === "submitted" || existing.state === "historical";
-    if (immutable) {
-      const allowedState = data.state === existing.state
-        || (existing.state === "submitted" && data.state === "historical");
-      if (!stateOnly || !allowedState) {
-        throw new Error("submitted_document_immutable");
+    return prisma.$transaction(async (tx) => {
+      const locked = await tx.$queryRaw<Array<{ submissionId: number | null; state: string }>>`
+        SELECT "submissionId", "state"
+        FROM "Document"
+        WHERE "id" = ${documentId} AND "userId" = ${userId}
+        FOR UPDATE
+      `;
+      if (!locked.length) throw new Error("not_found");
+      const existing = await tx.document.findFirstOrThrow({
+        where: { id: documentId, userId },
+        include: { applications: { select: { id: true, userId: true, isDemo: true } } },
+      });
+      if (
+        options?.requireNonDemoProvenance
+        && existing.applications.length > 0
+        && !existing.applications.some((application) => application.userId === userId && !application.isDemo)
+      ) throw new Error("not_found");
+      const keys = Object.keys(data);
+      const stateOnly = keys.every((key) => key === "state");
+      const immutable = existing.submissionId !== null || existing.state === "submitted" || existing.state === "historical";
+      if (immutable) {
+        const allowedState = data.state === existing.state
+          || (existing.state === "submitted" && data.state === "historical");
+        if (!stateOnly || !allowedState) throw new Error("submitted_document_immutable");
+      } else if (data.state === "submitted") {
+        throw new Error("submitted_state_reserved");
       }
-    } else if (data.state === "submitted") {
-      throw new Error("submitted_state_reserved");
-    }
-    const changed = await prisma.document.updateMany({
-      where: {
-        id: documentId,
-        userId,
-        submissionId: existing.submissionId,
-        state: existing.state,
-      },
-      data,
+      const row = await tx.document.update({
+        where: { id: documentId, userId },
+        data,
+        include: { applications: { select: { id: true, company: true, role: true } } },
+      });
+      return mapDoc(row);
     });
-    if (changed.count !== 1) throw new Error("submitted_document_immutable");
-    return (await this.getDocument(id, userId))!;
   }
 
   async createDocument(userId: string, data: CreateDocumentInput): Promise<DocumentRecord> {
@@ -1540,7 +1767,7 @@ export class PrismaAdapter implements DatabaseAdapter {
     return mapDoc(row);
   }
 
-  async updateDocumentLinks(id: string, userId: string, applicationIds: string[]): Promise<DocumentRecord> {
+  async updateDocumentLinks(id: string, userId: string, applicationIds: string[], options?: DocumentMutationOptions): Promise<DocumentRecord> {
     const documentId = nid(id);
     const requestedApplicationIds = Array.from(new Set(applicationIds)).map(nid);
     return prisma.$transaction(async (tx) => {
@@ -1551,11 +1778,24 @@ export class PrismaAdapter implements DatabaseAdapter {
         FOR UPDATE
       `;
       if (!locked.length) throw new Error("not_found");
+      const existing = await tx.document.findFirstOrThrow({
+        where: { id: documentId, userId },
+        include: { applications: { select: { id: true, userId: true, isDemo: true } } },
+      });
+      if (
+        options?.requireNonDemoProvenance
+        && existing.applications.length > 0
+        && !existing.applications.some((application) => application.userId === userId && !application.isDemo)
+      ) throw new Error("not_found");
       if (locked[0].submissionId !== null || locked[0].state === "submitted" || locked[0].state === "historical") {
         throw new Error("submitted_document_immutable");
       }
       const owned = await tx.application.findMany({
-        where: { id: { in: requestedApplicationIds }, userId },
+        where: {
+          id: { in: requestedApplicationIds },
+          userId,
+          ...(options?.requireNonDemoProvenance ? { isDemo: false } : {}),
+        },
         select: { id: true },
       });
       if (owned.length !== requestedApplicationIds.length) throw new Error("invalid_applications");
@@ -1583,7 +1823,7 @@ export class PrismaAdapter implements DatabaseAdapter {
     throw new Error("submitted_document_immutable");
   }
 
-  async deleteDocument(id: string, userId: string): Promise<DocumentRecord | null> {
+  async deleteDocument(id: string, userId: string, options?: DocumentMutationOptions): Promise<DocumentRecord | null> {
     const documentId = nid(id);
     return prisma.$transaction(async (tx) => {
       const locked = await tx.$queryRaw<Array<{ submissionId: number | null; state: string }>>`
@@ -1593,6 +1833,15 @@ export class PrismaAdapter implements DatabaseAdapter {
         FOR UPDATE
       `;
       if (!locked.length) return null;
+      const provenance = await tx.document.findFirstOrThrow({
+        where: { id: documentId, userId },
+        include: { applications: { select: { id: true, userId: true, isDemo: true } } },
+      });
+      if (
+        options?.requireNonDemoProvenance
+        && provenance.applications.length > 0
+        && !provenance.applications.some((application) => application.userId === userId && !application.isDemo)
+      ) throw new Error("not_found");
       if (locked[0].submissionId !== null || locked[0].state === "submitted" || locked[0].state === "historical") {
         throw new Error("submitted_document_immutable");
       }

--- a/lib/db/prisma-adapter.ts
+++ b/lib/db/prisma-adapter.ts
@@ -187,7 +187,7 @@ function assertEventMatchesParent(
   if (
     (event.isDemo ?? false) !== expected.isDemo
     || (event.demoWorkspaceId ?? null) !== expected.demoWorkspaceId
-    || (expected.isDemo && !event.demoKey?.startsWith(`${application.demoKey}:event:`))
+    || (expected.isDemo && (typeof event.demoKey !== "string" || event.demoKey.length === 0))
     || (!expected.isDemo && event.demoKey != null)
   ) throw new Error("demo_marker_conflict");
 }
@@ -433,6 +433,17 @@ export class PrismaAdapter implements DatabaseAdapter {
         tx.application.count({ where: { userId, demoWorkspaceId: workspace.id, isDemo: true } }),
         tx.applicationEvent.count({ where: { userId, demoWorkspaceId: workspace.id, isDemo: true } }),
       ]);
+      // Preserve the Firestore cleanup contract before the workspace cascade deletes
+      // submissions and the database clears Document.submissionId via SetNull.
+      await tx.document.updateMany({
+        where: {
+          userId,
+          submission: {
+            application: { userId, demoWorkspaceId: workspace.id, isDemo: true },
+          },
+        },
+        data: { state: "historical" },
+      });
       await tx.demoWorkspace.delete({ where: { id: workspace.id, userId } });
       return { deletedApplications, deletedEvents };
     });
@@ -1740,14 +1751,18 @@ export class PrismaAdapter implements DatabaseAdapter {
     });
   }
 
-  async createDocument(userId: string, data: CreateDocumentInput): Promise<DocumentRecord> {
+  async createDocument(userId: string, data: CreateDocumentInput, options?: DocumentMutationOptions): Promise<DocumentRecord> {
     const { applicationIds, submissionId, ...rest } = data;
     if (submissionId || rest.state === "submitted") throw new Error("submitted_state_reserved");
     const requestedApplicationIds = Array.from(new Set(applicationIds.map(nid)));
     const row = await prisma.$transaction(async (tx) => {
       const owned = requestedApplicationIds.length
         ? await tx.application.findMany({
-            where: { id: { in: requestedApplicationIds }, userId },
+            where: {
+              id: { in: requestedApplicationIds },
+              userId,
+              ...(options?.requireNonDemoProvenance ? { isDemo: false } : {}),
+            },
             select: { id: true },
           })
         : [];

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -251,6 +251,11 @@ export interface EnsureDemoWorkspaceResult {
 
 export interface DeleteDemoWorkspaceResult {
   deletedApplications: number;
+  /**
+   * Best-effort event count captured when deletion is prepared. The count is stable
+   * across retries, but may underreport events added concurrently; those events are
+   * still removed as part of the workspace deletion.
+   */
   deletedEvents: number;
 }
 

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -84,6 +84,9 @@ export interface ApplicationRecord {
   currentStage: string | null;
   createdAt: Date;
   updatedAt: Date;
+  isDemo: boolean;
+  demoWorkspaceId: string | null;
+  demoKey: string | null;
   contacts?: ContactRecord[];
 }
 
@@ -114,6 +117,8 @@ export interface DocumentRecord {
   submittedAt: Date | null;
   submissionId: string | null;
   uploadedAt: Date;
+  /** Raw parent IDs retained so machine boundaries can detect dangling links. */
+  applicationIds?: string[];
   applications?: ApplicationRef[];
 }
 
@@ -162,6 +167,9 @@ export interface ApplicationEventRecord {
   outcome: string | null;
   metadata: Record<string, unknown> | null;
   createdAt: Date;
+  isDemo: boolean;
+  demoWorkspaceId: string | null;
+  demoKey: string | null;
   application?: ApplicationRef;
 }
 
@@ -209,6 +217,41 @@ export interface ApplicationRef {
   id: string;
   company: string;
   role: string;
+}
+
+export type DemoVisibility = "include" | "exclude" | "only";
+
+export interface DemoReadOptions {
+  demoVisibility?: DemoVisibility;
+}
+
+export interface DocumentMutationOptions {
+  /**
+   * Require current raw application associations, and any replacement
+   * associations, to retain owner-scoped non-demo provenance at the same
+   * transactional serialization point as the mutation.
+   */
+  requireNonDemoProvenance?: boolean;
+}
+
+export interface DemoWorkspaceRecord {
+  id: string;
+  userId: string;
+  seedVersion: number;
+  state: "creating" | "ready" | "deleting";
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface EnsureDemoWorkspaceResult {
+  workspace: DemoWorkspaceRecord;
+  applications: ApplicationRecord[];
+  replayed: boolean;
+}
+
+export interface DeleteDemoWorkspaceResult {
+  deletedApplications: number;
+  deletedEvents: number;
 }
 
 export interface UserRecord {

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -119,6 +119,8 @@ export interface DocumentRecord {
   uploadedAt: Date;
   /** Raw parent IDs retained so machine boundaries can detect dangling links. */
   applicationIds?: string[];
+  /** Sticky internal marker: this document has been associated with demo data. */
+  demoProvenance?: boolean;
   applications?: ApplicationRef[];
 }
 

--- a/lib/demo-workspace/__tests__/fixtures.test.ts
+++ b/lib/demo-workspace/__tests__/fixtures.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { APPLICATION_EVENT_TYPES } from "@/lib/applications/events";
+import { STATUS_ORDER } from "@/types";
+import { DEMO_FIXTURE_VERSION, createDemoFixtures } from "../fixtures";
+
+describe("demo workspace fixture contract", () => {
+  it("creates a bounded, stable, coherent fictional workflow", () => {
+    const createdAt = new Date("2026-08-10T12:00:00.000Z");
+    const fixture = createDemoFixtures(createdAt);
+
+    expect(DEMO_FIXTURE_VERSION).toBe(1);
+    expect(fixture.applications.length).toBeGreaterThanOrEqual(3);
+    expect(fixture.applications.length).toBeLessThanOrEqual(6);
+    expect(new Set(fixture.applications.map((app) => app.demoKey)).size).toBe(fixture.applications.length);
+    expect(fixture.applications.every((app) => STATUS_ORDER.includes(app.status))).toBe(true);
+    expect(fixture.applications.every((app) => /demo|fictional/i.test(`${app.company} ${app.notes}`))).toBe(true);
+
+    const appKeys = new Set(fixture.applications.map((app) => app.demoKey));
+    expect(fixture.events.length).toBeGreaterThanOrEqual(fixture.applications.length);
+    expect(fixture.events.length).toBeLessThanOrEqual(20);
+    expect(new Set(fixture.events.map((event) => event.demoKey)).size).toBe(fixture.events.length);
+    for (const event of fixture.events) {
+      expect(appKeys.has(event.applicationDemoKey)).toBe(true);
+      expect(APPLICATION_EVENT_TYPES).toContain(event.type);
+      expect(Number.isNaN(event.occurredAt.getTime())).toBe(false);
+      expect(event.occurredAt.getTime()).toBeLessThanOrEqual(createdAt.getTime());
+    }
+  });
+
+  it("is deterministic for the same creation time", () => {
+    const createdAt = new Date("2026-08-10T12:00:00.000Z");
+    expect(createDemoFixtures(createdAt)).toEqual(createDemoFixtures(createdAt));
+  });
+});

--- a/lib/demo-workspace/__tests__/presentation.test.ts
+++ b/lib/demo-workspace/__tests__/presentation.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { realApplications } from "../presentation";
+
+const app = (id: string, isDemo: boolean) => ({ id, isDemo });
+
+describe("demo presentation statistics", () => {
+  it("returns zero real rows for a demo-only workspace", () => {
+    expect(realApplications([app("demo", true)])).toEqual([]);
+  });
+
+  it("keeps only real and legacy unmarked rows in a mixed workspace", () => {
+    const legacy = { id: "legacy", isDemo: undefined };
+    expect(realApplications([app("demo", true), app("real", false), legacy])).toEqual([app("real", false), legacy]);
+  });
+});

--- a/lib/demo-workspace/fixtures.ts
+++ b/lib/demo-workspace/fixtures.ts
@@ -1,0 +1,104 @@
+import type { ApplicationEventType } from "@/lib/applications/events";
+import type { ApplicationStatus } from "@/types";
+
+export const DEMO_FIXTURE_VERSION = 1;
+
+export interface DemoApplicationFixture {
+  demoKey: string;
+  company: string;
+  role: string;
+  status: ApplicationStatus;
+  appliedAt: Date | null;
+  lastContact: Date | null;
+  followUpAt: Date | null;
+  notes: string;
+  source: string;
+  remote: boolean;
+  salaryMin: number | null;
+  salaryMax: number | null;
+  rating: number | null;
+}
+
+export interface DemoEventFixture {
+  demoKey: string;
+  applicationDemoKey: string;
+  type: ApplicationEventType;
+  occurredAt: Date;
+  source: string;
+  actor: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface DemoFixtures {
+  seedVersion: number;
+  createdAt: Date;
+  applications: DemoApplicationFixture[];
+  events: DemoEventFixture[];
+}
+
+function daysBefore(anchor: Date, days: number): Date {
+  return new Date(anchor.getTime() - days * 86_400_000);
+}
+
+export function createDemoFixtures(createdAt = new Date()): DemoFixtures {
+  const anchor = new Date(createdAt);
+  return {
+    seedVersion: DEMO_FIXTURE_VERSION,
+    createdAt: anchor,
+    applications: [
+      {
+        demoKey: "northstar-product-engineer",
+        company: "Northstar Labs (Fictional Demo)",
+        role: "Senior Product Engineer",
+        status: "interview",
+        appliedAt: daysBefore(anchor, 18),
+        lastContact: daysBefore(anchor, 2),
+        followUpAt: daysBefore(anchor, -3),
+        notes: "Fictional demo opportunity for exploring interviews and follow-ups.",
+        source: "demo",
+        remote: true,
+        salaryMin: 95000,
+        salaryMax: 120000,
+        rating: 5,
+      },
+      {
+        demoKey: "acme-platform-engineer",
+        company: "Acme Cloud (Fictional Demo)",
+        role: "Platform Engineer",
+        status: "applied",
+        appliedAt: daysBefore(anchor, 8),
+        lastContact: null,
+        followUpAt: daysBefore(anchor, -1),
+        notes: "Fictional demo opportunity showing an active application.",
+        source: "demo",
+        remote: false,
+        salaryMin: 85000,
+        salaryMax: 105000,
+        rating: 4,
+      },
+      {
+        demoKey: "bluebird-backend-engineer",
+        company: "Bluebird Systems (Fictional Demo)",
+        role: "Backend Engineer",
+        status: "inbound",
+        appliedAt: null,
+        lastContact: null,
+        followUpAt: null,
+        notes: "Fictional demo lead ready for qualification.",
+        source: "demo",
+        remote: true,
+        salaryMin: null,
+        salaryMax: null,
+        rating: 3,
+      },
+    ],
+    events: [
+      { demoKey: "northstar-discovered", applicationDemoKey: "northstar-product-engineer", type: "opportunity_discovered", occurredAt: daysBefore(anchor, 21), source: "demo", actor: "demo-workspace", metadata: { channel: "website" } },
+      { demoKey: "northstar-contact", applicationDemoKey: "northstar-product-engineer", type: "recruiter_contacted", occurredAt: daysBefore(anchor, 2), source: "demo", actor: "demo-workspace", metadata: { channel: "email", outcome: "interview invited" } },
+      { demoKey: "northstar-interview", applicationDemoKey: "northstar-product-engineer", type: "interview_scheduled", occurredAt: daysBefore(anchor, 1), source: "demo", actor: "demo-workspace", metadata: { interviewType: "technical", scheduledAt: daysBefore(anchor, -4).toISOString(), durationMinutes: 60 } },
+      { demoKey: "acme-discovered", applicationDemoKey: "acme-platform-engineer", type: "opportunity_discovered", occurredAt: daysBefore(anchor, 10), source: "demo", actor: "demo-workspace", metadata: { channel: "referral" } },
+      { demoKey: "acme-applied", applicationDemoKey: "acme-platform-engineer", type: "stage_changed", occurredAt: daysBefore(anchor, 8), source: "demo", actor: "demo-workspace", metadata: { fromStage: "inbound", toStage: "applied", toStatus: "applied" } },
+      { demoKey: "bluebird-discovered", applicationDemoKey: "bluebird-backend-engineer", type: "opportunity_discovered", occurredAt: daysBefore(anchor, 3), source: "demo", actor: "demo-workspace", metadata: { channel: "linkedin" } },
+    ],
+  };
+}

--- a/lib/demo-workspace/presentation.ts
+++ b/lib/demo-workspace/presentation.ts
@@ -1,0 +1,3 @@
+export function realApplications<T extends { isDemo?: boolean }>(applications: readonly T[]): T[] {
+  return applications.filter((application) => application.isDemo !== true);
+}

--- a/lib/documents/__tests__/provenance.test.ts
+++ b/lib/documents/__tests__/provenance.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+import { sanitizeDocumentAssociations } from "../provenance";
+
+describe("sanitizeDocumentAssociations durable demo provenance", () => {
+  it("rejects a detached document that previously had demo provenance", async () => {
+    const resolve = vi.fn();
+
+    const result = await sanitizeDocumentAssociations({
+      id: "doc-1",
+      demoProvenance: true,
+      applicationIds: [],
+      applications: [],
+    }, resolve);
+
+    expect(result).toBeNull();
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it("keeps a confirmed real association while stripping internal provenance", async () => {
+    const result = await sanitizeDocumentAssociations({
+      id: "doc-1",
+      demoProvenance: true,
+      applicationIds: ["real-app"],
+      applications: [{ id: "real-app" }],
+    }, async () => ({ id: "real-app" }));
+
+    expect(result).toEqual({ id: "doc-1", applications: [{ id: "real-app" }] });
+  });
+});

--- a/lib/documents/__tests__/service.test.ts
+++ b/lib/documents/__tests__/service.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const deleteFile = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/storage", () => ({ deleteFile }));
+
+import { deleteDocumentWithContent } from "../service";
+
+const guard = { requireNonDemoProvenance: true } as const;
+
+function adapter(deleteDocument: ReturnType<typeof vi.fn>) {
+  return { deleteDocument } as never;
+}
+
+describe("deleteDocumentWithContent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not delete content when the transactional provenance guard rejects", async () => {
+    const deleteDocument = vi.fn().mockRejectedValue(new Error("not_found"));
+
+    await expect(
+      deleteDocumentWithContent(adapter(deleteDocument), "doc-1", "owner-1", guard),
+    ).rejects.toThrow("not_found");
+
+    expect(deleteDocument).toHaveBeenCalledWith("doc-1", "owner-1", guard);
+    expect(deleteFile).not.toHaveBeenCalled();
+  });
+
+  it("does not delete content when document metadata is absent", async () => {
+    const deleteDocument = vi.fn().mockResolvedValue(null);
+
+    await expect(
+      deleteDocumentWithContent(adapter(deleteDocument), "doc-1", "owner-1", guard),
+    ).resolves.toBeNull();
+
+    expect(deleteFile).not.toHaveBeenCalled();
+  });
+
+  it("deletes content only after guarded metadata deletion succeeds", async () => {
+    const document = { id: "doc-1", filename: "stored.pdf" };
+    const deleteDocument = vi.fn().mockResolvedValue(document);
+
+    await expect(
+      deleteDocumentWithContent(adapter(deleteDocument), "doc-1", "owner-1", guard),
+    ).resolves.toBe(document);
+
+    expect(deleteDocument).toHaveBeenCalledWith("doc-1", "owner-1", guard);
+    expect(deleteFile).toHaveBeenCalledWith("stored.pdf");
+    expect(deleteDocument.mock.invocationCallOrder[0]).toBeLessThan(
+      deleteFile.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("propagates storage cleanup failures without repeating metadata deletion", async () => {
+    const deleteDocument = vi.fn().mockResolvedValue({ id: "doc-1", filename: "stored.pdf" });
+    deleteFile.mockRejectedValue(new Error("storage_failed"));
+
+    await expect(
+      deleteDocumentWithContent(adapter(deleteDocument), "doc-1", "owner-1", guard),
+    ).rejects.toThrow("storage_failed");
+
+    expect(deleteDocument).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/documents/__tests__/upload.test.ts
+++ b/lib/documents/__tests__/upload.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { mockCreateDocument, mockUploadFile } = vi.hoisted(() => ({
+const { mockCreateDocument, mockUploadFile, mockDeleteFile } = vi.hoisted(() => ({
   mockCreateDocument: vi.fn(),
   mockUploadFile: vi.fn(),
+  mockDeleteFile: vi.fn(),
 }));
 
 vi.mock("@/lib/db", () => ({
@@ -11,6 +12,7 @@ vi.mock("@/lib/db", () => ({
 
 vi.mock("@/lib/storage", () => ({
   uploadFile: mockUploadFile,
+  deleteFile: mockDeleteFile,
 }));
 
 import {
@@ -36,6 +38,7 @@ describe("uploadDocument", () => {
   beforeEach(() => {
     mockCreateDocument.mockReset();
     mockUploadFile.mockReset();
+    mockDeleteFile.mockReset();
     mockCreateDocument.mockResolvedValue(fixtureDoc);
   });
 
@@ -65,7 +68,7 @@ describe("uploadDocument", () => {
       version: 1,
       contentHash: expect.stringMatching(/^[0-9a-f]{64}$/),
       source: "upload",
-    });
+    }, undefined);
   });
 
   it("rejects files over 10MB before writing storage", async () => {
@@ -111,6 +114,7 @@ describe("uploadDocumentContent", () => {
   beforeEach(() => {
     mockCreateDocument.mockReset();
     mockUploadFile.mockReset();
+    mockDeleteFile.mockReset();
     mockCreateDocument.mockResolvedValue(fixtureDoc);
   });
 
@@ -144,5 +148,24 @@ describe("uploadDocumentContent", () => {
     expect(res.isError).toBe(true);
     expect(res.content[0].text).toMatch(/invalid base64/i);
     expect(mockUploadFile).not.toHaveBeenCalled();
+  });
+
+  it("guards creation transactionally and removes storage when a parent becomes forbidden", async () => {
+    mockCreateDocument.mockRejectedValue(new Error("invalid_applications"));
+
+    const res = await uploadDocumentContent({
+      filename: "CV.pdf",
+      mimeType: "application/pdf",
+      contentBase64: PDF_BYTES.toString("base64"),
+      applicationIds: ["app-1"],
+    }, "user-1");
+
+    expect(res.isError).toBe(true);
+    expect(mockCreateDocument).toHaveBeenCalledWith(
+      "user-1",
+      expect.objectContaining({ applicationIds: ["app-1"] }),
+      { requireNonDemoProvenance: true },
+    );
+    expect(mockDeleteFile).toHaveBeenCalledTimes(1);
   });
 });

--- a/lib/documents/provenance.ts
+++ b/lib/documents/provenance.ts
@@ -4,6 +4,7 @@ export interface DocumentAssociationRef {
 
 export interface DocumentAssociationRecord {
   applicationIds?: string[];
+  demoProvenance?: boolean;
   applications?: DocumentAssociationRef[];
 }
 
@@ -19,9 +20,10 @@ export async function sanitizeDocumentAssociations<T extends DocumentAssociation
   const hydrated = Array.isArray(document.applications) ? document.applications : [];
   const withoutRawIds = { ...document };
   delete withoutRawIds.applicationIds;
+  delete withoutRawIds.demoProvenance;
 
   if (!hydrated.length) {
-    return rawIds.length ? null : withoutRawIds as T;
+    return rawIds.length || document.demoProvenance === true ? null : withoutRawIds as T;
   }
 
   const visible = await Promise.all(

--- a/lib/documents/provenance.ts
+++ b/lib/documents/provenance.ts
@@ -1,0 +1,37 @@
+export interface DocumentAssociationRef {
+  id: string;
+}
+
+export interface DocumentAssociationRecord {
+  applicationIds?: string[];
+  applications?: DocumentAssociationRef[];
+}
+
+/**
+ * Fail-closed document boundary for machine and public paths.
+ * Raw association IDs are internal provenance and are never returned.
+ */
+export async function sanitizeDocumentAssociations<T extends DocumentAssociationRecord>(
+  document: T,
+  resolveVisibleParent: (id: string) => Promise<unknown | null>,
+): Promise<T | null> {
+  const rawIds = Array.isArray(document.applicationIds) ? document.applicationIds : [];
+  const hydrated = Array.isArray(document.applications) ? document.applications : [];
+  const withoutRawIds = { ...document };
+  delete withoutRawIds.applicationIds;
+
+  if (!hydrated.length) {
+    return rawIds.length ? null : withoutRawIds as T;
+  }
+
+  const visible = await Promise.all(
+    hydrated.map(async (application) =>
+      await resolveVisibleParent(application.id) ? application : null),
+  );
+  const applications = visible.filter(
+    (application): application is DocumentAssociationRef => application !== null,
+  );
+  if (!applications.length) return null;
+
+  return { ...withoutRawIds, applications } as T;
+}

--- a/lib/documents/service.ts
+++ b/lib/documents/service.ts
@@ -1,6 +1,6 @@
 import { deleteFile } from "@/lib/storage";
 import type { DatabaseAdapter } from "@/lib/db/adapter";
-import type { DocumentRecord } from "@/lib/db/types";
+import type { DocumentMutationOptions, DocumentRecord } from "@/lib/db/types";
 
 /**
  * Shared deletion path for REST and MCP. Database metadata is removed first so
@@ -11,8 +11,9 @@ export async function deleteDocumentWithContent(
   db: DatabaseAdapter,
   id: string,
   userId: string,
+  options?: DocumentMutationOptions,
 ): Promise<DocumentRecord | null> {
-  const document = await db.deleteDocument(id, userId);
+  const document = await db.deleteDocument(id, userId, options);
   if (!document) return null;
   await deleteFile(document.filename);
   return document;

--- a/lib/documents/upload.ts
+++ b/lib/documents/upload.ts
@@ -1,7 +1,7 @@
 import crypto from "crypto";
 import { getDb } from "@/lib/db";
 import { deleteFile, uploadFile } from "@/lib/storage";
-import type { DocumentRecord } from "@/lib/db/types";
+import type { DocumentMutationOptions, DocumentRecord } from "@/lib/db/types";
 
 export const MAX_DOCUMENT_UPLOAD_SIZE = 10 * 1024 * 1024;
 export const MAX_DOCUMENT_BASE64_SIZE = Math.ceil(MAX_DOCUMENT_UPLOAD_SIZE / 3) * 4 + 4;
@@ -40,6 +40,7 @@ export type UploadDocumentInput = {
   mimeType: string;
   buffer: Buffer;
   applicationIds?: string[];
+  mutationOptions?: DocumentMutationOptions;
 };
 
 export type McpToolResponse = {
@@ -85,6 +86,7 @@ export async function uploadDocument({
   mimeType,
   buffer,
   applicationIds = [],
+  mutationOptions,
 }: UploadDocumentInput): Promise<DocumentRecord> {
   if (buffer.length > MAX_DOCUMENT_UPLOAD_SIZE) {
     throw new DocumentUploadError("too_large", "File too large (max 10 MB)");
@@ -114,7 +116,7 @@ export async function uploadDocument({
       version: 1,
       contentHash: crypto.createHash("sha256").update(buffer).digest("hex"),
       source: "upload",
-    });
+    }, mutationOptions);
   } catch (error) {
     await deleteFile(storedFilename).catch(() => {});
     throw error;
@@ -138,6 +140,7 @@ export async function uploadDocumentContent(
       mimeType: args.mimeType,
       buffer: decodeBase64Content(args.contentBase64),
       applicationIds: args.applicationIds,
+      mutationOptions: { requireNonDemoProvenance: true },
     });
     const visible = sanitizeDocument ? await sanitizeDocument(doc) : doc;
     if (!visible) {

--- a/lib/documents/upload.ts
+++ b/lib/documents/upload.ts
@@ -129,6 +129,7 @@ export async function uploadDocumentContent(
     applicationIds?: string[];
   },
   userId: string,
+  sanitizeDocument?: (document: DocumentRecord) => Promise<DocumentRecord | null>,
 ): Promise<McpToolResponse> {
   try {
     const doc = await uploadDocument({
@@ -138,8 +139,12 @@ export async function uploadDocumentContent(
       buffer: decodeBase64Content(args.contentBase64),
       applicationIds: args.applicationIds,
     });
+    const visible = sanitizeDocument ? await sanitizeDocument(doc) : doc;
+    if (!visible) {
+      return { content: [{ type: "text", text: "Application not found or access denied" }], isError: true };
+    }
     return {
-      content: [{ type: "text", text: JSON.stringify(doc, null, 2) }],
+      content: [{ type: "text", text: JSON.stringify(visible, null, 2) }],
     };
   } catch (err) {
     if (err instanceof DocumentUploadError) {

--- a/messages/de.json
+++ b/messages/de.json
@@ -224,10 +224,17 @@
     "triage_weak": "Schwach",
     "triage_pass": "Ablehnen",
     "triage_unrated": "Unbewertet",
-    "triage_action": "Du hast {count} hochpriorisierte Opportunities zu prüfen"
+    "triage_action": "Du hast {count} hochpriorisierte Opportunities zu prüfen",
+    "demo_banner_title": "Demo-Workspace",
+    "demo_banner_description": "Diese klar markierten fiktiven Bewerbungen zeigen den Workflow und werden aus regulären Statistiken ausgeschlossen.",
+    "remove_demo": "Demo-Workspace entfernen",
+    "removing_demo": "Demo-Workspace wird entfernt…",
+    "demo_remove_error": "Der Demo-Workspace konnte nicht sicher entfernt werden.",
+    "demo_create_error": "Der Demo-Workspace konnte nicht erstellt werden."
   },
   "confirm": {
     "delete": "Opportunity wirklich löschen?",
+    "remove_demo": "Den vollständigen Demo-Workspace entfernen? Deine echten Bewerbungen werden nicht verändert.",
     "bulk_archive_confirm": "{count} ausgewählte Opportunities archivieren?",
     "bulk_delete_confirm": "{count} ausgewählte Opportunities löschen? Dies kann nicht rückgängig gemacht werden."
   },
@@ -533,6 +540,9 @@
     "create_app": "Opportunity erstellen",
     "required_fields": "Kunde und Projekt sind Pflichtfelder.",
     "error_create": "Fehler beim Erstellen der Opportunity.",
+    "create_demo": "Demo-Workspace erstellen",
+    "creating_demo": "Demo-Workspace wird erstellt…",
+    "error_create_demo": "Der Demo-Workspace konnte nicht erstellt werden.",
     "done_title": "Alles bereit!",
     "done_description": "Dein CRM ist einsatzbereit. Hier sind ein paar Tipps:",
     "tips_title": "Schnelltipps",
@@ -753,8 +763,13 @@
     "filtered_empty_title": "Keine passenden Opportunities",
     "filtered_empty_description": "Deine Opportunities sind weiterhin da. Passe die aktiven Filter an oder lösche sie.",
     "create": "Neue Opportunity",
+    "create_demo": "Demo-Workspace erstellen",
+    "creating_demo": "Demo-Workspace wird erstellt…",
     "clear_filters": "Filter löschen",
     "dismiss_overdue": "Überfällige Wiedervorlage für {company} ausblenden"
+  },
+  "demoWorkspace": {
+    "badge": "Demo"
   },
   "events": {
     "eventTypes": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -224,10 +224,17 @@
     "triage_weak": "Weak",
     "triage_pass": "Pass",
     "triage_unrated": "Unrated",
-    "triage_action": "You have {count} high-priority opportunities to review"
+    "triage_action": "You have {count} high-priority opportunities to review",
+    "demo_banner_title": "Demo workspace",
+    "demo_banner_description": "These clearly marked fictional opportunities demonstrate the workflow and are excluded from regular statistics.",
+    "remove_demo": "Remove demo workspace",
+    "removing_demo": "Removing demo workspace…",
+    "demo_remove_error": "The demo workspace could not be removed safely.",
+    "demo_create_error": "The demo workspace could not be created."
   },
   "confirm": {
     "delete": "Really delete this opportunity?",
+    "remove_demo": "Remove the complete demo workspace? Your real opportunities will not be changed.",
     "bulk_archive_confirm": "Archive {count} selected opportunities?",
     "bulk_delete_confirm": "Delete {count} selected opportunities? This cannot be undone."
   },
@@ -533,6 +540,9 @@
     "create_app": "Create Opportunity",
     "required_fields": "Account and opportunity are required.",
     "error_create": "Failed to create opportunity.",
+    "create_demo": "Create demo workspace",
+    "creating_demo": "Creating demo workspace…",
+    "error_create_demo": "Failed to create the demo workspace.",
     "done_title": "You're All Set!",
     "done_description": "Your CRM is ready to use. Here are some tips to get you started:",
     "tips_title": "Quick Tips",
@@ -753,8 +763,13 @@
     "filtered_empty_title": "No matching opportunities",
     "filtered_empty_description": "Your opportunities are still here. Adjust or clear the active filters.",
     "create": "New opportunity",
+    "create_demo": "Create demo workspace",
+    "creating_demo": "Creating demo workspace…",
     "clear_filters": "Clear filters",
     "dismiss_overdue": "Dismiss overdue follow-up for {company}"
+  },
+  "demoWorkspace": {
+    "badge": "Demo"
   },
   "events": {
     "eventTypes": {

--- a/openspec/changes/add-demo-workspace-onboarding/.openspec.yaml
+++ b/openspec/changes/add-demo-workspace-onboarding/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-10

--- a/openspec/changes/add-demo-workspace-onboarding/design.md
+++ b/openspec/changes/add-demo-workspace-onboarding/design.md
@@ -49,7 +49,7 @@ The onboarding wizard and true-empty state can call `POST /api/demo-workspace`. 
 
 ### 5. Seed CLI is a guarded lifecycle client
 
-`prisma/seed.ts` requires `DEMO_SEED_USER_ID`, rejects `NODE_ENV=production` and production deployment markers, resolves the configured adapter, and calls `ensureDemoWorkspace`. It performs no deletion and never chooses the first user. Failures set a non-zero exit code.
+`prisma/seed.ts` rejects `NODE_ENV=production` and production deployment markers, then requires `DEMO_SEED_ENABLED` to equal the exact string `true` and requires `DEMO_SEED_USER_ID`, all before resolving the configured adapter. Only after those guards pass does it call `ensureDemoWorkspace`. Missing or non-`true` opt-in values fail closed. It performs no deletion and never chooses the first user. Failures set a non-zero exit code.
 
 **Why:** The seed command becomes an explicit development convenience instead of a destructive database initializer.
 

--- a/openspec/changes/add-demo-workspace-onboarding/design.md
+++ b/openspec/changes/add-demo-workspace-onboarding/design.md
@@ -1,0 +1,75 @@
+## Context
+
+Nexus CRM exposes a shared `DatabaseAdapter` through Prisma/PostgreSQL and Firestore. The normal application list powers dashboard views, analytics, public sharing, MCP, and the internal agent, so inserting ordinary sample rows would contaminate metrics and automation. The current `prisma/seed.ts` is unsafe because it chooses an arbitrary user and globally deletes applications.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Give an authenticated user with no real applications an optional, realistic demo workspace.
+- Make demo identity explicit, versioned, owner-scoped, backend-equivalent, idempotent, and concurrency-safe.
+- Keep demos visible and clearly labeled in the interactive CRM while excluding them from real analytics and machine/public interfaces.
+- Remove all generated demo applications/events without touching real or foreign-tenant data.
+- Reuse the lifecycle from a production-blocked, explicit-user seed CLI.
+
+**Non-Goals:**
+- Create demo documents, submissions, contacts, credentials, email integrations, or external files.
+- Convert Application into an event-sourced aggregate.
+- Migrate or classify existing applications as demos from names, notes, URLs, or sources.
+- Expose demo creation through MCP or general application-create payloads.
+
+## Decisions
+
+### 1. First-class workspace plus explicit row markers
+
+Add `DemoWorkspace` keyed uniquely by `userId`, with `seedVersion` and lifecycle state. Add `isDemo`, `demoWorkspaceId`, and stable `demoKey` to applications and events. Database constraints require all-or-none demo markers, and workspace deletion cascades in Prisma.
+
+**Why:** A workspace is a lockable idempotency boundary; explicit row markers make query exclusion, UI labeling, and safe cleanup auditable. Names or `source` strings are unsafe because genuine data can collide.
+
+**Alternative rejected:** only a nullable marker on Application. It cannot reliably represent in-progress/replayed lifecycle state or lock concurrent creates.
+
+### 2. Provider-neutral fixture contract, adapter-owned atomic lifecycle
+
+`lib/demo-workspace/fixtures.ts` defines a small versioned set of fictional applications and coherent events using stable keys and dates relative to creation. `DatabaseAdapter.ensureDemoWorkspace(userId, fixtures)` and `deleteDemoWorkspace(userId)` own persistence semantics.
+
+Prisma uses one transaction and a user-row/workspace lock. Firestore uses deterministic owner-derived document IDs and a transaction/batch lifecycle. Both reject first creation when a non-demo application exists and return replay results for repeated calls.
+
+**Why:** Ordinary create APIs intentionally cannot set demo markers. Adapter-owned methods can enforce backend-specific atomicity without exposing privileged fields.
+
+### 3. Demo visibility is explicit at read boundaries
+
+Application and event reads accept `demoVisibility: "include" | "exclude" | "only"`, defaulting to `include` for the authenticated CRM UI. MCP, agent, and public-share paths always pass `exclude`; direct lookups and read-before-write paths return not-found for demo targets. Event pagination filters at the persistence layer so limits and cursors describe only visible rows.
+
+**Why:** Post-filtering pages gives incorrect totals/cursors and can leak demos through detail or mutation paths. Explicit visibility is clearer than route-specific array filtering.
+
+### 4. UI separates demos from real metrics
+
+The onboarding wizard and true-empty state can call `POST /api/demo-workspace`. The dashboard shows a demo banner and visual badges, and exposes a confirmed `DELETE /api/demo-workspace` action. Dashboard and analytics derive metrics from `applications.filter(!isDemo)` while normal table/Kanban/detail views continue displaying marked demos.
+
+**Why:** Users need to explore the workflow, but sample rows must not look like or count as real pipeline performance.
+
+### 5. Seed CLI is a guarded lifecycle client
+
+`prisma/seed.ts` requires `DEMO_SEED_USER_ID`, rejects `NODE_ENV=production` and production deployment markers, resolves the configured adapter, and calls `ensureDemoWorkspace`. It performs no deletion and never chooses the first user. Failures set a non-zero exit code.
+
+**Why:** The seed command becomes an explicit development convenience instead of a destructive database initializer.
+
+## Risks / Trade-offs
+
+- **[Firestore legacy documents lack `isDemo`]** → Map absence to false and ensure exclusion queries/scans preserve correct logical pagination; add required composite indexes where query shapes permit.
+- **[Concurrent real and demo creation]** → Prisma locks the user boundary; Firestore uses a workspace transaction and deterministic IDs. API rechecks for real rows and fails closed.
+- **[New MCP call site forgets exclusion]** → Centralize an `MCP_DEMO_VISIBILITY` option and add transport tests for list, detail, event, canonical-URL, package, and mutation paths.
+- **[Partial Firestore deletion]** → Persist `deleting` state, reuse retryable application cascade, re-query by `userId + workspaceId + isDemo`, verify no remnants, then remove workspace. Retrying resumes safely.
+- **[Migration rollback leaves marked rows]** → Roll back application code before dropping schema. The migration is additive; old code ignores new columns. Do not drop columns until demo rows/workspaces are removed.
+
+## Migration Plan
+
+1. Deploy the additive Prisma migration and regenerate the client.
+2. Deploy code that treats missing Firestore demo markers as real (`false`) and writes explicit markers for new demos.
+3. Add/update Firestore indexes required by demo-aware query paths.
+4. Deploy API/UI/MCP changes.
+5. Validate Prisma and Firestore adapter contract tests, then run lint, full tests, typecheck, and production build.
+6. Rollback: disable UI/API creation, delete demo workspaces through the lifecycle endpoint if desired, roll back application code, and retain additive columns/table until a later cleanup migration.
+
+## Open Questions
+
+None blocking. Version 1 intentionally contains only applications and events so complete deletion has no external-file or historical-submission retention ambiguity.

--- a/openspec/changes/add-demo-workspace-onboarding/proposal.md
+++ b/openspec/changes/add-demo-workspace-onboarding/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+New users currently enter an empty CRM without a quick way to understand the application and event workflow. A removable demo workspace provides guided, realistic exploration without contaminating real user data, analytics, or MCP automation.
+
+## What Changes
+
+- Add an optional onboarding action that creates a versioned set of clearly marked fictional applications and lifecycle events for the authenticated user only.
+- Persist demo workspace identity and demo markers explicitly and equivalently in Prisma/PostgreSQL and Firestore.
+- Make creation concurrency-safe and idempotent, and allow creation only while the user has no real applications.
+- Exclude demo applications and their child data from regular statistics, public sharing, MCP reads, and MCP mutations.
+- Add an authenticated, owner-scoped action that completely removes only the current user's demo workspace and all of its generated data; repeated deletion remains safe.
+- Harden `prisma/seed.ts`: require an explicit user, reject production, remove every global/arbitrary-user operation, and reuse the same provider-neutral demo workspace lifecycle.
+- Add tenant-isolation, replay/idempotency, MCP visibility, backend-parity, and safe-deletion regression tests.
+
+## Capabilities
+
+### New Capabilities
+
+- `demo-workspace-lifecycle`: Versioned, tenant-scoped creation, visibility, idempotency, and complete deletion of fictional demo applications and events across Prisma and Firestore.
+- `demo-workspace-onboarding`: Optional onboarding and empty-state controls, clear visual demo labeling, statistics exclusion, and safe removal.
+- `demo-data-boundaries`: Demo-data exclusion from MCP, agent, public-share, and regular analytics surfaces, including read-before-write authorization.
+- `safe-development-seeding`: Production-blocked, explicit-user, provider-neutral seeding without global deletion or arbitrary tenant selection.
+
+### Modified Capabilities
+
+_None; this repository currently has no baseline specs under `openspec/specs/`._
+
+## Impact
+
+- **Persistence:** `prisma/schema.prisma`, an additive Prisma migration, `lib/db/types.ts`, `lib/db/adapter.ts`, and both database adapters.
+- **API/security:** a new authenticated `/api/demo-workspace` route plus demo-aware MCP and public-share access paths.
+- **UI:** onboarding, empty-state, dashboard/action menu, application presentation, analytics calculations, and English/German messages.
+- **Operations:** `prisma/seed.ts` becomes explicit, non-production, provider-neutral, and non-destructive.
+- **Tests:** adapter contract coverage, Firestore/Prisma lifecycle tests, route/MCP tests, and focused UI/statistics tests.

--- a/openspec/changes/add-demo-workspace-onboarding/specs/demo-data-boundaries/spec.md
+++ b/openspec/changes/add-demo-workspace-onboarding/specs/demo-data-boundaries/spec.md
@@ -19,6 +19,10 @@ MCP, internal-agent, and public-share application queries SHALL exclude demo app
 - **WHEN** a share page is generated for an owner with demo data
 - **THEN** no demo application is disclosed or counted
 
+#### Scenario: Document detached during demo removal
+- **WHEN** a document previously associated with a demo application is retained while that demo application is removed
+- **THEN** Prisma and Firestore persist durable demo provenance before detachment, machine and public reads fail closed unless a confirmed real parent remains, and internal provenance markers are never returned
+
 ### Requirement: Machine mutations cannot target demos
 MCP and internal-agent read-before-write paths SHALL treat demo applications as unavailable and SHALL not update, delete, attach children to, or derive artifacts from them.
 

--- a/openspec/changes/add-demo-workspace-onboarding/specs/demo-data-boundaries/spec.md
+++ b/openspec/changes/add-demo-workspace-onboarding/specs/demo-data-boundaries/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Machine and public reads exclude demos
+MCP, internal-agent, and public-share application queries SHALL exclude demo applications and demo-owned child data for ordinary and global/admin read scopes.
+
+#### Scenario: MCP list and filtered list
+- **WHEN** MCP lists applications for a tenant or global admin scope
+- **THEN** no demo application is returned and pagination totals describe only real rows
+
+#### Scenario: MCP direct lookup
+- **WHEN** MCP requests a demo application by ID or canonical URL
+- **THEN** the result is indistinguishable from not found
+
+#### Scenario: Event and package queries
+- **WHEN** MCP queries activity, events, submissions, documents, or recall packages
+- **THEN** demo-parent records and demo application references are excluded with correct visible cursors
+
+#### Scenario: Public share
+- **WHEN** a share page is generated for an owner with demo data
+- **THEN** no demo application is disclosed or counted
+
+### Requirement: Machine mutations cannot target demos
+MCP and internal-agent read-before-write paths SHALL treat demo applications as unavailable and SHALL not update, delete, attach children to, or derive artifacts from them.
+
+#### Scenario: Demo-targeted mutation
+- **WHEN** a machine tool attempts update, deletion, event, note, contact, submission, document-link, or CV generation against a demo ID
+- **THEN** the operation returns a controlled not-found/access-denied result and performs no mutation
+
+#### Scenario: Upsert by demo canonical URL
+- **WHEN** MCP upserts a real application using a canonical URL that exists only on a hidden demo
+- **THEN** the demo is not updated and normal real-application conflict/create rules apply
+
+### Requirement: Demo visibility is backend-equivalent
+Prisma and Firestore SHALL apply demo visibility before pagination, limits, cursor generation, nested relation hydration, and aggregate computation.
+
+#### Scenario: Excluded rows precede visible rows
+- **WHEN** demo rows sort before real rows in a bounded query
+- **THEN** the query continues until it fills the visible page or exhausts real rows and returns a cursor based only on visible data

--- a/openspec/changes/add-demo-workspace-onboarding/specs/demo-workspace-lifecycle/spec.md
+++ b/openspec/changes/add-demo-workspace-onboarding/specs/demo-workspace-lifecycle/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Tenant-scoped versioned demo creation
+The system SHALL create a versioned demo workspace only for the authenticated user's tenant, only when that tenant has no real applications, and SHALL create explicitly marked fictional applications and events through both Prisma and Firestore.
+
+#### Scenario: Empty tenant creates demos
+- **WHEN** an authenticated user with no real applications requests demo creation
+- **THEN** the system creates the expected marked applications and events owned only by that user
+
+#### Scenario: Tenant with real data is rejected
+- **WHEN** a user with at least one non-demo application requests first-time demo creation
+- **THEN** the system returns a controlled conflict and performs no writes
+
+#### Scenario: Backend parity
+- **WHEN** the same fixture version is created through Prisma and Firestore
+- **THEN** both backends expose equivalent logical demo applications, events, keys, and ownership markers
+
+### Requirement: Idempotent and concurrency-safe lifecycle
+The system SHALL converge repeated or concurrent create requests on one logical workspace and one record per stable demo key.
+
+#### Scenario: Repeated creation
+- **WHEN** the owner repeats demo creation for an existing ready workspace of the same version
+- **THEN** the system returns the existing workspace as a replay without duplicates
+
+#### Scenario: Concurrent creation
+- **WHEN** two creation requests run concurrently for the same owner and fixture version
+- **THEN** exactly one logical workspace and one copy of every fixture exist
+
+### Requirement: Complete owner-scoped deletion
+The system SHALL remove only demo data belonging to the authenticated user's workspace, SHALL remove all generated applications and events, and SHALL treat repeated deletion as success.
+
+#### Scenario: Mixed real and demo records
+- **WHEN** an owner removes their demo workspace while real applications exist
+- **THEN** only that owner's marked demo applications, events, and workspace metadata are deleted
+
+#### Scenario: Foreign tenant protection
+- **WHEN** one tenant deletes its demo workspace
+- **THEN** another tenant's real and demo data remain unchanged
+
+#### Scenario: Delete replay
+- **WHEN** deletion is repeated after the workspace is absent
+- **THEN** the operation succeeds with zero additional deletions
+
+#### Scenario: Firestore retry after partial failure
+- **WHEN** Firestore deletion is interrupted after a partial batch
+- **THEN** retrying resumes the deleting lifecycle and eventually leaves no owner-scoped demo remnants

--- a/openspec/changes/add-demo-workspace-onboarding/specs/demo-workspace-onboarding/spec.md
+++ b/openspec/changes/add-demo-workspace-onboarding/specs/demo-workspace-onboarding/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Optional empty-CRM demo action
+The onboarding wizard and regular true-empty state SHALL offer an optional action to create a demo workspace without replacing the existing real-application and skip actions.
+
+#### Scenario: Onboarding creation succeeds
+- **WHEN** a new user chooses the demo action
+- **THEN** the UI disables duplicate submission, creates the workspace, refreshes application data, completes onboarding, and displays the demo workflow
+
+#### Scenario: Creation fails
+- **WHEN** the demo API returns an error
+- **THEN** the onboarding remains available and displays a localized, retryable error
+
+### Requirement: Clear visual separation
+Every demo application displayed in the dashboard, table, Kanban, focus, and detail surfaces SHALL be visibly identified as fictional demo data, and the dashboard SHALL show a demo-workspace notice.
+
+#### Scenario: Demo record presentation
+- **WHEN** a marked demo application is displayed
+- **THEN** a localized Demo badge or equivalent unambiguous label is visible
+
+### Requirement: Demo-free regular statistics
+Dashboard and analytics statistics SHALL calculate only from non-demo applications while marked demos remain browsable in CRM views.
+
+#### Scenario: Demo-only workspace
+- **WHEN** a workspace contains only demo applications
+- **THEN** all regular pipeline and analytics metrics report zero real applications
+
+#### Scenario: Mixed workspace
+- **WHEN** real and demo applications coexist
+- **THEN** metrics equal the values calculated from real applications alone
+
+### Requirement: Safe removal control
+An owner with a demo workspace SHALL have a localized, confirmed action that removes the workspace and refreshes all affected application and activity views.
+
+#### Scenario: Remove demo workspace
+- **WHEN** the owner confirms removal
+- **THEN** the UI calls the owner-scoped delete endpoint, clears demo selections, refreshes cached data, and preserves real records

--- a/openspec/changes/add-demo-workspace-onboarding/specs/safe-development-seeding/spec.md
+++ b/openspec/changes/add-demo-workspace-onboarding/specs/safe-development-seeding/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Seed execution is explicitly non-production
+The development seed command SHALL fail before database writes in production or when the target user is not explicitly supplied.
+
+#### Scenario: Production execution
+- **WHEN** the seed command runs with `NODE_ENV=production` or a production deployment marker
+- **THEN** it exits non-zero without reading, deleting, or creating application data
+
+#### Scenario: Missing target user
+- **WHEN** no explicit demo seed user ID is supplied
+- **THEN** the command exits non-zero and does not select an arbitrary user
+
+### Requirement: Seed is non-destructive and provider-neutral
+The seed command SHALL use the configured database adapter's demo-workspace lifecycle and SHALL never perform global deletion or alter real applications.
+
+#### Scenario: Existing real data
+- **WHEN** the target user or another tenant has real applications
+- **THEN** the seed command performs no deletion and follows normal demo-creation eligibility rules
+
+#### Scenario: Configured backend
+- **WHEN** the command runs with Prisma or Firestore configured
+- **THEN** it invokes the same versioned provider-neutral fixture contract and lifecycle semantics
+
+### Requirement: Seed replay is safe
+Repeated seed execution for the same target SHALL converge without duplicates and failures SHALL produce a non-zero process exit status.
+
+#### Scenario: Seed replay
+- **WHEN** the seed runs twice for an existing demo workspace
+- **THEN** the second run reports replay and creates no duplicate application or event
+
+#### Scenario: Seed failure
+- **WHEN** persistence returns an error
+- **THEN** the command exits non-zero and does not report success

--- a/openspec/changes/add-demo-workspace-onboarding/specs/safe-development-seeding/spec.md
+++ b/openspec/changes/add-demo-workspace-onboarding/specs/safe-development-seeding/spec.md
@@ -1,15 +1,23 @@
 ## ADDED Requirements
 
-### Requirement: Seed execution is explicitly non-production
-The development seed command SHALL fail before database writes in production or when the target user is not explicitly supplied.
+### Requirement: Seed execution requires explicit development authorization
+The development seed command SHALL reject production environments, then require `DEMO_SEED_ENABLED` to equal the exact string `true` and an explicitly supplied target user before resolving a database adapter or accessing application data.
 
 #### Scenario: Production execution
 - **WHEN** the seed command runs with `NODE_ENV=production` or a production deployment marker
-- **THEN** it exits non-zero without reading, deleting, or creating application data
+- **THEN** it exits non-zero before adapter resolution without reading, deleting, or creating application data
+
+#### Scenario: Missing seed opt-in
+- **WHEN** `DEMO_SEED_ENABLED` is absent
+- **THEN** the command exits non-zero before adapter resolution or database access
+
+#### Scenario: Non-true seed opt-in
+- **WHEN** `DEMO_SEED_ENABLED` has any value other than the exact string `true`
+- **THEN** the command exits non-zero before adapter resolution or database access
 
 #### Scenario: Missing target user
 - **WHEN** no explicit demo seed user ID is supplied
-- **THEN** the command exits non-zero and does not select an arbitrary user
+- **THEN** the command exits non-zero before adapter resolution and does not select an arbitrary user
 
 ### Requirement: Seed is non-destructive and provider-neutral
 The seed command SHALL use the configured database adapter's demo-workspace lifecycle and SHALL never perform global deletion or alter real applications.

--- a/openspec/changes/add-demo-workspace-onboarding/tasks.md
+++ b/openspec/changes/add-demo-workspace-onboarding/tasks.md
@@ -1,0 +1,38 @@
+## 1. Persistence contract (RED → GREEN)
+
+- [x] 1.1 Add failing fixture-contract tests for stable unique keys, coherent fictional labels/events, bounded counts, and valid dates/statuses.
+- [x] 1.2 Implement the provider-neutral versioned demo fixture module until fixture tests pass.
+- [x] 1.3 Add failing shared adapter contract tests for owner isolation, empty-CRM eligibility, repeated/concurrent creation, visibility modes, and repeated safe deletion.
+- [x] 1.4 Add Prisma schema fields, `DemoWorkspace`, constraints/indexes, and an additive migration; regenerate Prisma Client.
+- [x] 1.5 Extend database record/filter/result types and `DatabaseAdapter` with explicit demo visibility and lifecycle methods.
+- [x] 1.6 Implement atomic Prisma create/replay/delete and visibility predicates; prove focused Prisma tests pass.
+- [x] 1.7 Implement deterministic Firestore create/replay and retryable owner/workspace-scoped deletion, including legacy missing-marker handling and logical pagination; prove focused Firestore tests pass.
+
+## 2. API and security boundaries (RED → GREEN)
+
+- [x] 2.1 Add failing `/api/demo-workspace` route tests for authentication, use of `auth.userId`, conflict on real data, replay, and deletion isolation.
+- [x] 2.2 Implement authenticated POST/DELETE lifecycle endpoints with controlled errors and cache-safe responses.
+- [x] 2.3 Add failing MCP transport tests covering demo exclusion from list/detail/filtered/canonical URL/events/activity/packages/health and rejection of demo-targeted mutations.
+- [x] 2.4 Apply `demoVisibility: "exclude"` consistently to MCP and internal-agent list, detail, nested, read-before-write, and canonical-URL paths; prove focused tests pass.
+- [x] 2.5 Add failing public-share tests and exclude demo applications before disclosure and share statistics.
+
+## 3. Onboarding and presentation (RED → GREEN)
+
+- [x] 3.1 Add failing onboarding tests for optional demo creation, pending state, localized failure, query invalidation, and completion.
+- [x] 3.2 Implement the onboarding and true-empty demo actions using a dashboard-owned mutation.
+- [x] 3.3 Add failing UI/statistics tests proving demo-only metrics are zero, mixed metrics count only real data, and demo removal preserves real rows.
+- [x] 3.4 Add localized demo banner/badges and confirmed removal control; display markers in focus, table, Kanban, and application detail surfaces.
+- [x] 3.5 Filter demo rows from dashboard/analytics calculations while keeping them browsable, and add English/German translations.
+
+## 4. Safe seed command (RED → GREEN)
+
+- [x] 4.1 Add failing tests for production rejection, required explicit user ID, no global deletion/arbitrary user selection, adapter selection, replay, and non-zero failures.
+- [x] 4.2 Replace `prisma/seed.ts` with a guarded provider-neutral demo lifecycle client and verify it contains no global delete operation.
+
+## 5. Verification and delivery
+
+- [x] 5.1 Run focused tenant-isolation, idempotency, deletion, MCP, seed, and UI tests and record real output.
+- [x] 5.2 Run `npm run lint`, full `npm test`, `npx tsc --noEmit`, and `npm run build`; fix every introduced failure.
+- [x] 5.3 Run `openspec validate add-demo-workspace-onboarding --strict` and reconcile every task checkbox with repository state.
+- [x] 5.4 Review the final diff for cross-tenant, fail-open, migration, seed, pagination, and unrelated-change risks.
+- [ ] 5.5 Commit conventionally, push `feat/demo-workspace-onboarding`, open a detailed PR, verify base/head/files, and monitor CI without merging.

--- a/prisma/__tests__/demo-workspace-migration.test.ts
+++ b/prisma/__tests__/demo-workspace-migration.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const migration = readFileSync(
+  new URL("../migrations/20260810153500_add_demo_workspace/migration.sql", import.meta.url),
+  "utf8",
+);
+
+describe("demo workspace migration", () => {
+  it("keeps legacy event rows valid and enforces parent tenant/classification", () => {
+    expect(migration).toContain('ADD COLUMN "isDemo" BOOLEAN NOT NULL DEFAULT false');
+    expect(migration).toContain('UNIQUE ("id", "userId", "isDemo")');
+    expect(migration).toMatch(/FOREIGN KEY \("applicationId", "userId", "isDemo"\)[\s\S]*REFERENCES "Application"\("id", "userId", "isDemo"\)/);
+  });
+
+  it("enforces exact demo workspace equality for demo event children", () => {
+    expect(migration).toContain('CREATE FUNCTION "check_application_event_demo_parent"()');
+    expect(migration).toContain('parent."demoWorkspaceId" IS DISTINCT FROM NEW."demoWorkspaceId"');
+    expect(migration).toContain('CREATE TRIGGER "ApplicationEvent_demo_parent_trigger"');
+  });
+});

--- a/prisma/__tests__/recovery-workflow.test.ts
+++ b/prisma/__tests__/recovery-workflow.test.ts
@@ -22,10 +22,16 @@ describe("production database recovery workflow", () => {
   it("only restarts after verification, bounds activation, and otherwise remains fail-closed", () => {
     const verified = workflow.indexOf('echo "Applications after migration: ${count_after}"');
     const restart = workflow.indexOf('timeout 120 docker compose -f docker-compose.yaml up -d "${service}"');
+    const readiness = workflow.indexOf('path:"/login",timeout:3000');
+    const activated = workflow.indexOf("service_stopped=0", restart);
 
     const cleanup = workflow.match(/cleanup_transition_on_exit\(\) \{([\s\S]*?)\n          \}/)?.[1] ?? "";
     expect(restart).toBeGreaterThan(verified);
+    expect(readiness).toBeGreaterThan(restart);
+    expect(activated).toBeGreaterThan(readiness);
+    expect(workflow).toContain("Service readiness probe timed out; refusing activation.");
     expect(workflow).toContain("Service remains stopped; recovery did not reach verified activation.");
     expect(cleanup).not.toContain(" up -d");
+    expect(cleanup).toContain('stop --timeout 30 "${service}"');
   });
 });

--- a/prisma/__tests__/recovery-workflow.test.ts
+++ b/prisma/__tests__/recovery-workflow.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const workflow = readFileSync(
+  new URL("../../.github/workflows/recover-production-db.yml", import.meta.url),
+  "utf8",
+);
+
+describe("production database recovery workflow", () => {
+  it("quiesces the compose service before counting, backing up, or migrating", () => {
+    const stop = workflow.indexOf('timeout 45 docker compose -f docker-compose.yaml stop --timeout 30 "${service}"');
+    const count = workflow.indexOf('count_before="$(db_count)"');
+    const backup = workflow.indexOf('compose_run_bounded "${transition_backup_container}"');
+    const migrate = workflow.indexOf('compose_run_bounded "${transition_migration_container}"');
+
+    expect(stop).toBeGreaterThan(-1);
+    expect(count).toBeGreaterThan(stop);
+    expect(backup).toBeGreaterThan(stop);
+    expect(migrate).toBeGreaterThan(stop);
+  });
+
+  it("only restarts after verification, bounds activation, and otherwise remains fail-closed", () => {
+    const verified = workflow.indexOf('echo "Applications after migration: ${count_after}"');
+    const restart = workflow.indexOf('timeout 120 docker compose -f docker-compose.yaml up -d "${service}"');
+
+    const cleanup = workflow.match(/cleanup_transition_on_exit\(\) \{([\s\S]*?)\n          \}/)?.[1] ?? "";
+    expect(restart).toBeGreaterThan(verified);
+    expect(workflow).toContain("Service remains stopped; recovery did not reach verified activation.");
+    expect(cleanup).not.toContain(" up -d");
+  });
+});

--- a/prisma/__tests__/seed.test.ts
+++ b/prisma/__tests__/seed.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+import { runDemoSeed } from "../seed";
+
+describe("demo seed lifecycle client", () => {
+  const adapter = { ensureDemoWorkspace: vi.fn() };
+
+  it("rejects production before resolving an adapter", async () => {
+    const resolveAdapter = vi.fn();
+    await expect(runDemoSeed({ NODE_ENV: "production", DEMO_SEED_USER_ID: "owner-1" }, resolveAdapter)).rejects.toThrow("production");
+    expect(resolveAdapter).not.toHaveBeenCalled();
+  });
+
+  it("requires an explicit user before resolving an adapter", async () => {
+    const resolveAdapter = vi.fn();
+    await expect(runDemoSeed({
+      NODE_ENV: "development",
+      DEMO_SEED_ENABLED: "true",
+    }, resolveAdapter)).rejects.toThrow("DEMO_SEED_USER_ID");
+    expect(resolveAdapter).not.toHaveBeenCalled();
+  });
+
+  it("requires an explicit positive seed opt-in before resolving an adapter", async () => {
+    const resolveAdapter = vi.fn();
+    await expect(runDemoSeed({
+      NODE_ENV: "development",
+      DEMO_SEED_USER_ID: "owner-1",
+    }, resolveAdapter)).rejects.toThrow("DEMO_SEED_ENABLED=true");
+    expect(resolveAdapter).not.toHaveBeenCalled();
+  });
+
+  it("uses the configured provider-neutral adapter lifecycle and reports replay", async () => {
+    adapter.ensureDemoWorkspace.mockResolvedValue({ replayed: true, applications: [] });
+    const resolveAdapter = vi.fn(() => adapter);
+    const result = await runDemoSeed({
+      NODE_ENV: "development",
+      DEMO_SEED_ENABLED: "true",
+      DEMO_SEED_USER_ID: "owner-1",
+    }, resolveAdapter);
+    expect(resolveAdapter).toHaveBeenCalledOnce();
+    expect(adapter.ensureDemoWorkspace).toHaveBeenCalledWith("owner-1", expect.objectContaining({ seedVersion: 1 }));
+    expect(result.replayed).toBe(true);
+  });
+});

--- a/prisma/migrations/20260810153500_add_demo_workspace/migration.sql
+++ b/prisma/migrations/20260810153500_add_demo_workspace/migration.sql
@@ -1,3 +1,6 @@
+ALTER TABLE "Document"
+  ADD COLUMN "demoProvenance" BOOLEAN NOT NULL DEFAULT false;
+
 CREATE TABLE "DemoWorkspace" (
   "id" SERIAL NOT NULL,
   "userId" TEXT NOT NULL,

--- a/prisma/migrations/20260810153500_add_demo_workspace/migration.sql
+++ b/prisma/migrations/20260810153500_add_demo_workspace/migration.sql
@@ -1,0 +1,74 @@
+CREATE TABLE "DemoWorkspace" (
+  "id" SERIAL NOT NULL,
+  "userId" TEXT NOT NULL,
+  "seedVersion" INTEGER NOT NULL,
+  "state" TEXT NOT NULL DEFAULT 'creating',
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "DemoWorkspace_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "DemoWorkspace_userId_key" ON "DemoWorkspace"("userId");
+CREATE UNIQUE INDEX "DemoWorkspace_id_userId_key" ON "DemoWorkspace"("id", "userId");
+CREATE INDEX "DemoWorkspace_state_idx" ON "DemoWorkspace"("state");
+ALTER TABLE "DemoWorkspace" ADD CONSTRAINT "DemoWorkspace_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "Application"
+  ADD COLUMN "isDemo" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN "demoWorkspaceId" INTEGER,
+  ADD COLUMN "demoKey" TEXT;
+ALTER TABLE "Application" ADD CONSTRAINT "Application_demoWorkspaceId_userId_fkey"
+  FOREIGN KEY ("demoWorkspaceId", "userId") REFERENCES "DemoWorkspace"("id", "userId") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Application" ADD CONSTRAINT "Application_demo_markers_check" CHECK (
+  ("isDemo" = false AND "demoWorkspaceId" IS NULL AND "demoKey" IS NULL) OR
+  ("isDemo" = true AND "demoWorkspaceId" IS NOT NULL AND "demoKey" IS NOT NULL)
+);
+CREATE INDEX "Application_userId_isDemo_createdAt_idx" ON "Application"("userId", "isDemo", "createdAt");
+CREATE UNIQUE INDEX "Application_demoWorkspaceId_demoKey_key" ON "Application"("demoWorkspaceId", "demoKey");
+ALTER TABLE "Application" ADD CONSTRAINT "Application_id_userId_isDemo_key"
+  UNIQUE ("id", "userId", "isDemo");
+
+ALTER TABLE "ApplicationEvent"
+  ADD COLUMN "isDemo" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN "demoWorkspaceId" INTEGER,
+  ADD COLUMN "demoKey" TEXT;
+ALTER TABLE "ApplicationEvent" ADD CONSTRAINT "ApplicationEvent_demoWorkspaceId_userId_fkey"
+  FOREIGN KEY ("demoWorkspaceId", "userId") REFERENCES "DemoWorkspace"("id", "userId") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "ApplicationEvent" DROP CONSTRAINT "ApplicationEvent_applicationId_fkey";
+ALTER TABLE "ApplicationEvent" ADD CONSTRAINT "ApplicationEvent_applicationId_userId_isDemo_fkey"
+  FOREIGN KEY ("applicationId", "userId", "isDemo") REFERENCES "Application"("id", "userId", "isDemo") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "ApplicationEvent" ADD CONSTRAINT "ApplicationEvent_demo_markers_check" CHECK (
+  ("isDemo" = false AND "demoWorkspaceId" IS NULL AND "demoKey" IS NULL) OR
+  ("isDemo" = true AND "demoWorkspaceId" IS NOT NULL AND "demoKey" IS NOT NULL)
+);
+CREATE INDEX "ApplicationEvent_userId_isDemo_occurredAt_id_idx" ON "ApplicationEvent"("userId", "isDemo", "occurredAt", "id");
+CREATE UNIQUE INDEX "ApplicationEvent_demoWorkspaceId_demoKey_key" ON "ApplicationEvent"("demoWorkspaceId", "demoKey");
+
+CREATE FUNCTION "check_application_event_demo_parent"() RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  parent "Application"%ROWTYPE;
+BEGIN
+  IF NEW."isDemo" THEN
+    SELECT * INTO parent
+    FROM "Application"
+    WHERE "id" = NEW."applicationId"
+      AND "userId" = NEW."userId"
+      AND "isDemo" = NEW."isDemo";
+    IF NOT FOUND OR parent."demoWorkspaceId" IS DISTINCT FROM NEW."demoWorkspaceId" THEN
+      RAISE EXCEPTION USING
+        ERRCODE = '23514',
+        CONSTRAINT = 'ApplicationEvent_demo_parent_check',
+        MESSAGE = 'demo event workspace must match its application parent';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER "ApplicationEvent_demo_parent_trigger"
+BEFORE INSERT OR UPDATE OF "applicationId", "userId", "isDemo", "demoWorkspaceId"
+ON "ApplicationEvent"
+FOR EACH ROW EXECUTE FUNCTION "check_application_event_demo_parent"();

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,6 +57,10 @@ model Application {
   jobSummary          String?
   currentStage        String?
   eventVersion        Int                     @default(0)
+  isDemo              Boolean                 @default(false)
+  demoWorkspaceId     Int?
+  demoWorkspace       DemoWorkspace?          @relation(fields: [demoWorkspaceId, userId], references: [id, userId], onDelete: Cascade)
+  demoKey             String?
   createdAt           DateTime                @default(now())
   updatedAt           DateTime                @updatedAt
   documents           Document[]
@@ -66,8 +70,11 @@ model Application {
   events              ApplicationEvent[]
 
   @@unique([userId, canonicalJobUrl])
+  @@unique([demoWorkspaceId, demoKey])
+  @@unique([id, userId, isDemo])
   @@index([userId, followUpAt])
   @@index([userId, status])
+  @@index([userId, isDemo, createdAt])
 }
 
 model Contact {
@@ -136,28 +143,49 @@ model ApplicationSubmission {
 }
 
 model ApplicationEvent {
-  id             Int         @id @default(autoincrement())
-  userId         String
-  user           User        @relation(fields: [userId], references: [id], onDelete: Cascade)
-  applicationId  Int
-  application    Application @relation(fields: [applicationId], references: [id], onDelete: Cascade)
-  type           String
-  idempotencyKey String?
-  requestHash    String?
-  occurredAt     DateTime
-  source         String?
-  actor          String?
-  contactId      String?
-  outcome        String?
-  metadata       Json?
-  createdAt      DateTime    @default(now())
+  id              Int            @id @default(autoincrement())
+  userId          String
+  user            User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+  applicationId   Int
+  application     Application    @relation(fields: [applicationId, userId, isDemo], references: [id, userId, isDemo], onDelete: Cascade)
+  type            String
+  idempotencyKey  String?
+  requestHash     String?
+  occurredAt      DateTime
+  source          String?
+  actor           String?
+  contactId       String?
+  outcome         String?
+  metadata        Json?
+  createdAt       DateTime       @default(now())
+  isDemo          Boolean        @default(false)
+  demoWorkspaceId Int?
+  demoWorkspace   DemoWorkspace? @relation(fields: [demoWorkspaceId, userId], references: [id, userId], onDelete: Cascade)
+  demoKey         String?
 
   @@unique([userId, idempotencyKey])
+  @@unique([demoWorkspaceId, demoKey])
   @@index([applicationId, occurredAt, id])
   @@index([userId, occurredAt, id])
   @@index([userId, type, occurredAt])
   @@index([userId, contactId, occurredAt])
   @@index([userId, outcome, occurredAt])
+  @@index([userId, isDemo, occurredAt, id])
+}
+
+model DemoWorkspace {
+  id           Int                @id @default(autoincrement())
+  userId       String             @unique
+  user         User               @relation(fields: [userId], references: [id], onDelete: Cascade)
+  seedVersion  Int
+  state        String             @default("creating")
+  createdAt    DateTime           @default(now())
+  updatedAt    DateTime           @updatedAt
+  applications Application[]
+  events       ApplicationEvent[]
+
+  @@unique([id, userId])
+  @@index([state])
 }
 
 model User {
@@ -183,6 +211,7 @@ model User {
   cvProfile              CvProfile?
   applicationSubmissions ApplicationSubmission[]
   applicationEvents      ApplicationEvent[]
+  demoWorkspace          DemoWorkspace?
   llmCredentials         LlmCredential[]
   agentThreads           AgentThread[]
   agentMessages          AgentMessage[]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -90,24 +90,25 @@ model Contact {
 }
 
 model Document {
-  id           Int                    @id @default(autoincrement())
-  userId       String
-  user         User                   @relation(fields: [userId], references: [id], onDelete: Cascade)
-  filename     String // stored filename on disk (uuid-based)
-  originalName String // user-facing name
-  size         Int // bytes
-  mimeType     String
-  documentType String                 @default("other")
-  state        String                 @default("current")
-  version      Int                    @default(1)
-  contentHash  String?
-  source       String?
-  generatedAt  DateTime?
-  submittedAt  DateTime?
-  submissionId Int?
-  submission   ApplicationSubmission? @relation(fields: [submissionId], references: [id], onDelete: SetNull)
-  uploadedAt   DateTime               @default(now())
-  applications Application[]
+  id             Int                    @id @default(autoincrement())
+  userId         String
+  user           User                   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  filename       String // stored filename on disk (uuid-based)
+  originalName   String // user-facing name
+  size           Int // bytes
+  mimeType       String
+  documentType   String                 @default("other")
+  state          String                 @default("current")
+  version        Int                    @default(1)
+  contentHash    String?
+  source         String?
+  generatedAt    DateTime?
+  submittedAt    DateTime?
+  submissionId   Int?
+  submission     ApplicationSubmission? @relation(fields: [submissionId], references: [id], onDelete: SetNull)
+  uploadedAt     DateTime               @default(now())
+  demoProvenance Boolean                @default(false)
+  applications   Application[]
 
   @@index([userId, documentType, state])
   @@index([submissionId])

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,76 +1,57 @@
-import { PrismaClient } from "@prisma/client";
+import { getDb } from "../lib/db";
+import type { DatabaseAdapter } from "../lib/db/adapter";
+import { createDemoFixtures } from "../lib/demo-workspace/fixtures";
 
-const prisma = new PrismaClient();
-
-async function main() {
-  // Find the first user to assign seeded data to
-  const user = await prisma.user.findFirst();
-  if (!user) {
-    console.error("No users found. Log in first, then re-run the seed.");
-    return;
-  }
-
-  // Clear existing data
-  await prisma.application.deleteMany();
-
-  const applications = [
-    {
-      company: "Amazon Ring",
-      role: "SDE",
-      status: "applied",
-      appliedAt: new Date("2026-02-10"),
-      lastContact: null,
-      notes: "Matt Brown (Recruiter); HackerRank offen",
-    },
-    {
-      company: "Zurich/NTT",
-      role: "Fullstack SE Alpha I",
-      status: "rejected",
-      appliedAt: new Date("2026-02-25"),
-      lastContact: null,
-      notes: "Franco Mahl; 240€/Tag; kein Feedback",
-    },
-    {
-      company: "Aircall",
-      role: "Senior Engineer",
-      status: "rejected",
-      appliedAt: new Date("2026-02-26"),
-      lastContact: null,
-      notes: "Guillaume Moulin; kein Feedback",
-    },
-    {
-      company: "Deloitte",
-      role: "Backend Engineer",
-      status: "applied",
-      appliedAt: null,
-      lastContact: null,
-      notes: "Carolina Rico Quinn; CV vorbereitet",
-    },
-    {
-      company: "KNAPP AG",
-      role: "Java Senior",
-      status: "inbound",
-      appliedAt: null,
-      lastContact: null,
-      notes: "Noch nicht abgeschickt",
-    },
-    {
-      company: "Ringier AG",
-      role: "Platform Engineer",
-      status: "inbound",
-      appliedAt: null,
-      lastContact: null,
-      notes: "Noch nicht abgeschickt",
-    },
-  ];
-
-  for (const app of applications) {
-    await prisma.application.create({ data: { ...app, userId: user.id } });
-  }
-
-  console.log(`Seeded ${applications.length} applications.`);
+interface SeedEnvironment {
+  NODE_ENV?: string;
+  DEMO_SEED_ENABLED?: string;
+  DEMO_SEED_USER_ID?: string;
+  VERCEL_ENV?: string;
+  RAILWAY_ENVIRONMENT_NAME?: string;
+  FLY_APP_NAME?: string;
+  K_SERVICE?: string;
 }
 
-main()
-  .catch(console.error)
-  .finally(() => prisma.$disconnect());
+type DemoLifecycleAdapter = Pick<DatabaseAdapter, "ensureDemoWorkspace">;
+
+function isProductionEnvironment(env: SeedEnvironment): boolean {
+  return env.NODE_ENV === "production"
+    || env.VERCEL_ENV === "production"
+    || env.RAILWAY_ENVIRONMENT_NAME === "production"
+    || Boolean(env.FLY_APP_NAME)
+    || Boolean(env.K_SERVICE);
+}
+
+export async function runDemoSeed(
+  env: SeedEnvironment = process.env,
+  resolveAdapter: () => DemoLifecycleAdapter = getDb,
+) {
+  if (isProductionEnvironment(env)) {
+    throw new Error("Demo seed is blocked in production environments");
+  }
+  if (env.DEMO_SEED_ENABLED !== "true") {
+    throw new Error("DEMO_SEED_ENABLED=true is required");
+  }
+  const userId = env.DEMO_SEED_USER_ID?.trim();
+  if (!userId) {
+    throw new Error("DEMO_SEED_USER_ID is required");
+  }
+
+  return resolveAdapter().ensureDemoWorkspace(userId, createDemoFixtures());
+}
+
+async function main() {
+  const result = await runDemoSeed();
+  console.log(
+    result.replayed
+      ? `Demo workspace already exists for ${process.env.DEMO_SEED_USER_ID}; replayed safely.`
+      : `Created ${result.applications.length} demo applications for ${process.env.DEMO_SEED_USER_ID}.`,
+  );
+}
+
+if (!process.env.VITEST) {
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -45,6 +45,9 @@ export const TRIAGE_COLORS: Record<TriageScore, string> = {
 
 export interface Application {
   id: string;
+  isDemo?: boolean;
+  demoWorkspaceId?: string | null;
+  demoKey?: string | null;
   company: string;
   role: string;
   status: ApplicationStatus;


### PR DESCRIPTION
## Summary

- adds an optional onboarding and true-empty-state action to create a clearly marked fictional demo workspace
- implements owner-scoped, idempotent demo lifecycle support for Prisma/PostgreSQL and Firestore
- keeps demo rows browsable while excluding them from regular statistics, public sharing, MCP, and internal-agent reads and mutations
- supports confirmed, complete, retry-safe removal of only the authenticated user's demo aggregate
- replaces the destructive development seed with a production-blocked, explicit-opt-in, explicit-user lifecycle client

## Security and data boundaries

- creation and deletion always use the authenticated `userId`
- explicit `isDemo`, `demoWorkspaceId`, and stable `demoKey` markers avoid heuristic classification
- composite PostgreSQL tenant/parent constraints and marker validation prevent cross-owner demo relationships
- every ordinary event writer inherits parent demo provenance; machine event reads also validate parent visibility
- owner lifecycle locks/sentinels serialize real and demo creation for Prisma and Firestore
- replay requires a ready, complete, exact-version fixture set
- Firestore deletion reuses retryable application cascades and verifies child/index remnants before deleting lifecycle metadata
- MCP and agent list/detail/activity/document/read-before-write paths treat demos as unavailable
- MCP document metadata, relink, and deletion enforce non-demo provenance inside the adapter transaction
- public sharing excludes demo records before disclosure and statistics
- regular deletion of individual demo rows is blocked; removal uses the workspace lifecycle
- `prisma/seed.ts` rejects production/deployment environments before adapter access and requires both `DEMO_SEED_ENABLED=true` and `DEMO_SEED_USER_ID`

## Validation

- [x] `npm ci` under Node.js 22.23.2
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] full `npm test` — 112 files, 760 tests passed
- [x] `npm run build`
- [x] `npx prisma validate`
- [x] all 20 migrations applied successfully to temporary PGlite PostgreSQL
- [x] legacy-row migration compatibility and cross-tenant FK rejection assertions
- [x] `openspec validate add-demo-workspace-onboarding --strict`
- [x] `git diff --check`

## Dependency audit

`npm audit --omit=dev --audit-level=high` reports existing repository advisories. This PR does not modify `package.json` or `package-lock.json`; automatic remediation includes breaking major/range changes and is intentionally not mixed into this feature.

## Screenshots

Existing synthetic desktop and mobile workspace screenshots provide the before-state. The demo-specific UI is covered by component tests; no temporary authentication bypass or preview-only product code is included in this PR.

## Notes

- The local Node 26 environment needs an explicit test `localStorage` file; the exact GitHub CI sequence was also reproduced successfully under Node 22 without that workaround.
- The production build passes with the repository's existing Turbopack NFT tracing warning and local default Better Auth secret warnings.
- Migration execution used PGlite because the local Docker daemon was unavailable; Prisma validation and generated SQL checks also pass.
- Demo fixtures intentionally contain no documents or submissions, avoiding external-file and retention ambiguity.
- This PR is intentionally not merged automatically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional demo workspaces with guided onboarding, sample applications, status indicators, localized labels, and confirmed removal.
  * Demo applications are clearly labeled throughout the dashboard, application views, and focus queue.
* **Bug Fixes**
  * Demo data is excluded from analytics, sharing, downloads, agent tools, and integrations.
  * Prevented editing or deleting demo records through regular application workflows.
  * Application creation now provides clear guidance when a demo workspace must be removed first.
* **Security**
  * Improved ownership checks and protection against cross-account or hidden demo-data access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->