### PR TITLE
fix(mcp): compact application list responses

### DIFF
--- a/app/api/mcp/__tests__/applications-list.test.ts
+++ b/app/api/mcp/__tests__/applications-list.test.ts
@@ -104,4 +104,36 @@ describe("MCP application list", () => {
       { id: "app-022", notes: "Note 22" },
     ]);
   });
+
+  it("treats an empty fields array as the default compact selection", async () => {
+    const result = await client.callTool({
+      name: "list_applications",
+      arguments: { fields: [], limit: 1 },
+    });
+
+    expect(JSON.parse(text(result))).toEqual([{
+      id: "app-000",
+      company: "Company 0",
+      role: "Engineer 0",
+      status: "applied",
+      currentStage: "screen",
+      rating: 4,
+      updatedAt: "2026-08-01T00:00:00.000Z",
+    }]);
+    expect(mocks.listApplicationsFiltered).toHaveBeenCalledWith("owner-1", expect.objectContaining({
+      fields: ["id", "company", "role", "status", "currentStage", "rating", "updatedAt"],
+    }), { demoVisibility: "exclude" });
+  });
+
+  it("returns a stable MCP error for an invalid application cursor", async () => {
+    mocks.listApplicationsFiltered.mockRejectedValueOnce(new Error("application_cursor_invalid"));
+
+    const result = await client.callTool({
+      name: "list_applications",
+      arguments: { cursor: "deleted-app" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(text(result))).toEqual({ error: { code: "application_cursor_invalid" } });
+  });
 });

--- a/app/api/mcp/__tests__/applications-list.test.ts
+++ b/app/api/mcp/__tests__/applications-list.test.ts
@@ -1,0 +1,107 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  listApplications: vi.fn(),
+  listApplicationsFiltered: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({ getDb: () => mocks }));
+vi.mock("@/lib/prisma", () => ({ prisma: {} }));
+
+import { createMcpServer } from "../route";
+
+const auth = {
+  userId: "owner-1",
+  readScopeUserId: "owner-1",
+  user: { id: "owner-1", name: "Owner", email: "owner@example.com", image: null, isAdmin: false },
+  authType: "mcp_oauth" as const,
+  scopes: ["mcp:tools"],
+};
+
+const applications = Array.from({ length: 100 }, (_, index) => ({
+  id: `app-${String(index).padStart(3, "0")}`,
+  company: `Company ${index}`,
+  role: `Engineer ${index}`,
+  status: "applied",
+  currentStage: "screen",
+  rating: 4,
+  updatedAt: `2026-08-${String((index % 28) + 1).padStart(2, "0")}T00:00:00.000Z`,
+  notes: `Note ${index}`,
+  jobDescription: "x".repeat(50_000),
+}));
+
+let client: Client;
+let server: ReturnType<typeof createMcpServer>;
+
+function text(result: Awaited<ReturnType<Client["callTool"]>>) {
+  const content = (result as { content: Array<{ type: string; text?: string }> }).content;
+  if (content[0]?.type !== "text" || typeof content[0].text !== "string") throw new Error("expected text");
+  return content[0].text;
+}
+
+describe("MCP application list", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mocks.listApplicationsFiltered.mockImplementation(async (_userId, filter) => {
+      let rows = applications;
+      if (filter.search) {
+        const q = filter.search.toLowerCase();
+        rows = rows.filter((app) =>
+          filter.searchFields.some((field: "company" | "role") => app[field].toLowerCase().includes(q)),
+        );
+      }
+      if (filter.cursor) {
+        rows = rows.slice(rows.findIndex((app) => app.id === filter.cursor) + 1);
+      }
+      return rows.slice(0, filter.limit).map((app) => Object.fromEntries(
+        ["id", ...filter.fields].map((field) => [field, app[field as keyof typeof app]]),
+      ));
+    });
+    server = createMcpServer(auth);
+    client = new Client({ name: "application-list-test", version: "1.0.0" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  });
+
+  afterEach(async () => {
+    await client.close();
+    await server.close();
+  });
+
+  it("returns a bounded compact index and supports field, cursor, and company-role query options", async () => {
+    const defaultResult = await client.callTool({ name: "list_applications", arguments: {} });
+    const defaultText = text(defaultResult);
+    const defaultRows = JSON.parse(defaultText) as Array<Record<string, unknown>>;
+
+    expect(defaultRows).toHaveLength(50);
+    expect(Object.keys(defaultRows[0])).toEqual([
+      "id", "company", "role", "status", "currentStage", "rating", "updatedAt",
+    ]);
+    expect(defaultText.length).toBeLessThan(20_000);
+    expect(mocks.listApplications).not.toHaveBeenCalled();
+    expect(mocks.listApplicationsFiltered).toHaveBeenNthCalledWith(1, "owner-1", {
+      search: undefined,
+      searchFields: ["company", "role"],
+      fields: ["id", "company", "role", "status", "currentStage", "rating", "updatedAt"],
+      limit: 50,
+      cursor: undefined,
+    }, { demoVisibility: "exclude" });
+
+    const tools = await client.listTools();
+    const compactTool = tools.tools.find((tool) => tool.name === "list_applications");
+    const filteredTool = tools.tools.find((tool) => tool.name === "list_applications_filtered");
+    expect(compactTool?.description).toContain("compact");
+    expect(filteredTool?.description).toContain("advanced");
+
+    const selectedResult = await client.callTool({
+      name: "list_applications",
+      arguments: { q: "engineer", fields: ["notes"], limit: 2, cursor: "app-020" },
+    });
+    expect(JSON.parse(text(selectedResult))).toEqual([
+      { id: "app-021", notes: "Note 21" },
+      { id: "app-022", notes: "Note 22" },
+    ]);
+  });
+});

