### PR TITLE
fix(mcp): return event metadata diagnostics

### DIFF
--- a/app/api/mcp/__tests__/events.test.ts
+++ b/app/api/mcp/__tests__/events.test.ts
@@ -148,6 +148,43 @@ describe("MCP application event contracts", () => {
     expect(text(result)).toMatchObject({ error: { code: "lifecycle_event_required", fields: ["status"] } });
   });
 
+  it("describes the accepted event metadata schema", async () => {
+    const tools = await client.listTools();
+    const tool = tools.tools.find(({ name }) => name === "record_application_event");
+
+    expect(tool?.description).toContain("Metadata is a JSON object with event-specific keys");
+    expect(tool?.description).toContain("stage_changed {toStage: string, fromStage?, toStatus?}");
+    expect(tool?.description).toContain("interview_scheduled {interviewType: string, scheduledAt: ISO 8601 date-time");
+    expect(tool?.description).toContain("Unknown keys are rejected");
+  });
+
+  it("returns actionable diagnostics for invalid event metadata", async () => {
+    mocks.getApplication.mockResolvedValue({ id: "app-1" });
+    const result = await client.callTool({
+      name: "record_application_event",
+      arguments: {
+        applicationId: "app-1",
+        type: "interview_scheduled",
+        metadata: {
+          interviewType: "technical",
+          scheduledAt: "2026-07-28T12:30:00.000Z",
+          durationMinutes: "sixty",
+        },
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(text(result)).toEqual({
+      error: {
+        code: "event_metadata_invalid",
+        path: "metadata.durationMinutes",
+        expected: "integer from 1 to 1440",
+        reason: "durationMinutes must be an integer from 1 to 1440",
+      },
+    });
+    expect(mocks.recordApplicationEvent).not.toHaveBeenCalled();
+  });
+
   it("does not expose the workflow-reserved submission event through the generic tool", async () => {
     const result = await client.callTool({
       name: "record_application_event",

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -15,6 +15,7 @@ import {
 import { parseStructuredApplicationMetadata } from "@/lib/applications/metadata";
 import {
   APPLICATION_EVENT_TYPES,
+  EventMetadataValidationError,
   parseApplicationEventCommand,
   parseEventQuery,
 } from "@/lib/applications/events";
@@ -568,7 +569,7 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
 
   server.tool(
     "record_application_event",
-    "Atomically append a canonical immutable application event and update the current-state projection when the event changes lifecycle state.",
+    "Atomically append a canonical immutable application event and update the current-state projection when the event changes lifecycle state. Metadata is a JSON object with event-specific keys: opportunity_discovered {channel?, nextAction?}; recruiter_contacted {contactId?, outcome?, nextAction?, channel?, followUpAt?, toStage?}; stage_changed {toStage: string, fromStage?, toStatus?}; interview_invited {contactId?, outcome?, nextAction?, interviewType?, scheduledAt?, durationMinutes?, followUpAt?, toStage?}; interview_scheduled {interviewType: string, scheduledAt: ISO 8601 date-time, contactId?, outcome?, nextAction?, durationMinutes?: integer 1..1440, toStage?}; interview_completed {contactId?, outcome?, nextAction?, interviewType?, followUpAt?, toStage?}; feedback_received {contactId?, outcome?, nextAction?, followUpAt?, toStage?}; follow_up_scheduled {followUpAt: ISO 8601 date-time, contactId?, nextAction?}; offer_received {contactId?, outcome?, nextAction?, followUpAt?}; application_rejected {contactId?, outcome?, reason?, fromStage?}; document_attached {documentId: string, documentType?}; note_added {note: string}. Unknown keys are rejected.",
     {
       applicationId: z.string().min(1),
       type: z.enum(APPLICATION_EVENT_TYPES),
@@ -593,7 +594,10 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       } catch (error) {
         const code = controlledErrorCode(error, EVENT_ERROR_CODES, "event_failed");
-        return { content: [{ type: "text", text: JSON.stringify({ error: { code } }) }], isError: true };
+        const details = error instanceof EventMetadataValidationError
+          ? { path: error.path, expected: error.expected, reason: error.reason }
+          : {};
+        return { content: [{ type: "text", text: JSON.stringify({ error: { code, ...details } }) }], isError: true };
       }
     },
   );

--- a/lib/applications/events.ts
+++ b/lib/applications/events.ts
@@ -151,8 +151,22 @@ export interface ParsedEventQuery {
   limit: number;
 }
 
-function invalidMetadata(): never {
-  throw new Error("event_metadata_invalid");
+export class EventMetadataValidationError extends Error {
+  readonly path: string;
+  readonly expected: string;
+  readonly reason: string;
+
+  constructor(path: string, expected: string, reason: string) {
+    super("event_metadata_invalid");
+    this.name = "EventMetadataValidationError";
+    this.path = path;
+    this.expected = expected;
+    this.reason = reason;
+  }
+}
+
+function invalidMetadata(path: string, expected: string, reason: string): never {
+  throw new EventMetadataValidationError(path, expected, reason);
 }
 
 function parseDate(value: unknown, errorCode: string): Date {
@@ -167,11 +181,20 @@ function parseDate(value: unknown, errorCode: string): Date {
 function optionalString(
   value: unknown,
   maxLength = 255,
+  path = "metadata",
 ): string | null {
   if (value === undefined || value === null || value === "") return null;
-  if (typeof value !== "string") invalidMetadata();
+  if (typeof value !== "string") {
+    invalidMetadata(path, `string with 1 to ${maxLength} characters`, `${path.split(".").at(-1)} must be a string`);
+  }
   const normalized = value.trim();
-  if (!normalized || normalized.length > maxLength) invalidMetadata();
+  if (!normalized || normalized.length > maxLength) {
+    invalidMetadata(
+      path,
+      `string with 1 to ${maxLength} characters`,
+      `${path.split(".").at(-1)} must contain 1 to ${maxLength} characters after trimming`,
+    );
+  }
   return normalized;
 }
 
@@ -180,51 +203,90 @@ function parseMetadata(
   value: unknown,
 ): Record<string, unknown> {
   if (value === undefined || value === null) value = {};
-  if (typeof value !== "object" || Array.isArray(value)) invalidMetadata();
+  if (typeof value !== "object" || Array.isArray(value)) {
+    invalidMetadata("metadata", "object", "metadata must be an object");
+  }
   const raw = value as Record<string, unknown>;
   const entries = Object.entries(raw);
-  if (entries.length > 100 || entries.some(([key]) => !key || key.length > 100)) {
-    invalidMetadata();
+  if (entries.length > 100) {
+    invalidMetadata("metadata", "object with at most 100 keys", "metadata must have at most 100 keys");
+  }
+  const invalidKey = entries.find(([key]) => !key || key.length > 100)?.[0];
+  if (invalidKey !== undefined) {
+    invalidMetadata(
+      invalidKey ? `metadata.${invalidKey}` : "metadata",
+      "key with 1 to 100 characters",
+      "metadata keys must contain 1 to 100 characters",
+    );
   }
   const allowed = new Set(EVENT_KEYS[type]);
-  if (entries.some(([key]) => !allowed.has(key))) invalidMetadata();
+  const unsupportedKey = entries.find(([key]) => !allowed.has(key))?.[0];
+  if (unsupportedKey !== undefined) {
+    invalidMetadata(
+      `metadata.${unsupportedKey}`,
+      `one of: ${EVENT_KEYS[type].join(", ") || "no metadata keys"}`,
+      `${unsupportedKey} is not accepted for ${type}`,
+    );
+  }
 
   const metadata: Record<string, unknown> = {};
   for (const [key, item] of entries) {
     if (item === undefined || item === null || item === "") continue;
     if (ISO_KEYS.has(key)) {
-      metadata[key] = parseDate(item, "event_metadata_invalid").toISOString();
+      try {
+        metadata[key] = parseDate(item, "event_metadata_invalid").toISOString();
+      } catch {
+        invalidMetadata(`metadata.${key}`, "ISO 8601 date-time string", `${key} must be a valid ISO 8601 date-time string`);
+      }
       continue;
     }
     if (ARRAY_KEYS.has(key)) {
-      if (!Array.isArray(item) || item.length > 20) invalidMetadata();
-      const values = item.map((entry) => optionalString(entry));
-      if (values.some((entry) => entry === null)) invalidMetadata();
+      if (!Array.isArray(item) || item.length > 20) {
+        invalidMetadata(`metadata.${key}`, "array of at most 20 non-empty strings", `${key} must be an array of at most 20 non-empty strings`);
+      }
+      const values = item.map((entry, index) => optionalString(entry, 255, `metadata.${key}.${index}`));
+      if (values.some((entry) => entry === null)) {
+        const index = values.findIndex((entry) => entry === null);
+        invalidMetadata(`metadata.${key}.${index}`, "non-empty string", `${key}[${index}] must be a non-empty string`);
+      }
       metadata[key] = values;
       continue;
     }
     if (INTEGER_KEYS.has(key)) {
-      if (!Number.isInteger(item)) invalidMetadata();
       const number = item as number;
       const max = key === "durationMinutes" ? 1_440 : 50;
       const min = key === "durationMinutes" ? 1 : 0;
-      if (number < min || number > max) invalidMetadata();
+      if (!Number.isInteger(item) || number < min || number > max) {
+        invalidMetadata(
+          `metadata.${key}`,
+          `integer from ${min} to ${max}`,
+          `${key} must be an integer from ${min} to ${max}`,
+        );
+      }
       metadata[key] = number;
       continue;
     }
     if (OBJECT_KEYS.has(key)) {
-      if (typeof item !== "object" || Array.isArray(item)) invalidMetadata();
+      if (typeof item !== "object" || item === null || Array.isArray(item)) {
+        invalidMetadata(`metadata.${key}`, "object", `${key} must be an object`);
+      }
       metadata[key] = item;
       continue;
     }
     if (key === "toStatus" || key === "fromStatus") {
-      const status = optionalString(item) as ApplicationStatus | null;
-      if (!status || !STATUS_SET.has(status)) invalidMetadata();
+      const status = optionalString(item, 255, `metadata.${key}`) as ApplicationStatus | null;
+      if (!status || !STATUS_SET.has(status)) {
+        invalidMetadata(
+          `metadata.${key}`,
+          "one of: inbound, applied, interview, offer, rejected",
+          `${key} must be a valid application status`,
+        );
+      }
       metadata[key] = status;
       continue;
     }
     const maxLength = key === "note" ? 5_000 : key === "reason" || key === "nextAction" ? 2_000 : 255;
-    const normalized = optionalString(item, maxLength);
+    const normalized = optionalString(item, maxLength, `metadata.${key}`);
     if (normalized !== null) metadata[key] = normalized;
   }
 
@@ -235,8 +297,13 @@ function parseMetadata(
     document_attached: ["documentId"],
     note_added: ["note"],
   };
-  if (required[type]?.some((key) => metadata[key] === undefined)) {
-    invalidMetadata();
+  const missingKey = required[type]?.find((key) => metadata[key] === undefined);
+  if (missingKey !== undefined) {
+    invalidMetadata(
+      `metadata.${missingKey}`,
+      "required value",
+      `${missingKey} is required for ${type}`,
+    );
   }
   if (Buffer.byteLength(JSON.stringify(metadata), "utf8") > 32_000) {
     throw new Error("event_metadata_too_large");


### PR DESCRIPTION
## Summary
- return the failing metadata path, expected type, and reason for `record_application_event` validation errors
- document the accepted event-specific metadata schema in the MCP tool description
- preserve owner and demo application checks before event parsing and mutation

## Strict TDD evidence
- RED: `vitest run app/api/mcp/__tests__/events.test.ts -t "returns actionable diagnostics for invalid event metadata"` failed because the response only contained `event_metadata_invalid`
- RED: `vitest run app/api/mcp/__tests__/events.test.ts -t "describes the accepted event metadata schema"` failed because the prior description omitted the schema
- GREEN: focused MCP tests passed (8/8); focused event tests passed (25/25)
- Sabotage: removed response diagnostics and confirmed the regression test failed; restored them and passed the MCP suite

## Verification
- `npm test`: 118 files, 806 tests passed
- `npm run lint`: passed
- `node ./node_modules/typescript/bin/tsc --noEmit`: passed
- `git diff --check`: passed
- `npm run build`: not completed locally because the pre-existing partial `node_modules` lacked Next.js; a clean install then exceeded available workspace disk. Remote CI is authoritative for build verification.

## Scope
No web UI changes. No account or demo-boundary changes.