--- a/app/api/mcp/__tests__/demo-boundaries.test.ts
+++ b/app/api/mcp/__tests__/demo-boundaries.test.ts
@@ -103,10 +103,15 @@ describe("MCP demo application boundaries", () => {
     await call("list_applications_filtered", { search: "demo" });
     const canonical = await call("find_application_by_job_url", { jobUrl: "https://example.com/jobs/demo" });
 
-    expect(mocks.listApplications).toHaveBeenCalledWith("owner-1", DEMO_EXCLUDE);
+    expect(mocks.listApplicationsFiltered).toHaveBeenNthCalledWith(
+      1,
+      "owner-1",
+      expect.objectContaining({ limit: 50 }),
+      DEMO_EXCLUDE,
+    );
     expect(mocks.getApplication).toHaveBeenCalledWith("demo-app", "owner-1", DEMO_EXCLUDE);
     expect(detail.isError).toBe(true);
-    expect(mocks.listApplicationsFiltered).toHaveBeenCalledWith("owner-1", expect.any(Object), DEMO_EXCLUDE);
+    expect(mocks.listApplicationsFiltered).toHaveBeenNthCalledWith(2, "owner-1", expect.any(Object), DEMO_EXCLUDE);
     expect(json(canonical)).toMatchObject({ application: null });
     expect(mocks.findApplicationByCanonicalJobUrl).toHaveBeenCalledWith(
       "owner-1",

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -223,10 +223,21 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
 
   server.tool(
     "list_applications",
-    "List all job applications for the authenticated user",
-    {},
-    async () => {
-      const apps = await getDb().listApplications(auth.readScopeUserId, MACHINE_DEMO_READ);
+    "List a compact, paginated application index. Heavy fields are available only when requested with fields.",
+    {
+      fields: z.array(z.string()).optional().describe("Fields to include. id is always included; heavy fields are opt-in."),
+      limit: z.number().int().min(1).max(200).default(50).describe("Max results to return (default: 50)"),
+      cursor: z.string().optional().describe("Application ID after which to continue"),
+      q: z.string().optional().describe("Case-insensitive substring match on company and role"),
+    },
+    async ({ fields, limit, cursor, q }) => {
+      const apps = await getDb().listApplicationsFiltered(auth.readScopeUserId, {
+        search: q,
+        searchFields: ["company", "role"],
+        fields: fields ?? ["id", "company", "role", "status", "currentStage", "rating", "updatedAt"],
+        limit,
+        cursor,
+      }, MACHINE_DEMO_READ);
       return {
         content: [{ type: "text", text: JSON.stringify(apps, null, 2) }],
       };
@@ -949,7 +960,7 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
 
   server.tool(
     "list_applications_filtered",
-    "List applications with filters, sorting, and field selection. Use 'fields' to exclude large fields like jobDescription and reduce token usage. Defaults to all fields, no contacts.",
+    "Run an advanced application query with status, rating, remote, sorting, contact, and field controls. Defaults to all fields, no contacts; use list_applications for a compact index.",
     {
       status: z
         .array(z.enum(["inbound", "applied", "interview", "offer", "rejected"]))

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -231,16 +231,28 @@ export function createMcpServer(auth: SessionAuthResult): McpServer {
       q: z.string().optional().describe("Case-insensitive substring match on company and role"),
     },
     async ({ fields, limit, cursor, q }) => {
-      const apps = await getDb().listApplicationsFiltered(auth.readScopeUserId, {
-        search: q,
-        searchFields: ["company", "role"],
-        fields: fields ?? ["id", "company", "role", "status", "currentStage", "rating", "updatedAt"],
-        limit,
-        cursor,
-      }, MACHINE_DEMO_READ);
-      return {
-        content: [{ type: "text", text: JSON.stringify(apps, null, 2) }],
-      };
+      try {
+        const apps = await getDb().listApplicationsFiltered(auth.readScopeUserId, {
+          search: q,
+          searchFields: ["company", "role"],
+          fields: fields?.length
+            ? fields
+            : ["id", "company", "role", "status", "currentStage", "rating", "updatedAt"],
+          limit,
+          cursor,
+        }, MACHINE_DEMO_READ);
+        return {
+          content: [{ type: "text", text: JSON.stringify(apps, null, 2) }],
+        };
+      } catch (error) {
+        if (error instanceof Error && error.message === "application_cursor_invalid") {
+          return {
+            content: [{ type: "text", text: JSON.stringify({ error: { code: "application_cursor_invalid" } }) }],
+            isError: true,
+          };
+        }
+        throw error;
+      }
     }
   );
 

--- a/lib/db/__tests__/firestore-adapter.test.ts
+++ b/lib/db/__tests__/firestore-adapter.test.ts
@@ -1962,6 +1962,27 @@ describe("FirestoreAdapter — CV patch isolation", () => {
   });
 });
 
+describe("FirestoreAdapter — application cursors", () => {
+  beforeEach(() => {
+    stores.applications.clear();
+    stores.applications.set("app-1", {
+      userId: "owner-1",
+      company: "Acme",
+      role: "Engineer",
+      status: "applied",
+      createdAt: mockTimestamp,
+      updatedAt: mockTimestamp,
+    });
+  });
+
+  it("rejects a cursor that is absent from the filtered result set", async () => {
+    const adapter = new FirestoreAdapter();
+
+    await expect(adapter.listApplicationsFiltered("owner-1", { cursor: "deleted-app" }))
+      .rejects.toThrow("application_cursor_invalid");
+  });
+});
+
 describe("FirestoreAdapter — explicit owner scopes", () => {
   beforeEach(() => {
     stores.applications.clear();

--- a/lib/db/__tests__/prisma-application-events.test.ts
+++ b/lib/db/__tests__/prisma-application-events.test.ts
@@ -185,6 +185,12 @@ describe("PrismaAdapter — atomic application events", () => {
       }));
   });
 
+  it("normalizes a malformed application cursor", async () => {
+    await expect(new PrismaAdapter().listApplicationsFiltered("owner-1", { cursor: "deleted-app" }))
+      .rejects.toThrow("application_cursor_invalid");
+    expect((fake.prisma.application as { findMany: ReturnType<typeof vi.fn> }).findMany).not.toHaveBeenCalled();
+  });
+
   it("updates the projection and creates one immutable event", async () => {
     const result = await new PrismaAdapter().recordApplicationEvent("1", "owner-1", command);
     expect(result.replayed).toBe(false);

--- a/lib/db/__tests__/prisma-application-events.test.ts
+++ b/lib/db/__tests__/prisma-application-events.test.ts
@@ -44,6 +44,7 @@ const fake = vi.hoisted(() => {
 
   const prisma: Record<string, unknown> = {};
   const applicationApi = {
+    findMany: vi.fn(async () => []),
     findFirst: vi.fn(async ({ where }: { where: { id?: number; userId?: string } }) => {
       if (where.id !== undefined && where.id !== application.id) return null;
       if (where.userId !== undefined && where.userId !== application.userId) return null;
@@ -171,6 +172,17 @@ describe("PrismaAdapter — atomic application events", () => {
   it("returns null instead of throwing for malformed application IDs", async () => {
     await expect(new PrismaAdapter().getApplication("not-an-id", "owner-1")).resolves.toBeNull();
     expect((fake.prisma.application as { findFirst: ReturnType<typeof vi.fn> }).findFirst).not.toHaveBeenCalled();
+  });
+
+  it("adds an ID tie-breaker to default cursor pagination", async () => {
+    await new PrismaAdapter().listApplicationsFiltered("owner-1", { cursor: "1", limit: 20 });
+
+    expect((fake.prisma.application as { findMany: ReturnType<typeof vi.fn> }).findMany)
+      .toHaveBeenCalledWith(expect.objectContaining({
+        orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+        cursor: { id: 1 },
+        skip: 1,
+      }));
   });
 
   it("updates the projection and creates one immutable event", async () => {

--- a/lib/db/__tests__/prisma-application-events.test.ts
+++ b/lib/db/__tests__/prisma-application-events.test.ts
@@ -191,6 +191,12 @@ describe("PrismaAdapter — atomic application events", () => {
     expect((fake.prisma.application as { findMany: ReturnType<typeof vi.fn> }).findMany).not.toHaveBeenCalled();
   });
 
+  it("rejects a numeric cursor outside the scoped result set", async () => {
+    await expect(new PrismaAdapter().listApplicationsFiltered("owner-1", { cursor: "999" }))
+      .rejects.toThrow("application_cursor_invalid");
+    expect((fake.prisma.application as { findMany: ReturnType<typeof vi.fn> }).findMany).not.toHaveBeenCalled();
+  });
+
   it("updates the projection and creates one immutable event", async () => {
     const result = await new PrismaAdapter().recordApplicationEvent("1", "owner-1", command);
     expect(result.replayed).toBe(false);

--- a/lib/db/firestore-adapter.ts
+++ b/lib/db/firestore-adapter.ts
@@ -1599,13 +1599,10 @@ export class FirestoreAdapter implements DatabaseAdapter {
     }
     if (filter.search) {
       const term = filter.search.toLowerCase();
-      apps = apps.filter(
-        (a) =>
-          a.company.toLowerCase().includes(term) ||
-          a.role.toLowerCase().includes(term) ||
-          (a.notes?.toLowerCase().includes(term) ?? false) ||
-          (a.jobDescription?.toLowerCase().includes(term) ?? false)
-      );
+      const searchFields = filter.searchFields ?? ["company", "role", "notes", "jobDescription"];
+      apps = apps.filter((app) => searchFields.some((field) =>
+        app[field]?.toLowerCase().includes(term) ?? false
+      ));
     }
 
     // Sort
@@ -1628,6 +1625,11 @@ export class FirestoreAdapter implements DatabaseAdapter {
           return desc ? -cmp : cmp;
         });
       }
+    }
+
+    if (filter.cursor) {
+      const cursorIndex = apps.findIndex((app) => app.id === filter.cursor);
+      if (cursorIndex >= 0) apps = apps.slice(cursorIndex + 1);
     }
 
     // Limit

--- a/lib/db/firestore-adapter.ts
+++ b/lib/db/firestore-adapter.ts
@@ -1629,7 +1629,8 @@ export class FirestoreAdapter implements DatabaseAdapter {
 
     if (filter.cursor) {
       const cursorIndex = apps.findIndex((app) => app.id === filter.cursor);
-      if (cursorIndex >= 0) apps = apps.slice(cursorIndex + 1);
+      if (cursorIndex < 0) throw new Error("application_cursor_invalid");
+      apps = apps.slice(cursorIndex + 1);
     }
 
     // Limit

--- a/lib/db/prisma-adapter.ts
+++ b/lib/db/prisma-adapter.ts
@@ -1452,7 +1452,10 @@ export class PrismaAdapter implements DatabaseAdapter {
     }
 
     // Sort
-    let orderBy: Prisma.ApplicationOrderByWithRelationInput = { createdAt: "desc" };
+    let orderBy: Prisma.ApplicationOrderByWithRelationInput[] = [
+      { createdAt: "desc" },
+      { id: "desc" },
+    ];
     if (filter.sort) {
       const desc = filter.sort.startsWith("-");
       const field = desc ? filter.sort.slice(1) : filter.sort;
@@ -1462,7 +1465,8 @@ export class PrismaAdapter implements DatabaseAdapter {
         "triageQuality",
       ];
       if (allowedSortFields.includes(field)) {
-        orderBy = { [field]: desc ? "desc" : "asc" };
+        const direction = desc ? "desc" : "asc";
+        orderBy = [{ [field]: direction }, { id: direction }];
       }
     }
 

--- a/lib/db/prisma-adapter.ts
+++ b/lib/db/prisma-adapter.ts
@@ -1477,6 +1477,13 @@ export class PrismaAdapter implements DatabaseAdapter {
     } catch {
       throw new Error("application_cursor_invalid");
     }
+    if (cursor) {
+      const cursorApplication = await prisma.application.findFirst({
+        where: { ...where, id: cursor.id },
+        select: { id: true },
+      });
+      if (!cursorApplication) throw new Error("application_cursor_invalid");
+    }
 
     if (includeContacts) {
       const rows = await prisma.application.findMany({

--- a/lib/db/prisma-adapter.ts
+++ b/lib/db/prisma-adapter.ts
@@ -1471,13 +1471,19 @@ export class PrismaAdapter implements DatabaseAdapter {
     }
 
     const includeContacts = filter.includeContacts ?? false;
+    let cursor: { id: number } | undefined;
+    try {
+      cursor = filter.cursor ? { id: nid(filter.cursor) } : undefined;
+    } catch {
+      throw new Error("application_cursor_invalid");
+    }
 
     if (includeContacts) {
       const rows = await prisma.application.findMany({
         where,
         orderBy,
         take: filter.limit ?? undefined,
-        cursor: filter.cursor ? { id: nid(filter.cursor) } : undefined,
+        cursor,
         skip: filter.cursor ? 1 : undefined,
         include: { contacts: true },
       });
@@ -1488,7 +1494,7 @@ export class PrismaAdapter implements DatabaseAdapter {
       where,
       orderBy,
       take: filter.limit ?? undefined,
-      cursor: filter.cursor ? { id: nid(filter.cursor) } : undefined,
+      cursor,
       skip: filter.cursor ? 1 : undefined,
     });
     // Map without contacts — give mapApp an empty contacts array to satisfy the type

--- a/lib/db/prisma-adapter.ts
+++ b/lib/db/prisma-adapter.ts
@@ -1445,12 +1445,10 @@ export class PrismaAdapter implements DatabaseAdapter {
     }
     if (filter.search) {
       const term = filter.search;
-      where.OR = [
-        { company: { contains: term, mode: "insensitive" } },
-        { role: { contains: term, mode: "insensitive" } },
-        { notes: { contains: term, mode: "insensitive" } },
-        { jobDescription: { contains: term, mode: "insensitive" } },
-      ];
+      const searchFields = filter.searchFields ?? ["company", "role", "notes", "jobDescription"];
+      where.OR = searchFields.map((field) => ({
+        [field]: { contains: term, mode: "insensitive" },
+      }));
     }
 
     // Sort
@@ -1475,6 +1473,8 @@ export class PrismaAdapter implements DatabaseAdapter {
         where,
         orderBy,
         take: filter.limit ?? undefined,
+        cursor: filter.cursor ? { id: nid(filter.cursor) } : undefined,
+        skip: filter.cursor ? 1 : undefined,
         include: { contacts: true },
       });
       return pickFields(rows.map(mapApp), filter.fields);
@@ -1484,6 +1484,8 @@ export class PrismaAdapter implements DatabaseAdapter {
       where,
       orderBy,
       take: filter.limit ?? undefined,
+      cursor: filter.cursor ? { id: nid(filter.cursor) } : undefined,
+      skip: filter.cursor ? 1 : undefined,
     });
     // Map without contacts — give mapApp an empty contacts array to satisfy the type
     const mapped = rows.map((row) => mapApp({ ...row, contacts: [] }));

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -509,10 +509,12 @@ export interface ListApplicationsFilter {
   ratingGte?: number;
   triageQualityGte?: number;
   search?: string;
+  searchFields?: Array<"company" | "role" | "notes" | "jobDescription">;
   remote?: boolean;
   sort?: string;
   fields?: string[];
   limit?: number;
+  cursor?: string;
   includeContacts?: boolean;
   page?: number;
   pageSize?: number;


### PR DESCRIPTION
## Summary
- make `list_applications` return a compact seven-field index by default
- add optional `fields`, `limit`, `cursor`, and company/role-only `q` inputs
- delegate to `listApplicationsFiltered` and preserve owner scope plus demo exclusion
- clarify the compact and advanced tool descriptions

## Strict TDD evidence
### RED
`npm test -- app/api/mcp/__tests__/applications-list.test.ts`

Failed as expected before production changes because `list_applications` still called `listApplications`; the mocked filtered query was not called and the MCP result contained an invalid undefined text value.

### GREEN
`npm test -- app/api/mcp/__tests__/applications-list.test.ts`

Passed: 1 test file, 1 test. The regression seeds 100 applications with 50,000-character job descriptions. It verifies the default response returns 50 compact records and stays below 20,000 characters.

### Regression proof
I temporarily restored the old `listApplications` delegation. The focused test failed again with the same invalid undefined MCP text result. I restored the fix and the focused test passed.

## Validation
- `npm test`: 119 files passed, 805 tests passed
- `npm run lint`: passed
- `npx tsc --noEmit`: passed
- `git diff --check`: passed

## Scope and non-goals
- No web UI changes.
- No schema or migration changes.
- No changes to application mutation behavior.
- `list_applications_filtered` keeps its existing advanced defaults and filters.

## Risk
Low. The compatibility change is limited to the MCP `list_applications` response shape. Callers that relied on its prior full-record response must request heavy fields explicitly. Prisma and Firestore use the same shared filter contract for search scope and cursor handling.
